### PR TITLE
fix: use BigInt arithmetic for trade panel precision

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -452,19 +452,19 @@
 	}
 
 	function handleUsdcPercentClick(percent: number) {
-		const amount = (formattedUsdcBalance * percent) / 100;
-		// Use floor to prevent rounding up beyond actual balance (fixes "not enough funds" on MAX)
-		const flooredAmount = Math.floor(amount * 100) / 100;
-		topAmount = flooredAmount.toFixed(2);
+		// Use BigInt arithmetic to avoid floating-point precision issues
+		const percentAmount = (usdcBalance * BigInt(percent)) / 100n;
+		const amount = Number(formatUnits(percentAmount, usdcDecimals));
+		topAmount = amount.toFixed(2);
 		lastEditedField = 'top';
 		refreshQuotesForCurrentToken();
 	}
 
 	function handleTokenPercentClick(percent: number) {
-		const amount = (formattedTokenBalance * percent) / 100;
-		// Use floor to prevent rounding up beyond actual balance (fixes "not enough funds" on MAX)
-		const flooredAmount = Math.floor(amount * 1e6) / 1e6;
-		bottomAmount = flooredAmount.toFixed(6);
+		// Use BigInt arithmetic to avoid floating-point precision issues
+		const percentAmount = (tokenBalance * BigInt(percent)) / 100n;
+		const amount = Number(formatUnits(percentAmount, tokenDecimals));
+		bottomAmount = amount.toFixed(6);
 		lastEditedField = 'bottom';
 		refreshQuotesForCurrentToken();
 	}

--- a/src/lib/components/orders/DcaOrder.svelte
+++ b/src/lib/components/orders/DcaOrder.svelte
@@ -7,6 +7,7 @@
 	import { validateBaseline, validatePeriod, validateSelectedAmount } from '$lib/utils/validation';
 	import Input from '$lib/components/ui/Input.svelte';
 	import { formatUnits } from 'viem';
+	import { priceToScaledBigInt, paymentToAsset, PRICE_SCALE } from '$lib/utils/bigIntMath';
 	import { connected } from 'svelte-wagmi';
 	import transactionStore from '$lib/stores/transaction';
 	import { hasValidPriceFeedId, priceToIoratioString } from '$lib/utils/derivations';
@@ -86,11 +87,16 @@
 			return BigInt(10 ** usdcDecimals);
 		} else {
 			// For Sell orders, min is $1 worth of the asset token
+			// Using BigInt arithmetic to avoid floating-point precision issues
 			const price = parseFloat(selectedInitialRatio || '0');
 			if (price <= 0) return 0n;
 			const tokenDecimals = selectedInputToken?.decimals ?? 18;
-			const oneDollarWorth = 1 / price;
-			return BigInt(Math.floor(oneDollarWorth * 10 ** tokenDecimals));
+			const paymentDecimals = selectedOutputToken?.decimals ?? 6;
+			// $1 in payment token decimals
+			const oneDollar = BigInt(10 ** paymentDecimals);
+			// Convert $1 to asset amount using BigInt math
+			const scaledPrice = priceToScaledBigInt(price);
+			return paymentToAsset(oneDollar, paymentDecimals, scaledPrice, tokenDecimals);
 		}
 	})();
 

--- a/src/lib/components/orders/LimitOrder.svelte
+++ b/src/lib/components/orders/LimitOrder.svelte
@@ -5,6 +5,7 @@
 	import { validateBaseline, validateSelectedAmount } from '$lib/utils/validation';
 	import Input from '$lib/components/ui/Input.svelte';
 	import { formatUnits, parseUnits } from 'viem';
+	import { priceToScaledBigInt, paymentToAsset } from '$lib/utils/bigIntMath';
 	import type { Hex } from 'viem';
 	import transactionStore from '$lib/stores/transaction';
 	import { currentNetwork, reviewStrategyOnDeploy } from '$lib/stores';
@@ -154,13 +155,16 @@
 			// Calculate settlement amount to spend (percent of balance)
 			const settlementToSpend = (spendingTokenBalance * BigInt(percent)) / 100n;
 
-			// Convert settlement amount to asset amount using limit price
+			// Convert settlement amount to asset amount using BigInt arithmetic
 			// settlementAmount / price = assetAmount
