### PR TITLE
Optimize admin TVL & trading volume page performance

### DIFF
--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -16,6 +16,7 @@ export function createTradeActivityQuery(network: Network | null, pollInterval: 
 	return createQuery<TradeActivityPayload>({
 		queryKey: ['tradeActivity', network?.id],
 		enabled: Boolean(network),
+		staleTime: 600_000,
 		refetchInterval: pollInterval,
 		queryFn: async () => {
 			const now = Math.floor(Date.now() / 1000);

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1274,15 +1274,18 @@
 		if (!res.ok) throw new Error('Failed to fetch wallet data');
 		const data = await res.json();
 
-		// Fetch wallets for each code
-		const wallets: RegisteredWallet[] = [];
-		for (const code of data.codes || []) {
-			const walletsRes = await fetch(`/api/admin/wallets?code=${code.code}`);
-			if (walletsRes.ok) {
-				const walletsData = await walletsRes.json();
-				wallets.push(...(walletsData.wallets || []));
-			}
-		}
+		// Fetch wallets for all codes in parallel
+		const walletResults = await Promise.all(
+			(data.codes || []).map(async (code: { code: string }) => {
+				const walletsRes = await fetch(`/api/admin/wallets?code=${code.code}`);
+				if (walletsRes.ok) {
+					const walletsData = await walletsRes.json();
+					return walletsData.wallets || [];
+				}
+				return [];
+			})
+		);
+		const wallets: RegisteredWallet[] = walletResults.flat();
 		return wallets;
 	}
 

--- a/src/routes/api/admin/tvl/+server.ts
+++ b/src/routes/api/admin/tvl/+server.ts
@@ -4,6 +4,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
 	kvGet,
+	getKv,
 	KV_KEYS,
 	getExcludedWalletsSet,
 	getTeamWalletsSet,
@@ -71,9 +72,14 @@ async function fetchWalletToCodeMapping(): Promise<Map<string, string>> {
 		// Fetch all access codes
 		const allCodes = (await kvGet<string[]>(KV_KEYS.allCodes())) || [];
 
-		// Fetch wallets for each code
-		for (const code of allCodes) {
-			const walletAddresses = (await kvGet<string[]>(KV_KEYS.codeWallets(code))) || [];
+		// Fetch wallets for all codes in parallel
+		const walletArrays = await Promise.all(
+			allCodes.map(async (code) => {
+				const walletAddresses = (await kvGet<string[]>(KV_KEYS.codeWallets(code))) || [];
+				return { code, walletAddresses };
+			})
+		);
+		for (const { code, walletAddresses } of walletArrays) {
 			for (const address of walletAddresses) {
 				walletToCode.set(address.toLowerCase(), code);
 			}
@@ -363,6 +369,17 @@ export const GET: RequestHandler = async ({ url }) => {
 		const limitParam = url.searchParams.get('limit');
 		const limit = limitParam ? parseInt(limitParam) : 90; // Default to 90 days
 
+		// Check KV cache first
+		const cacheKey = `tvl:cache:${limit}`;
+		const cached = await kvGet<TvlResponse>(cacheKey);
+		if (cached) {
+			return json(cached, {
+				headers: {
+					'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=7200'
+				}
+			});
+		}
+
 		// Get wallet-to-code mapping, excluded wallets, and team wallets
 		const [walletToCode, excludedWallets, teamWallets] = await Promise.all([
 			fetchWalletToCodeMapping(),
@@ -409,8 +426,8 @@ export const GET: RequestHandler = async ({ url }) => {
 		// Calculate TVL for each day (in parallel, but limit concurrency)
 		const dailyTvl: DailyTvlEntry[] = [];
 
-		// Process in batches of 5 to avoid overwhelming the blob storage
-		const batchSize = 5;
+		// Process in batches of 15 to avoid overwhelming the blob storage
+		const batchSize = 15;
 		for (let i = 0; i < limitedDates.length; i += batchSize) {
 			const batch = limitedDates.slice(i, i + batchSize);
 			const batchResults = await Promise.all(
@@ -450,7 +467,7 @@ export const GET: RequestHandler = async ({ url }) => {
 		// Sort daily TVL by date ascending for charts
 		dailyTvl.sort((a, b) => a.date.localeCompare(b.date));
 
-		return json({
+		const response: TvlResponse = {
 			success: true,
 			latest: latestTvl
 				? {
@@ -468,7 +485,19 @@ export const GET: RequestHandler = async ({ url }) => {
 					}
 				: null,
 			daily: dailyTvl
-		} as TvlResponse);
+		};
+
+		// Cache in KV with 1-hour TTL
+		const client = await getKv();
+		if (client) {
+			await client.set(cacheKey, JSON.stringify(response), { EX: 3600 });
+		}
+
+		return json(response, {
+			headers: {
+				'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=7200'
+			}
+		});
 	} catch (error) {
 		console.error('[TVL API] Error:', error);
 		return json(


### PR DESCRIPTION
## Summary
- Parallelize wallet fetching in TVL API and admin page using `Promise.all` (was sequential `for..of`)
- Add KV cache with 1-hour TTL to TVL endpoint, avoiding recomputation from Blob storage on repeat requests
- Add `Cache-Control` headers (`s-maxage=3600, stale-while-revalidate=7200, max-age=300`) to TVL responses
- Increase TVL daily batch size from 5 to 15
- Add `staleTime: 600_000` (10 min) to trade activity query to prevent refetching on every component mount

## Test plan
- [ ] Load admin page, confirm TVL and trading volume tabs load faster
- [ ] Check DevTools Network tab: TVL response should have `Cache-Control` header
- [ ] Second load within 1 hour should be near-instant (KV cache hit)
- [ ] Verify TVL data accuracy is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Enhanced caching for trade activity queries to reduce redundant data fetching
  * Accelerated wallet data retrieval in admin operations through concurrent processing
  * Implemented response caching for TVL API endpoint with optimized batch processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->