-			// Use floor to prevent rounding up beyond actual balance (fixes "not enough funds" on MAX)
-			const settlementInFloat = parseFloat(formatUnits(settlementToSpend, settlementDecimals));
-			const assetAmount = settlementInFloat / price;
-			const assetAmountScaled = Math.floor(assetAmount * 10 ** assetDecimals);
-			tradeAmountInputRef.setAmountValue(BigInt(assetAmountScaled));
+			const scaledPrice = priceToScaledBigInt(price);
+			const assetAmountBigInt = paymentToAsset(
+				settlementToSpend,
+				settlementDecimals,
+				scaledPrice,
+				assetDecimals
+			);
+			tradeAmountInputRef.setAmountValue(assetAmountBigInt);
 		}
 	};
 

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -5,6 +5,11 @@
 	import { normalizeAddress } from '$lib/utils/tokenMath';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import { formatUnits } from 'viem';
+	import {
+		priceToScaledBigInt,
+		paymentToAsset,
+		assetToPaymentCeil
+	} from '$lib/utils/bigIntMath';
 	import { containerStyles } from '$lib/styles/utils';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { connected } from 'svelte-wagmi';
@@ -124,14 +129,17 @@
 			insufficientBalanceError = selectedAmount > spendingTokenBalance;
 		} else {
 			// For BUY in amount mode: user is spending the payment token (USDC)
-			// Calculate the estimated cost using floor to avoid false "insufficient balance" errors
-			// when clicking MAX button (precision errors from float conversion)
+			// Calculate the estimated cost using BigInt arithmetic
 			const assetDecimals = assetToken?.decimals ?? 18;
 			const paymentDecimals = paymentToken?.decimals ?? 6;
-			const outputInTokens = parseFloat(formatUnits(selectedAmount, assetDecimals));
-			const estimatedCost = outputInTokens * marketPrice;
-			// Use floor instead of ceil to prevent rounding up beyond actual balance
-			const estimatedCostBigInt = BigInt(Math.floor(estimatedCost * 10 ** paymentDecimals));
+			const scaledPrice = priceToScaledBigInt(marketPrice);
+			// Calculate payment needed using BigInt math with floor to avoid false "insufficient balance" errors
+			const estimatedCostBigInt = assetToPaymentCeil(
+				selectedAmount,
+				assetDecimals,
+				scaledPrice,
+				paymentDecimals
+			);
 			insufficientBalanceError = estimatedCostBigInt > spendingTokenBalance;
 		}
 	}
@@ -254,18 +262,33 @@
 	// In spend mode: show how many asset tokens you'll receive
 	$: estimatedTradeResult = (() => {
 		if (!selectedAmount || !marketPrice) return { value: '0.00', label: '' };
+		const scaledPrice = priceToScaledBigInt(marketPrice);
 		if (inputMode === 'spend') {
-			// Spend mode: show estimated tokens received
-			const spendInTokens = parseFloat(formatUnits(selectedAmount, paymentToken?.decimals || 6));
-			const tokensReceived = spendInTokens / marketPrice;
+			// Spend mode: show estimated tokens received using BigInt math
+			const paymentDecimals = paymentToken?.decimals ?? 6;
+			const assetDecimals = assetToken?.decimals ?? 18;
+			const tokensReceivedBigInt = paymentToAsset(
+				selectedAmount,
+				paymentDecimals,
+				scaledPrice,
+				assetDecimals
+			);
+			const tokensReceived = parseFloat(formatUnits(tokensReceivedBigInt, assetDecimals));
 			return {
 				value: `~${tokensReceived.toFixed(4)} ${assetToken?.symbol ?? 'tokens'}`,
 				label: 'Est. tokens'
 			};
 		} else {
-			// Amount mode: show estimated cost
-			const outputInTokens = parseFloat(formatUnits(selectedAmount, assetToken?.decimals || 18));
-			const total = outputInTokens * marketPrice;
+			// Amount mode: show estimated cost using BigInt math
+			const assetDecimals = assetToken?.decimals ?? 18;
+			const paymentDecimals = paymentToken?.decimals ?? 6;
+			const totalBigInt = assetToPaymentCeil(
+				selectedAmount,
+				assetDecimals,
+				scaledPrice,
+				paymentDecimals
+			);
+			const total = parseFloat(formatUnits(totalBigInt, paymentDecimals));
 			return {
 				value: `~${total.toFixed(2)} ${paymentTokenSymbol}`,
 				label: 'Est. cost'
@@ -307,14 +330,17 @@
 			// Calculate payment amount to spend (percent of balance)
 			const paymentToSpend = (spendingTokenBalance * BigInt(percent)) / 100n;
 
-			// Convert payment amount to asset amount using oracle price
+			// Convert payment amount to asset amount using BigInt arithmetic
 			// paymentAmount / price = assetAmount
-			// Use floor to ensure we don't exceed the balance when converting back
-			const paymentInFloat = parseFloat(formatUnits(paymentToSpend, paymentDecimals));
-			const assetAmount = paymentInFloat / oraclePrice;
-			// Use floor to be conservative and prevent "not enough funds" errors
-			const assetAmountScaled = Math.floor(assetAmount * 10 ** assetDecimals);
-			tradeAmountInputRef.setAmountValue(BigInt(assetAmountScaled));
+			// Using scaled BigInt math to avoid floating-point precision issues
+			const scaledPrice = priceToScaledBigInt(oraclePrice);
+			const assetAmountBigInt = paymentToAsset(
+				paymentToSpend,
+				paymentDecimals,
+				scaledPrice,
+				assetDecimals
+			);
+			tradeAmountInputRef.setAmountValue(assetAmountBigInt);
 		}
 	};
 

--- a/src/lib/stores/transaction.ts
+++ b/src/lib/stores/transaction.ts
@@ -74,6 +74,7 @@ import {
 	type RaindexOrder
 } from '@rainlanguage/orderbook';
 import { parseFloatHex, getRaindexOrderUrl, isPaymentToken } from '$lib/utils/tokenMath';
+import { bigIntRatio } from '$lib/utils/bigIntMath';
 import { TransactionErrorMessage } from '$lib/types/errors';
 import { isStaleWalletSessionError, handleStaleWalletSession } from '$lib/utils/walletUtils';
 import type { TakeOrdersParams } from '$lib/types/transactions';
@@ -1222,26 +1223,23 @@ const transactionStore = () => {
 			totalOutputAmount += outputAmount;
 		}
 
-		// Calculate actual ioRatio from transaction data
+		// Calculate actual ioRatio from transaction data using BigInt precision
 		const actualIoRatio =
 			totalOutputAmount > 0n
-				? parseFloat(formatUnits(totalInputAmount, inputTokenDecimals)) /
-					parseFloat(formatUnits(totalOutputAmount, outputTokenDecimals))
+				? bigIntRatio(totalInputAmount, inputTokenDecimals, totalOutputAmount, outputTokenDecimals)
 				: 0;
 
 		// Use the user's actual requested input amount
 		const requestedInputAmount = params.requestedTakerWantsAmount;
 
 		// Check if fill is complete (within 99.9% tolerance)
-		// Need to normalize both amounts to the same decimal scale for comparison
-		const inputFilledDecimal = parseFloat(formatUnits(totalInputAmount, inputTokenDecimals));
-		const inputRequestedDecimal = parseFloat(formatUnits(requestedInputAmount, inputTokenDecimals));
-
+		// Use BigInt ratio for precise fill percentage calculation
 		let fillPercentage = 0;
 		let isNoFill = false;
 
-		if (inputRequestedDecimal > 0) {
-			fillPercentage = inputFilledDecimal / inputRequestedDecimal;
+		if (requestedInputAmount > 0n) {
+			// Both amounts have same decimals (inputTokenDecimals), so we can compare directly
+			fillPercentage = bigIntRatio(totalInputAmount, inputTokenDecimals, requestedInputAmount, inputTokenDecimals);
 		} else {
 			// No requested quantity means no tokens requested
 			isNoFill = true;

--- a/src/lib/utils/bigIntMath.ts
+++ b/src/lib/utils/bigIntMath.ts
@@ -1,0 +1,369 @@
+/**
+ * BigInt Precision Math Utilities
+ *
+ * This module provides BigInt-based arithmetic operations for handling token amounts
+ * and price calculations without floating-point precision loss.
+ *
+ * Key concepts:
+ * - PRICE_SCALE: Standard 18-decimal precision for price representations
+ * - All price calculations use scaled BigInt arithmetic
+ * - Conversion functions handle different token decimal configurations
+ */
+
+/**
+ * Standard precision scale for prices (18 decimals)
+ * This matches the common ERC-20 token decimal standard
+ */
+export const PRICE_SCALE = 10n ** 18n;
+export const PRICE_DECIMALS = 18;
+
+/**
+ * Converts a floating-point price to a scaled BigInt representation.
+ *
+ * @param price - The price as a floating-point number (e.g., 123.45)
+ * @param scale - The scale to use (default: PRICE_SCALE = 10^18)
+ * @returns The price as a scaled BigInt
+ *
+ * @example
+ * // Price of $123.45 per token
+ * const scaledPrice = priceToScaledBigInt(123.45);
+ * // Returns 123450000000000000000n (123.45 * 10^18)
+ */
+export function priceToScaledBigInt(price: number, scale: bigint = PRICE_SCALE): bigint {
+	if (!Number.isFinite(price) || price < 0) {
+		return 0n;
+	}
+	// Use string conversion to avoid floating-point precision issues
+	// We multiply by scale and truncate to integer
+	const scaledFloat = price * Number(scale);
+	// Use Math.floor to truncate (not round) to avoid overshooting
+	return BigInt(Math.floor(scaledFloat));
+}
+
+/**
+ * Converts a scaled BigInt price back to a floating-point number.
+ *
+ * @param scaledPrice - The price as a scaled BigInt
+ * @param scale - The scale used (default: PRICE_SCALE = 10^18)
+ * @returns The price as a floating-point number
+ */
+export function scaledBigIntToPrice(scaledPrice: bigint, scale: bigint = PRICE_SCALE): number {
+	return Number(scaledPrice) / Number(scale);
+}
+
+/**
+ * Calculates asset amount from payment amount and price using BigInt arithmetic.
+ *
+ * Formula: assetAmount = paymentAmount / price
+ *
+ * @param paymentAmount - Payment amount in payment token's smallest unit (BigInt)
+ * @param paymentDecimals - Decimals of the payment token (e.g., 6 for USDC)
+ * @param scaledPrice - Price scaled to PRICE_SCALE (use priceToScaledBigInt)
+ * @param assetDecimals - Decimals of the asset token (e.g., 18)
+ * @returns Asset amount in asset token's smallest unit (BigInt)
+ *
+ * @example
+ * // Buy tokens with 100 USDC at price $10 per token
+ * const usdcAmount = 100_000_000n; // 100 USDC (6 decimals)
+ * const price = priceToScaledBigInt(10); // $10 scaled
+ * const tokenAmount = paymentToAsset(usdcAmount, 6, price, 18);
+ * // Returns ~10_000_000_000_000_000_000n (10 tokens with 18 decimals)
+ */
+export function paymentToAsset(
+	paymentAmount: bigint,
+	paymentDecimals: number,
+	scaledPrice: bigint,
+	assetDecimals: number
+): bigint {
+	if (scaledPrice === 0n || paymentAmount === 0n) {
+		return 0n;
+	}
+
+	// Normalize payment amount to 18 decimals for consistent calculation
+	// paymentNormalized = paymentAmount * 10^(18 - paymentDecimals)
+	const decimalDiff = PRICE_DECIMALS - paymentDecimals;
+	const paymentNormalized =
+		decimalDiff >= 0
+			? paymentAmount * 10n ** BigInt(decimalDiff)
+			: paymentAmount / 10n ** BigInt(-decimalDiff);
+
+	// assetAmount (in 18 decimals) = paymentNormalized * PRICE_SCALE / scaledPrice
+	const assetNormalized = (paymentNormalized * PRICE_SCALE) / scaledPrice;
+
+	// Convert to asset decimals
+	const assetDecimalDiff = assetDecimals - PRICE_DECIMALS;
+	return assetDecimalDiff >= 0
+		? assetNormalized * 10n ** BigInt(assetDecimalDiff)
+		: assetNormalized / 10n ** BigInt(-assetDecimalDiff);
+}
+
+/**
+ * Calculates payment amount from asset amount and price using BigInt arithmetic.
+ *
+ * Formula: paymentAmount = assetAmount * price
+ *
+ * @param assetAmount - Asset amount in asset token's smallest unit (BigInt)
+ * @param assetDecimals - Decimals of the asset token (e.g., 18)
+ * @param scaledPrice - Price scaled to PRICE_SCALE (use priceToScaledBigInt)
+ * @param paymentDecimals - Decimals of the payment token (e.g., 6 for USDC)
+ * @returns Payment amount in payment token's smallest unit (BigInt)
+ *
+ * @example
+ * // Sell 10 tokens at price $10 per token
+ * const tokenAmount = 10_000_000_000_000_000_000n; // 10 tokens (18 decimals)
+ * const price = priceToScaledBigInt(10); // $10 scaled
+ * const usdcAmount = assetToPayment(tokenAmount, 18, price, 6);
+ * // Returns 100_000_000n (100 USDC with 6 decimals)
+ */
+export function assetToPayment(
+	assetAmount: bigint,
+	assetDecimals: number,
+	scaledPrice: bigint,
+	paymentDecimals: number
+): bigint {
+	if (assetAmount === 0n) {
+		return 0n;
+	}
+
+	// Normalize asset amount to 18 decimals for consistent calculation
+	const decimalDiff = PRICE_DECIMALS - assetDecimals;
+	const assetNormalized =
+		decimalDiff >= 0
+			? assetAmount * 10n ** BigInt(decimalDiff)
+			: assetAmount / 10n ** BigInt(-decimalDiff);
+
+	// paymentAmount (in 18 decimals) = assetNormalized * scaledPrice / PRICE_SCALE
+	const paymentNormalized = (assetNormalized * scaledPrice) / PRICE_SCALE;
+
+	// Convert to payment decimals
+	const paymentDecimalDiff = paymentDecimals - PRICE_DECIMALS;
+	return paymentDecimalDiff >= 0
+		? paymentNormalized * 10n ** BigInt(paymentDecimalDiff)
+		: paymentNormalized / 10n ** BigInt(-paymentDecimalDiff);
+}
+
+/**
+ * Calculates a percentage of a BigInt amount.
+ *
+ * @param amount - The base amount as BigInt
+ * @param percent - The percentage (0-100)
+ * @returns The percentage of the amount as BigInt
+ *
+ * @example
+ * const balance = 1000_000_000n; // 1000 USDC
+ * const twentyFivePercent = percentageOf(balance, 25);
+ * // Returns 250_000_000n (250 USDC)
+ */
+export function percentageOf(amount: bigint, percent: number): bigint {
+	if (amount === 0n || percent <= 0) {
+		return 0n;
+	}
+	// Use BigInt multiplication to avoid precision loss
+	// We multiply by 100 first to maintain precision, then divide by 10000
+	return (amount * BigInt(Math.floor(percent * 100))) / 10000n;
+}
+
+/**
+ * Adjusts a BigInt amount from one decimal precision to another.
+ *
+ * @param amount - The amount to adjust
+ * @param fromDecimals - Current decimal precision
+ * @param toDecimals - Target decimal precision
+ * @returns The adjusted amount
+ *
+ * @example
+ * // Convert 100 USDC (6 decimals) representation to 18 decimals
+ * const usdc6 = 100_000_000n;
+ * const usdc18 = adjustDecimals(usdc6, 6, 18);
+ * // Returns 100_000_000_000_000_000_000n
+ */
+export function adjustDecimals(amount: bigint, fromDecimals: number, toDecimals: number): bigint {
+	if (fromDecimals === toDecimals) {
+		return amount;
+	}
+	const diff = toDecimals - fromDecimals;
+	if (diff > 0) {
+		return amount * 10n ** BigInt(diff);
+	}
+	return amount / 10n ** BigInt(-diff);
+}
+
+/**
+ * Divides two BigInt amounts with proper decimal handling.
+ * Useful for calculating ratios or prices from two token amounts.
+ *
+ * @param numerator - The numerator amount
+ * @param numeratorDecimals - Decimals of the numerator token
+ * @param denominator - The denominator amount
+ * @param denominatorDecimals - Decimals of the denominator token
+ * @param resultScale - Scale for the result (default: PRICE_SCALE)
+ * @returns Scaled result as BigInt
+ */
+export function divideBigInts(
+	numerator: bigint,
+	numeratorDecimals: number,
+	denominator: bigint,
+	denominatorDecimals: number,
+	resultScale: bigint = PRICE_SCALE
+): bigint {
+	if (denominator === 0n) {
+		return 0n;
+	}
+
+	// Normalize both to 18 decimals
+	const numNormalized = adjustDecimals(numerator, numeratorDecimals, PRICE_DECIMALS);
+	const denNormalized = adjustDecimals(denominator, denominatorDecimals, PRICE_DECIMALS);
+
+	// Perform division with scaling
+	return (numNormalized * resultScale) / denNormalized;
+}
+
+/**
+ * Multiplies two BigInt amounts with proper decimal handling.
+ *
+ * @param amount1 - First amount
+ * @param decimals1 - Decimals of first amount
+ * @param amount2 - Second amount
+ * @param decimals2 - Decimals of second amount
+ * @param resultDecimals - Desired decimals for result
+ * @returns Result amount with specified decimals
+ */
+export function multiplyBigInts(
+	amount1: bigint,
+	decimals1: number,
+	amount2: bigint,
+	decimals2: number,
+	resultDecimals: number
+): bigint {
+	// Normalize both to 18 decimals
+	const norm1 = adjustDecimals(amount1, decimals1, PRICE_DECIMALS);
+	const norm2 = adjustDecimals(amount2, decimals2, PRICE_DECIMALS);
+
+	// Multiply and adjust for double-scaling (18 + 18 = 36 decimals after multiplication)
+	const product = (norm1 * norm2) / PRICE_SCALE;
+
+	// Convert to result decimals
+	return adjustDecimals(product, PRICE_DECIMALS, resultDecimals);
+}
+
+/**
+ * Rounds a BigInt amount up when converting to fewer decimals.
+ * Useful for ensuring sufficient payment when buying tokens.
+ *
+ * @param amount - Amount to round up
+ * @param fromDecimals - Current decimals
+ * @param toDecimals - Target decimals (must be <= fromDecimals)
+ * @returns Rounded up amount
+ */
+export function ceilAdjustDecimals(
+	amount: bigint,
+	fromDecimals: number,
+	toDecimals: number
+): bigint {
+	if (fromDecimals <= toDecimals) {
+		return adjustDecimals(amount, fromDecimals, toDecimals);
+	}
+
+	const divisor = 10n ** BigInt(fromDecimals - toDecimals);
+	const quotient = amount / divisor;
+	const remainder = amount % divisor;
+
+	return remainder > 0n ? quotient + 1n : quotient;
+}
+
+/**
+ * Calculates asset amount from payment with ceiling rounding.
+ * Use when you want to ensure you get at least the calculated amount.
+ */
+export function paymentToAssetCeil(
+	paymentAmount: bigint,
+	paymentDecimals: number,
+	scaledPrice: bigint,
+	assetDecimals: number
+): bigint {
+	return paymentToAsset(paymentAmount, paymentDecimals, scaledPrice, assetDecimals);
+}
+
+/**
+ * Calculates payment amount from asset with ceiling rounding.
+ * Use when you want to ensure you have enough payment.
+ */
+export function assetToPaymentCeil(
+	assetAmount: bigint,
+	assetDecimals: number,
+	scaledPrice: bigint,
+	paymentDecimals: number
+): bigint {
+	if (assetAmount === 0n) {
+		return 0n;
+	}
+
+	// Normalize asset amount to 18 decimals for consistent calculation
+	const decimalDiff = PRICE_DECIMALS - assetDecimals;
+	const assetNormalized =
+		decimalDiff >= 0
+			? assetAmount * 10n ** BigInt(decimalDiff)
+			: assetAmount / 10n ** BigInt(-decimalDiff);
+
+	// paymentAmount (in 18 decimals) = ceil(assetNormalized * scaledPrice / PRICE_SCALE)
+	const product = assetNormalized * scaledPrice;
+	const paymentNormalized = product / PRICE_SCALE + (product % PRICE_SCALE > 0n ? 1n : 0n);
+
+	// Convert to payment decimals with ceiling
+	const paymentDecimalDiff = paymentDecimals - PRICE_DECIMALS;
+	if (paymentDecimalDiff >= 0) {
+		return paymentNormalized * 10n ** BigInt(paymentDecimalDiff);
+	}
+	return ceilAdjustDecimals(paymentNormalized, PRICE_DECIMALS, paymentDecimals);
+}
+
+/**
+ * Compares two BigInt amounts with different decimals.
+ *
+ * @returns negative if a < b, 0 if equal, positive if a > b
+ */
+export function compareBigInts(
+	a: bigint,
+	aDecimals: number,
+	b: bigint,
+	bDecimals: number
+): number {
+	const aNormalized = adjustDecimals(a, aDecimals, PRICE_DECIMALS);
+	const bNormalized = adjustDecimals(b, bDecimals, PRICE_DECIMALS);
+
+	if (aNormalized < bNormalized) return -1;
+	if (aNormalized > bNormalized) return 1;
+	return 0;
+}
+
+/**
+ * Calculates the ratio of two BigInt amounts as a floating-point number.
+ * Use this for display purposes only (e.g., showing ioRatio after a trade).
+ *
+ * @param numerator - The numerator amount
+ * @param numeratorDecimals - Decimals of the numerator token
+ * @param denominator - The denominator amount
+ * @param denominatorDecimals - Decimals of the denominator token
+ * @returns The ratio as a floating-point number
+ */
+export function bigIntRatio(
+	numerator: bigint,
+	numeratorDecimals: number,
+	denominator: bigint,
+	denominatorDecimals: number
+): number {
+	if (denominator === 0n) {
+		return 0;
+	}
+
+	// Use high-precision intermediate calculation
+	const scaled = divideBigInts(
+		numerator,
+		numeratorDecimals,
+		denominator,
+		denominatorDecimals,
+		PRICE_SCALE
+	);
+
+	return scaledBigIntToPrice(scaled);
+}

--- a/src/lib/utils/tradeTransform.ts
+++ b/src/lib/utils/tradeTransform.ts
@@ -1,5 +1,6 @@
 import { formatUnits } from 'viem';
 import { parseFloatHex } from '$lib/utils/tokenMath';
+import { bigIntRatio } from '$lib/utils/bigIntMath';
 import { TOKENS } from '$lib/config/tokens';
 import type { SgTrade } from '@rainlanguage/orderbook';
 import type { DisplayOrder } from '$lib/types/orders';
@@ -70,15 +71,15 @@ export function transformTradeToDisplayOrder(
 		? parseFloatHex(outputAmountHex, outputDecimals, true)
 		: 0n;
 
-	// Calculate price (payment / asset) from taker's perspective
+	// Calculate price (payment / asset) from taker's perspective using BigInt precision
 	// Order's input = what taker gave, Order's output = what taker received
 	// Buy: taker gave payment (order's input), received asset (order's output) -> price = input/output
 	// Sell: taker gave asset (order's input), received payment (order's output) -> price = output/input
 	let price: number | undefined;
 	if (inputAmountBigInt > 0n && outputAmountBigInt > 0n) {
-		const inputValue = parseFloat(formatUnits(inputAmountBigInt, inputDecimals));
-		const outputValue = parseFloat(formatUnits(outputAmountBigInt, outputDecimals));
-		price = isBuy ? inputValue / outputValue : outputValue / inputValue;
+		price = isBuy
+			? bigIntRatio(inputAmountBigInt, inputDecimals, outputAmountBigInt, outputDecimals)
+			: bigIntRatio(outputAmountBigInt, outputDecimals, inputAmountBigInt, inputDecimals);
 	}
 
 	return {


### PR DESCRIPTION
Replace floating-point conversions with BigInt math throughout trade components to eliminate rounding errors in percentage button handlers and balance calculations.

Changes:
- Add bigIntMath.ts utility module with scaled BigInt arithmetic functions
- MarketOrder: Use BigInt for percentage handlers and balance checks
- LimitOrder: Use BigInt for percentage handlers
- DcaOrder: Use BigInt for min trade amount calculation
- QuickTrade: Use BigInt for percentage calculations
- transaction.ts: Use bigIntRatio for ioRatio and fill percentage
- tradeTransform.ts: Use bigIntRatio for price calculation