### PR TITLE
Bump sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@fontsource/ia-writer-mono": "5.2.5",
 				"@graphql-codegen/typescript-document-nodes": "4.0.16",
 				"@rainlanguage/float": "0.0.0-alpha.40",
-				"@rainlanguage/orderbook": "0.0.1-alpha.229",
+				"@rainlanguage/orderbook": "0.0.1-alpha.231",
 				"@scalar/api-reference": "1.40.1",
 				"@sveltejs/adapter-static": "3.0.10",
 				"@testing-library/user-event": "14.5.2",
@@ -6030,9 +6030,9 @@
 			}
 		},
 		"node_modules/@rainlanguage/orderbook": {
-			"version": "0.0.1-alpha.229",
-			"resolved": "https://registry.npmjs.org/@rainlanguage/orderbook/-/orderbook-0.0.1-alpha.229.tgz",
-			"integrity": "sha512-CR11Vd6BQCmP8Xj15HfaMxbNeRPM+Sai4bnWhh7dlMnG0kh56PIzDFo4xSnD6eowOnsL9VWG5LvhNpsAKZj5ZQ==",
+			"version": "0.0.1-alpha.231",
+			"resolved": "https://registry.npmjs.org/@rainlanguage/orderbook/-/orderbook-0.0.1-alpha.231.tgz",
+			"integrity": "sha512-TsXLyzAgm3e2VzawP5YhYVOWsCTf1hrQvJfA8GqUrwOvsPsnUslJ/MrKDpwTt/Fbb+GGAm9qFZJU786g3mDdHw==",
 			"license": "LicenseRef-DCL-1.0",
 			"dependencies": {
 				"buffer": "6.0.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@fontsource/ia-writer-mono": "5.2.5",
 		"@graphql-codegen/typescript-document-nodes": "4.0.16",
 		"@rainlanguage/float": "0.0.0-alpha.40",
-		"@rainlanguage/orderbook": "0.0.1-alpha.229",
+		"@rainlanguage/orderbook": "0.0.1-alpha.231",
 		"@scalar/api-reference": "1.40.1",
 		"@sveltejs/adapter-static": "3.0.10",
 		"@testing-library/user-event": "14.5.2",

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -35,6 +35,11 @@ import {
 } from '$lib/utils/orderbook';
 import { fetchQuotesWithBatching } from '$lib/utils/quoteBatcher';
 
+const DEBUG_ORDER_HASHES = new Set([
+	'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
+	'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
+]);
+
 // Re-export types and utilities
 export type { ProcessedQuote, TokenPriceSummary };
 export { OrderV4_ABI, normalizeOrderData, scaleAmount, walkOrderbook, hexToBigInt };
@@ -63,15 +68,35 @@ function processOrdersWithQuotes(
 
 	// Process each order with its quotes
 	orders.forEach((order) => {
+		const orderHashLc = order.orderHash?.toLowerCase();
+		const isDebugOrder = !!orderHashLc && DEBUG_ORDER_HASHES.has(orderHashLc);
 		const quotes = quotesMap.get(order);
 		if (!quotes || quotes.length === 0) {
+			if (isDebugOrder) {
+				console.log('[orders-debug] no quotes from batcher for order', {
+					orderHash: order.orderHash
+				});
+			}
 			return;
+		}
+		if (isDebugOrder) {
+			console.log('[orders-debug] quotes fetched for order', {
+				orderHash: order.orderHash,
+				quoteCount: quotes.length,
+				successCount: quotes.filter((q) => q.success && !!q.data).length
+			});
 		}
 
 		try {
 			// Convert RaindexOrder to SgOrder to get orderBytes
 			const sgOrderResult = order.convertToSgOrder();
 			if (sgOrderResult.error || !sgOrderResult.value) {
+				if (isDebugOrder) {
+					console.log('[orders-debug] convertToSgOrder failed', {
+						orderHash: order.orderHash,
+						error: sgOrderResult.error?.readableMsg
+					});
+				}
 				return;
 			}
 			const sgOrder = sgOrderResult.value;
@@ -86,6 +111,14 @@ function processOrdersWithQuotes(
 				try {
 					// Skip if the quote failed
 					if (!quote.success || !quote.data) {
+						if (isDebugOrder) {
+							console.log('[orders-debug] skipping failed/empty quote', {
+								orderHash: order.orderHash,
+								success: quote.success,
+								hasData: !!quote.data,
+								error: quote.error
+							});
+						}
 						return;
 					}
 
@@ -100,12 +133,26 @@ function processOrdersWithQuotes(
 						!maxOutput.startsWith('0x') ||
 						maxOutput.length !== 66
 					) {
+						if (isDebugOrder) {
+							console.log('[orders-debug] invalid ratio/maxOutput format', {
+								orderHash: order.orderHash,
+								ratio,
+								maxOutput
+							});
+						}
 						return;
 					}
 
 					// Verify maxOutput is not zero by converting to Float and checking
 					const maxOutputFloat = Float.fromHex(maxOutput as `0x${string}`);
 					if (maxOutputFloat.error || !maxOutputFloat.value) {
+						if (isDebugOrder) {
+							console.log('[orders-debug] maxOutput Float.fromHex failed', {
+								orderHash: order.orderHash,
+								maxOutput,
+								error: maxOutputFloat.error?.readableMsg
+							});
+						}
 						return;
 					}
 					// Check if maxOutput is zero
@@ -115,12 +162,26 @@ function processOrdersWithQuotes(
 					if (!zeroFloat.error && zeroFloat.value) {
 						const isZero = maxOutputFloat.value.eq(zeroFloat.value);
 						if (!isZero.error && isZero.value) {
+							if (isDebugOrder) {
+								console.log('[orders-debug] maxOutput is zero, skipping', {
+									orderHash: order.orderHash
+								});
+							}
 							return;
 						}
 					}
 					const inputDefinition = orderData.validInputs[quote.pair.inputIndex];
 					const outputDefinition = orderData.validOutputs[quote.pair.outputIndex];
 					if (!inputDefinition || !outputDefinition) {
+						if (isDebugOrder) {
+							console.log('[orders-debug] missing IO definition', {
+								orderHash: order.orderHash,
+								inputIndex: quote.pair.inputIndex,
+								outputIndex: quote.pair.outputIndex,
+								validInputsLen: orderData.validInputs.length,
+								validOutputsLen: orderData.validOutputs.length
+							});
+						}
 						return;
 					}
 
@@ -133,6 +194,14 @@ function processOrdersWithQuotes(
 					const normalizedOutput = normalizeAddress(outputTokenAddress);
 					const normalizedQuote = normalizeAddress(quoteToken.address);
 					if (normalizedInput !== normalizedQuote && normalizedOutput !== normalizedQuote) {
+						if (isDebugOrder) {
+							console.log('[orders-debug] dropped by quote-token filter', {
+								orderHash: order.orderHash,
+								inputTokenAddress,
+								outputTokenAddress,
+								quoteToken: quoteToken.address
+							});
+						}
 						return;
 					}
 					const allTokens = [quoteToken, ...stockTokens];
@@ -197,6 +266,23 @@ function processOrdersWithQuotes(
 						const normalizedAsset = normalizeAddress(metrics.assetAddress);
 						processedQuote.assetAddress = normalizedAsset ?? metrics.assetAddress;
 						processedQuote.quotePerAsset = metrics.quotePerAsset;
+						if (isDebugOrder) {
+							console.log('[orders-debug] processed quote side/price', {
+								orderHash: order.orderHash,
+								side: processedQuote.side,
+								assetAddress: processedQuote.assetAddress,
+								quotePerAsset: processedQuote.quotePerAsset,
+								inputTokenAddress,
+								outputTokenAddress
+							});
+						}
+					} else if (isDebugOrder) {
+						console.log('[orders-debug] describeQuote returned null', {
+							orderHash: order.orderHash,
+							inputTokenAddress,
+							outputTokenAddress,
+							quoteToken: quoteToken.address
+						});
 					}
 
 					processedQuotes.push(processedQuote);
@@ -261,9 +347,16 @@ export async function fetchAndQuotePaymentTokenOrders(
 				owners: []
 			};
 
-			// Filter only by stock tokens - payment token filtering is too restrictive
-			// Orders should be visible regardless of which payment token is configured
-			const tokenAddresses = stockTokens.map((t) => t.address as `0x${string}`);
+			// Include both stock + payment token addresses on each side.
+			// Some SDK/subgraph versions treat inputs+outputs as an AND condition; including payment
+			// here ensures stock/payment pairs (e.g. tSTOX/USDC) are not dropped server-side.
+			const tokenAddresses = [
+				...new Set(
+					stockTokens
+						.map((t) => t.address.toLowerCase())
+						.concat(defaultPaymentToken.address.toLowerCase())
+				)
+			] as `0x${string}`[];
 
 			filters.tokens = { inputs: tokenAddresses, outputs: tokenAddresses };
 
@@ -274,6 +367,15 @@ export async function fetchAndQuotePaymentTokenOrders(
 			}
 
 			const pageOrders = ordersResult.value.orders;
+			const debugPageOrders = pageOrders
+				.map((o) => o.orderHash?.toLowerCase())
+				.filter((h) => !!h && DEBUG_ORDER_HASHES.has(h));
+			if (debugPageOrders.length > 0) {
+				console.log('[orders-debug] fetchAndQuotePaymentTokenOrders found debug orders in page', {
+					page,
+					hashes: debugPageOrders
+				});
+			}
 			allOrders.push(...pageOrders);
 
 			// If we got fewer orders than the page size, we've reached the end
@@ -351,10 +453,14 @@ export async function fetchAndQuoteTokenOrders(
 
 	// Fetch orders for this specific token only
 	const tokenAddr = tokenAddress as `0x${string}`;
+	const paymentAddr = defaultPaymentToken.address as `0x${string}`;
+	const tokenPairAddresses = [...new Set([tokenAddr.toLowerCase(), paymentAddr.toLowerCase()])] as `0x${string}`[];
 	const filters: GetOrdersFilters = {
 		active: true,
 		owners: [],
-		tokens: { inputs: [tokenAddr], outputs: [tokenAddr] }
+		// Include payment token on both sides so stock/payment pairs are returned even
+		// when token filter semantics are strict (inputs AND outputs).
+		tokens: { inputs: tokenPairAddresses, outputs: tokenPairAddresses }
 	};
 
 	const ordersResult = await client.getOrders([networkId], filters, 1);
@@ -364,9 +470,30 @@ export async function fetchAndQuoteTokenOrders(
 	}
 
 	const allOrders = ordersResult.value.orders;
+	const debugOrders = allOrders
+		.map((o) => o.orderHash?.toLowerCase())
+		.filter((h) => !!h && DEBUG_ORDER_HASHES.has(h));
+	console.log('[orders-debug] fetchAndQuoteTokenOrders result', {
+		tokenAddress,
+		paymentToken: defaultPaymentToken.address,
+		totalOrders: allOrders.length,
+		debugOrderHashes: debugOrders
+	});
 
 	// Get quotes using batching with jitter and retries
 	const quotesMap = await fetchQuotesWithBatching(allOrders);
+	for (const order of allOrders) {
+		const hash = order.orderHash?.toLowerCase();
+		if (hash && DEBUG_ORDER_HASHES.has(hash)) {
+			const quotes = quotesMap.get(order) ?? [];
+			console.log('[orders-debug] batch quotes map entry', {
+				orderHash: order.orderHash,
+				quoteCount: quotes.length,
+				successCount: quotes.filter((q) => q.success && !!q.data).length,
+				errors: quotes.filter((q) => !q.success).map((q) => q.error)
+			});
+		}
+	}
 
 	// Process and filter the quotes
 	const processedQuotes = processOrdersWithQuotes(
@@ -375,6 +502,19 @@ export async function fetchAndQuoteTokenOrders(
 		defaultPaymentToken,
 		stockTokens
 	);
+	const debugProcessed = processedQuotes.filter((q) =>
+		DEBUG_ORDER_HASHES.has(q.orderHash?.toLowerCase?.() ?? '')
+	);
+	console.log('[orders-debug] processed quotes for debug hashes', {
+		count: debugProcessed.length,
+		entries: debugProcessed.map((q) => ({
+			orderHash: q.orderHash,
+			side: q.side,
+			inputTokenAddress: q.inputTokenAddress,
+			outputTokenAddress: q.outputTokenAddress,
+			quotePerAsset: q.quotePerAsset
+		}))
+	});
 
 	return processedQuotes;
 }

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -35,11 +35,6 @@ import {
 } from '$lib/utils/orderbook';
 import { fetchQuotesWithBatching } from '$lib/utils/quoteBatcher';
 
-const DEBUG_ORDER_HASHES = new Set([
-	'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
-	'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
-]);
-
 // Re-export types and utilities
 export type { ProcessedQuote, TokenPriceSummary };
 export { OrderV4_ABI, normalizeOrderData, scaleAmount, walkOrderbook, hexToBigInt };
@@ -68,35 +63,15 @@ function processOrdersWithQuotes(
 
 	// Process each order with its quotes
 	orders.forEach((order) => {
-		const orderHashLc = order.orderHash?.toLowerCase();
-		const isDebugOrder = !!orderHashLc && DEBUG_ORDER_HASHES.has(orderHashLc);
 		const quotes = quotesMap.get(order);
 		if (!quotes || quotes.length === 0) {
-			if (isDebugOrder) {
-				console.log('[orders-debug] no quotes from batcher for order', {
-					orderHash: order.orderHash
-				});
-			}
 			return;
-		}
-		if (isDebugOrder) {
-			console.log('[orders-debug] quotes fetched for order', {
-				orderHash: order.orderHash,
-				quoteCount: quotes.length,
-				successCount: quotes.filter((q) => q.success && !!q.data).length
-			});
 		}
 
 		try {
 			// Convert RaindexOrder to SgOrder to get orderBytes
 			const sgOrderResult = order.convertToSgOrder();
 			if (sgOrderResult.error || !sgOrderResult.value) {
-				if (isDebugOrder) {
-					console.log('[orders-debug] convertToSgOrder failed', {
-						orderHash: order.orderHash,
-						error: sgOrderResult.error?.readableMsg
-					});
-				}
 				return;
 			}
 			const sgOrder = sgOrderResult.value;
@@ -111,14 +86,6 @@ function processOrdersWithQuotes(
 				try {
 					// Skip if the quote failed
 					if (!quote.success || !quote.data) {
-						if (isDebugOrder) {
-							console.log('[orders-debug] skipping failed/empty quote', {
-								orderHash: order.orderHash,
-								success: quote.success,
-								hasData: !!quote.data,
-								error: quote.error
-							});
-						}
 						return;
 					}
 
@@ -133,26 +100,12 @@ function processOrdersWithQuotes(
 						!maxOutput.startsWith('0x') ||
 						maxOutput.length !== 66
 					) {
-						if (isDebugOrder) {
-							console.log('[orders-debug] invalid ratio/maxOutput format', {
-								orderHash: order.orderHash,
-								ratio,
-								maxOutput
-							});
-						}
 						return;
 					}
 
 					// Verify maxOutput is not zero by converting to Float and checking
 					const maxOutputFloat = Float.fromHex(maxOutput as `0x${string}`);
 					if (maxOutputFloat.error || !maxOutputFloat.value) {
-						if (isDebugOrder) {
-							console.log('[orders-debug] maxOutput Float.fromHex failed', {
-								orderHash: order.orderHash,
-								maxOutput,
-								error: maxOutputFloat.error?.readableMsg
-							});
-						}
 						return;
 					}
 					// Check if maxOutput is zero
@@ -162,26 +115,12 @@ function processOrdersWithQuotes(
 					if (!zeroFloat.error && zeroFloat.value) {
 						const isZero = maxOutputFloat.value.eq(zeroFloat.value);
 						if (!isZero.error && isZero.value) {
-							if (isDebugOrder) {
-								console.log('[orders-debug] maxOutput is zero, skipping', {
-									orderHash: order.orderHash
-								});
-							}
 							return;
 						}
 					}
 					const inputDefinition = orderData.validInputs[quote.pair.inputIndex];
 					const outputDefinition = orderData.validOutputs[quote.pair.outputIndex];
 					if (!inputDefinition || !outputDefinition) {
-						if (isDebugOrder) {
-							console.log('[orders-debug] missing IO definition', {
-								orderHash: order.orderHash,
-								inputIndex: quote.pair.inputIndex,
-								outputIndex: quote.pair.outputIndex,
-								validInputsLen: orderData.validInputs.length,
-								validOutputsLen: orderData.validOutputs.length
-							});
-						}
 						return;
 					}
 
@@ -194,14 +133,6 @@ function processOrdersWithQuotes(
 					const normalizedOutput = normalizeAddress(outputTokenAddress);
 					const normalizedQuote = normalizeAddress(quoteToken.address);
 					if (normalizedInput !== normalizedQuote && normalizedOutput !== normalizedQuote) {
-						if (isDebugOrder) {
-							console.log('[orders-debug] dropped by quote-token filter', {
-								orderHash: order.orderHash,
-								inputTokenAddress,
-								outputTokenAddress,
-								quoteToken: quoteToken.address
-							});
-						}
 						return;
 					}
 					const allTokens = [quoteToken, ...stockTokens];
@@ -266,23 +197,6 @@ function processOrdersWithQuotes(
 						const normalizedAsset = normalizeAddress(metrics.assetAddress);
 						processedQuote.assetAddress = normalizedAsset ?? metrics.assetAddress;
 						processedQuote.quotePerAsset = metrics.quotePerAsset;
-						if (isDebugOrder) {
-							console.log('[orders-debug] processed quote side/price', {
-								orderHash: order.orderHash,
-								side: processedQuote.side,
-								assetAddress: processedQuote.assetAddress,
-								quotePerAsset: processedQuote.quotePerAsset,
-								inputTokenAddress,
-								outputTokenAddress
-							});
-						}
-					} else if (isDebugOrder) {
-						console.log('[orders-debug] describeQuote returned null', {
-							orderHash: order.orderHash,
-							inputTokenAddress,
-							outputTokenAddress,
-							quoteToken: quoteToken.address
-						});
 					}
 
 					processedQuotes.push(processedQuote);
@@ -367,15 +281,6 @@ export async function fetchAndQuotePaymentTokenOrders(
 			}
 
 			const pageOrders = ordersResult.value.orders;
-			const debugPageOrders = pageOrders
-				.map((o) => o.orderHash?.toLowerCase())
-				.filter((h) => !!h && DEBUG_ORDER_HASHES.has(h));
-			if (debugPageOrders.length > 0) {
-				console.log('[orders-debug] fetchAndQuotePaymentTokenOrders found debug orders in page', {
-					page,
-					hashes: debugPageOrders
-				});
-			}
 			allOrders.push(...pageOrders);
 
 			// If we got fewer orders than the page size, we've reached the end
@@ -470,30 +375,9 @@ export async function fetchAndQuoteTokenOrders(
 	}
 
 	const allOrders = ordersResult.value.orders;
-	const debugOrders = allOrders
-		.map((o) => o.orderHash?.toLowerCase())
-		.filter((h) => !!h && DEBUG_ORDER_HASHES.has(h));
-	console.log('[orders-debug] fetchAndQuoteTokenOrders result', {
-		tokenAddress,
-		paymentToken: defaultPaymentToken.address,
-		totalOrders: allOrders.length,
-		debugOrderHashes: debugOrders
-	});
 
 	// Get quotes using batching with jitter and retries
 	const quotesMap = await fetchQuotesWithBatching(allOrders);
-	for (const order of allOrders) {
-		const hash = order.orderHash?.toLowerCase();
-		if (hash && DEBUG_ORDER_HASHES.has(hash)) {
-			const quotes = quotesMap.get(order) ?? [];
-			console.log('[orders-debug] batch quotes map entry', {
-				orderHash: order.orderHash,
-				quoteCount: quotes.length,
-				successCount: quotes.filter((q) => q.success && !!q.data).length,
-				errors: quotes.filter((q) => !q.success).map((q) => q.error)
-			});
-		}
-	}
 
 	// Process and filter the quotes
 	const processedQuotes = processOrdersWithQuotes(
@@ -502,19 +386,6 @@ export async function fetchAndQuoteTokenOrders(
 		defaultPaymentToken,
 		stockTokens
 	);
-	const debugProcessed = processedQuotes.filter((q) =>
-		DEBUG_ORDER_HASHES.has(q.orderHash?.toLowerCase?.() ?? '')
-	);
-	console.log('[orders-debug] processed quotes for debug hashes', {
-		count: debugProcessed.length,
-		entries: debugProcessed.map((q) => ({
-			orderHash: q.orderHash,
-			side: q.side,
-			inputTokenAddress: q.inputTokenAddress,
-			outputTokenAddress: q.outputTokenAddress,
-			quotePerAsset: q.quotePerAsset
-		}))
-	});
 
 	return processedQuotes;
 }

--- a/src/lib/clients/raindex.ts
+++ b/src/lib/clients/raindex.ts
@@ -1,5 +1,6 @@
 import { RaindexClient } from '@rainlanguage/orderbook';
 import type { Network } from '$lib/config/network';
+type RaindexClientInstance = RaindexClient;
 
 /**
  * Raindex settings YAML.
@@ -47,7 +48,7 @@ rainlangs:
 
 // Two-client pool for load balancing
 interface ClientPool {
-	clients: [RaindexClient, RaindexClient];
+	clients: [RaindexClientInstance, RaindexClientInstance];
 	currentIndex: number;
 }
 
@@ -104,7 +105,7 @@ async function getClientPool(network: Network): Promise<ClientPool> {
  * Get the next client using round-robin load balancing.
  * Each client has different primary RPCs, SDK handles failover within each.
  */
-export async function getLoadBalancedClient(network: Network): Promise<RaindexClient> {
+export async function getLoadBalancedClient(network: Network): Promise<RaindexClientInstance> {
 	const pool = await getClientPool(network);
 	const client = pool.clients[pool.currentIndex];
 	pool.currentIndex = (pool.currentIndex + 1) % 2;
@@ -114,7 +115,7 @@ export async function getLoadBalancedClient(network: Network): Promise<RaindexCl
 /**
  * Create a RaindexClient from the hardcoded settings YAML.
  */
-export async function createRaindexClient(): Promise<RaindexClient> {
+export async function createRaindexClient(): Promise<RaindexClientInstance> {
 	const clientResult = await RaindexClient.new([SETTINGS_YAML]);
 	if (clientResult.error) {
 		throw new Error(`Failed to create RaindexClient: ${clientResult.error.readableMsg}`);

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -166,22 +166,22 @@ export const TOKENS: CategorizedToken[] = [
 		limitOrders: []
 	},
 	// wtSTOX token temporarily disabled
-	{
-		chainId: base.id,
-		address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
-		unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
-		legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
-		// legacySymbol: 'tSTOX',
-		symbol: 'wtSTOX',
-		decimals: 18,
-		name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-		logoUrl: '/images/SPLG.png',
-		priceFeedId: '0x54e2e127c93950de5a710100fd1cd387aba1ec8920850efdb05da5fee57d2e32',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SPLG',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
+	// {
+	// 	chainId: base.id,
+	// 	address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
+	// 	unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
+	// 	legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
+	// 	// legacySymbol: 'tSTOX',
+	// 	symbol: 'wtSTOX',
+	// 	decimals: 18,
+	// 	name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
+	// 	logoUrl: '/images/SPLG.png',
+	// 	priceFeedId: '0x54e2e127c93950de5a710100fd1cd387aba1ec8920850efdb05da5fee57d2e32',
+	// 	category: 'ST0x',
+	// 	tradingViewSymbol: 'AMEX:SPLG',
+	// 	tradingViewMarket: 'america',
+	// 	limitOrders: []
+	// },
 	{
 		chainId: base.id,
 		address: '0xEB7F3E4093C9d68253b6104FbbfF561F3eC0442F',

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -166,22 +166,22 @@ export const TOKENS: CategorizedToken[] = [
 		limitOrders: []
 	},
 	// wtSTOX token temporarily disabled
-	// {
-	// 	chainId: base.id,
-	// 	address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
-	// 	unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
-	// 	legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
-	// 	// legacySymbol: 'tSTOX',
-	// 	symbol: 'wtSTOX',
-	// 	decimals: 18,
-	// 	name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-	// 	logoUrl: '/images/SPLG.png',
-	// 	priceFeedId: '0x4dfbf28d72ab41a878afcd4c6d5e9593dca7cf65a0da739cbad9b7414004f82d',
-	// 	category: 'ST0x',
-	// 	tradingViewSymbol: 'AMEX:SPLG',
-	// 	tradingViewMarket: 'america',
-	// 	limitOrders: []
-	// },
+	{
+		chainId: base.id,
+		address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
+		unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
+		legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
+		// legacySymbol: 'tSTOX',
+		symbol: 'wtSTOX',
+		decimals: 18,
+		name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
+		logoUrl: '/images/SPLG.png',
+		priceFeedId: '0x54e2e127c93950de5a710100fd1cd387aba1ec8920850efdb05da5fee57d2e32',
+		category: 'ST0x',
+		tradingViewSymbol: 'AMEX:SPLG',
+		tradingViewMarket: 'america',
+		limitOrders: []
+	},
 	{
 		chainId: base.id,
 		address: '0xEB7F3E4093C9d68253b6104FbbfF561F3eC0442F',

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -310,62 +310,32 @@ export function filterQuotesForSide(
 ): ProcessedQuote[] {
 	const normalizedAsset = assetAddress.toLowerCase();
 	const normalizedPayment = paymentAddress.toLowerCase();
-	const debugHashes = new Set([
-		'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
-		'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
-	]);
 
 	return quotes.filter((quote) => {
 		const inputAddr = quote.inputTokenAddress?.toLowerCase();
 		const outputAddr = quote.outputTokenAddress?.toLowerCase();
 		const price = quote.quotePerAsset;
-		const orderHashLc = quote.orderHash?.toLowerCase();
-		const isDebug = !!orderHashLc && debugHashes.has(orderHashLc);
-		if (isDebug) {
-			console.log('[orders-debug] filterQuotesForSide incoming', {
-				orderHash: quote.orderHash,
-				orderSide,
-				inputAddr,
-				outputAddr,
-				normalizedAsset,
-				normalizedPayment,
-				side: quote.side,
-				price
-			});
-		}
 
 		if (orderSide === 'Buy') {
 			// For Buy: we need ASK orders (seller offering asset for payment)
-			const include =
+			return (
 				inputAddr === normalizedPayment &&
 				outputAddr === normalizedAsset &&
 				quote.side === 'ask' &&
 				price !== undefined &&
 				Number.isFinite(price) &&
-				price > 0;
-			if (isDebug) {
-				console.log('[orders-debug] filterQuotesForSide buy decision', {
-					orderHash: quote.orderHash,
-					include
-				});
-			}
-			return include;
+				price > 0
+			);
 		} else {
 			// For Sell: we need BID orders (buyer offering payment for asset)
-			const include =
+			return (
 				inputAddr === normalizedAsset &&
 				outputAddr === normalizedPayment &&
 				quote.side === 'bid' &&
 				price !== undefined &&
 				Number.isFinite(price) &&
-				price > 0;
-			if (isDebug) {
-				console.log('[orders-debug] filterQuotesForSide sell decision', {
-					orderHash: quote.orderHash,
-					include
-				});
-			}
-			return include;
+				price > 0
+			);
 		}
 	});
 }

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -220,458 +220,76 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		// (often the best-priced, thin order) aborts the whole flow even when a later order could cover
 		// the remainder — hence aggressive quote freshness + conservative per-leg fill (haircut).
 		const takerAddress = getSignerAddress();
-		if (takerAddress) {
-			const userLc = takerAddress.toLowerCase();
-			const touchesOwnOrder = walkResult.fills.some((f) => {
-				const od = (f.quote as ProcessedQuote).orderData;
-				return od?.owner && od.owner.toLowerCase() === userLc;
-			});
-			if (!touchesOwnOrder) {
-				const firstQuote = walkResult.fills[0].quote as ProcessedQuote;
-				if (firstQuote.orderData && firstQuote.sgOrder) {
-					let mode: TakeOrdersMode;
-					let amountDecimals: number;
-					if (orderSide === 'Sell') {
-						mode = 'spendExact';
-						amountDecimals = assetToken.decimals;
-					} else if (inputMode === 'spend') {
-						mode = 'spendExact';
-						amountDecimals = paymentToken.decimals;
-					} else {
-						mode = 'buyExact';
-						amountDecimals = assetToken.decimals;
-					}
-					const takeRequest: TakeOrdersRequest = {
-						taker: takerAddress,
-						chainId: network.id,
-						sellToken: orderSide === 'Buy' ? paymentToken.address : assetToken.address,
-						buyToken: orderSide === 'Buy' ? assetToken.address : paymentToken.address,
-						mode,
-						amount: formatUnits(amount, amountDecimals),
-						priceCap: priceCapStrForSdk
-					};
-					const { inputAmountFilled } = walkResult;
-					const toTokenInfo = ({ address, decimals, symbol }: TokenInfo): TokenInfo => ({
-						address,
-						decimals,
-						symbol
-					});
-					const aggregatedParams: TakeOrdersParams = {
-						orderData: firstQuote.orderData as OrderV4,
-						ioIndexes: { input: firstQuote.inputIOIndex ?? 0, output: firstQuote.outputIOIndex ?? 0 },
-						takerWantsToken: toTokenInfo(isBuy ? assetToken : paymentToken),
-						takerPaysToken: toTokenInfo(isBuy ? paymentToken : assetToken),
-						requestedTakerWantsAmount: isBuy && inputMode !== 'spend' ? amount : inputAmountFilled,
-						simulation: walkResult
-					};
-					const aggregatedHandled = await transactionStore.handleAggregatedTakeOrdersCalldata(
-						takeRequest,
-						firstQuote.sgOrder as SgOrder,
-						aggregatedParams,
-						isBuy ? paymentToken.symbol : assetToken.symbol
-					);
-					// Handler returns true for any "handled" outcome (success or user-visible error); false = fall back to legacy path.
-					if (aggregatedHandled) {
-						const { status, error: txError } = get(transactionStore);
-						if (status === TransactionStatus.SUCCESS) {
-							return { success: true };
-						}
-						if (status === TransactionStatus.ERROR) {
-							return {
-								success: false,
-								error: txError || 'Order failed'
-							};
-						}
-						return {
-							success: false,
-							error: 'Order did not complete. Please try again.'
-						};
-					}
-				}
-			}
+		if (!takerAddress) {
+			return { success: false, error: 'Wallet not connected. Please reconnect and try again.' };
 		}
-
-		const orderInfos = Array.from(orderInfoMap.values());
-
-		await Promise.all(
-			orderInfos.map(async (orderInfo) => {
-				if (orderInfo.raindexOrder) {
-					// We already have the RaindexOrder object from quote processing.
-					return;
-				}
-				try {
-					const ordersResult = await client.getOrders(
-						[network.id],
-						{
-							owners: [],
-							orderHash: orderInfo.order.orderHash as `0x${string}`
-						},
-						1
-					);
-
-					if (ordersResult.error || !ordersResult.value?.orders.length) {
-						console.warn('[marketOrderExecution] Failed to hydrate RaindexOrder by hash', {
-							orderHash: orderInfo.order.orderHash,
-							error: ordersResult.error?.readableMsg
-						});
-						return;
-					}
-
-					const raindexOrderObj = ordersResult.value.orders[0];
-					// Always keep the RaindexOrder object so we can use getTakeCalldata(),
-					// which populates signedContext internally for oracle-enabled orders.
-					orderInfo.raindexOrder = raindexOrderObj;
-
-					// If we already have hydrated order data from quotes, no need to decode again.
-					if (orderInfo.orderData?.owner) {
-						return;
-					}
-
-					const quotesResult = await raindexOrderObj.getQuotes();
-					if (quotesResult.error || !quotesResult.value?.length) return;
-
-					const validQuotes = quotesResult.value.filter(
-						(q: RaindexOrderQuote) => q.success && q.data
-					);
-					if (validQuotes.length === 0) return;
-
-					const sgOrderResult = raindexOrderObj.convertToSgOrder();
-					if (sgOrderResult.error || !sgOrderResult.value) return;
-
-					const sgOrder = sgOrderResult.value;
-					const decodedOrder = AbiCoder.defaultAbiCoder().decode([OrderV4_ABI], sgOrder.orderBytes);
-					const orderData = normalizeOrderData(decodedOrder[0] as OrderV4);
-
-					orderInfo.order = sgOrder;
-					orderInfo.orderData = orderData;
-					orderInfo.quotes = validQuotes;
-				} catch (orderError) {
-					console.error('Error hydrating order', orderInfo.order.orderHash, orderError);
-				}
-			})
-		);
-
-		// 4. Filter to only executable orders (exclude user's own orders)
-		const userAddress = getSignerAddress()?.toLowerCase();
-		const executableOrders = orderInfos.filter((info) => {
-			if (!info.orderData?.owner) return false;
-			// Cannot take your own order - contract will reject it
-			if (userAddress && info.orderData.owner.toLowerCase() === userAddress) {
-				console.log('[marketOrderExecution] Excluding own order:', info.order.orderHash);
-				return false;
-			}
-			return true;
-		});
-		if (executableOrders.length === 0) {
-			return { success: false, error: 'Orders temporarily unavailable. Please try again.' };
+		const firstQuote = walkResult.fills[0].quote as ProcessedQuote;
+		if (!firstQuote.orderData || !firstQuote.sgOrder) {
+			return { success: false, error: 'Unable to prepare aggregated order route. Please refresh and retry.' };
 		}
-
-		// Determine if we can use an exact output cap (IOIsInput=false) instead of
-		// estimating the receive amount. This applies when the user specifies exactly
-		// how much they want to spend: Buy+spend (USD budget) or Sell (asset amount).
-		const useOutputCap = orderSide === 'Sell' || inputMode === 'spend';
-
-		// 5. Compute per-order fill amounts from walkResult
-		// Output-cap (IOIsInput=false): amounts are what taker pays per order
-		// Input-cap (IOIsInput=true): amounts are what taker receives per order
-		const fillAmountsByOrderHash = new Map<string, bigint>();
-		for (const fill of walkResult.fills) {
-			const orderHash = fill.quote.orderHash?.toLowerCase() ?? '';
-			if (!orderHash) continue;
-			const wantAsset = useOutputCap ? !isBuy : isBuy;
-			let fillAmount = wantAsset ? fill.assetAmount : fill.paymentAmount;
-			if (isBuy && wantAsset) {
-				fillAmount = haircutBuyExecutionFill(fillAmount);
-			}
-			const current = fillAmountsByOrderHash.get(orderHash) ?? 0n;
-			fillAmountsByOrderHash.set(orderHash, current + fillAmount);
-		}
-
-		// 6. Build TakeOrderConfigs with parallel fill amounts array
-		const takeOrderConfigs: TakeOrderConfigV4[] = [];
-		const orderFillAmounts: bigint[] = [];
-		const takeOrderRaindexOrders: RaindexOrder[] = [];
-		for (const orderInfo of executableOrders) {
-			if (!orderInfo.orderData?.validInputs?.length || !orderInfo.orderData?.validOutputs?.length) {
-				continue;
-			}
-			if (!orderInfo.raindexOrder) {
-				continue;
-			}
-
-			const inputIndex = orderInfo.inputIOIndex;
-			const outputIndex = orderInfo.outputIOIndex;
-			const hasInput = orderInfo.orderData.validInputs[inputIndex];
-			const hasOutput = orderInfo.orderData.validOutputs[outputIndex];
-
-			if (!hasInput || !hasOutput) {
-				continue;
-			}
-
-			const matchingFill = walkResult.fills.find(
-				(f) =>
-					(f.quote.orderHash?.toLowerCase() ?? '') ===
-						(orderInfo.order.orderHash?.toLowerCase() ?? '') &&
-					(f.quote.inputIOIndex ?? 0) === inputIndex &&
-					(f.quote.outputIOIndex ?? 0) === outputIndex
-			);
-			const signedContext =
-				(
-					matchingFill?.quote as ProcessedQuote & {
-						signedContext?: TakeOrderConfigV4['signedContext'];
-					}
-				)?.signedContext ?? [];
-
-			takeOrderConfigs.push({
-				order: orderInfo.orderData,
-				inputIOIndex: inputIndex.toString(),
-				outputIOIndex: outputIndex.toString(),
-				signedContext
-			});
-			takeOrderRaindexOrders.push(orderInfo.raindexOrder);
-
-			// Add fill amount for this order (parallel to takeOrderConfigs)
-			const orderHash = orderInfo.order.orderHash?.toLowerCase() ?? '';
-			orderFillAmounts.push(fillAmountsByOrderHash.get(orderHash) ?? 0n);
-		}
-
-		if (takeOrderConfigs.length === 0) {
-			return { success: false, error: 'Unable to prepare order. Please try again.' };
-		}
-
-		const primaryOrder = executableOrders[0];
-
-		// 7. Calculate approval amount
-		const { inputAmountFilled, outputAmountGiven, inputDecimals, outputDecimals } = walkResult;
-
-		let requiredApprovalAmount: bigint;
-		if (isBuy && inputMode !== 'spend') {
-			// Buy+amount: buffer since we accept paying more for target quantity
-			const approvalBuffer = outputAmountGiven / 20n; // 5%
-			let total = outputAmountGiven + (approvalBuffer > 0n ? approvalBuffer : 1n);
-			// Multiple separate takes: leg 1 actual spend can exceed the walk estimate for that leg;
-			// add a little extra so leg 2 is not blocked by allowance.
-			if (executableOrders.length > 1) {
-				const multiLegExtra = outputAmountGiven / 50n; // +2%
-				total += multiLegExtra > 0n ? multiLegExtra : 1n;
-			}
-			requiredApprovalAmount = total;
+		let mode: TakeOrdersMode;
+		let amountDecimals: number;
+		if (orderSide === 'Sell') {
+			mode = 'spendExact';
+			amountDecimals = assetToken.decimals;
+		} else if (inputMode === 'spend') {
+			mode = 'spendExact';
+			amountDecimals = paymentToken.decimals;
 		} else {
-			// Buy+spend or Sell: exact spend amount, no padding needed
-			requiredApprovalAmount = amount;
+			mode = 'buyExact';
+			amountDecimals = assetToken.decimals;
 		}
-
-		// 8. `priceCapStrForSdk` / emergency ratio hex: from worst fill (see above). `maximumIORatioHex`
-		// uses Float.maxPositiveValue() so the contract does not reject valid ratios (PR #150).
-
-		// 9a. Use getTakeCalldata() only when signed context is not already present on fills.
-		// If signed context exists, prefer the regular takeOrders path with explicit signedContext
-		// to avoid "not ready" oracle-calldata skips.
-		const ordersWithCalldata = executableOrders.filter((o) => o.raindexOrder);
-		const hasSignedContextOnFills = walkResult.fills.some((fill) => {
-			const quoteWithContext = fill.quote as ProcessedQuote & { signedContext?: unknown[] };
-			return (quoteWithContext.signedContext?.length ?? 0) > 0;
-		});
-		console.log('[marketOrderExecution] path decision', {
-			orderSide,
-			inputMode,
-			totalExecutableOrders: executableOrders.length,
-			ordersWithCalldata: ordersWithCalldata.length,
-			hasSignedContextOnFills,
-			fillCount: walkResult.fills.length
-		});
-		if (ordersWithCalldata.length > 0 && !hasSignedContextOnFills) {
-			const mode: TakeOrdersMode =
-				orderSide === 'Sell'
-					? 'spendExact'
-					: inputMode === 'spend'
-						? 'spendExact'
-						: 'buyExact';
-
-			// Amount decimals: what the taker specifies (asset for buy/sell, payment for buy+spend)
-			const amountDecimals =
-				orderSide === 'Buy' && inputMode === 'spend'
-					? paymentToken.decimals
-					: assetToken.decimals;
-
-			if (!takerAddress) {
-				return { success: false, error: 'Wallet not connected. Please reconnect and try again.' };
-			}
-
-			const oracleInputs = ordersWithCalldata
-				.filter((o) => o.raindexOrder)
-				.map((orderInfo) => {
-					const fillAmount =
-						fillAmountsByOrderHash.get(orderInfo.order.orderHash?.toLowerCase() ?? '') ?? 0n;
-					const amountStr = String(
-						Float.fromFixedDecimalLossy(fillAmount, amountDecimals).float.format().value ?? '0'
-					);
-					console.log('[marketOrderExecution] oracle input', {
-						orderHash: orderInfo.order.orderHash,
-						inputIndex: orderInfo.inputIOIndex,
-						outputIndex: orderInfo.outputIOIndex,
-						fillAmount: fillAmount.toString(),
-						amountStr,
-						priceCapStr: priceCapStrForSdk
-					});
-					return {
-						raindexOrder: orderInfo.raindexOrder!,
-						inputIndex: orderInfo.inputIOIndex,
-						outputIndex: orderInfo.outputIOIndex,
-						fillAmount,
-						amountStr,
-						priceCapStr: priceCapStrForSdk,
-						taker: takerAddress
-					};
-				})
-				.filter((input) => input.fillAmount > 0n)
-				.map(({ fillAmount: _fillAmount, ...input }) => input);
-
-			if (oracleInputs.length === 0) {
-				return {
-					success: false,
-					error: 'No executable quote amount found for selected order(s). Please refresh and try again.'
-				};
-			}
-
-			// 10–13 (oracle variant) - use params built from the same walkResult
-			const toTokenInfo = ({ address, decimals, symbol }: TokenInfo): TokenInfo => ({
-				address,
-				decimals,
-				symbol
-			});
-			const takerWantsInfo = toTokenInfo(isBuy ? assetToken : paymentToken);
-			const takerPaysInfo = toTokenInfo(isBuy ? paymentToken : assetToken);
-			const requestedTakerWantsAmount =
-				isBuy && inputMode !== 'spend' ? amount : inputAmountFilled;
-
-			const oracleParams: TakeOrdersParams = {
-				orderData: primaryOrder.orderData,
-				ioIndexes: { input: primaryOrder.inputIOIndex, output: primaryOrder.outputIOIndex },
-				takerWantsToken: takerWantsInfo,
-				takerPaysToken: takerPaysInfo,
-				requestedTakerWantsAmount,
-				simulation: walkResult,
-				orderFillAmounts,
-				orderFillDecimals: useOutputCap ? outputDecimals : inputDecimals,
-				requiredPayerAllowance: requiredApprovalAmount
-			};
-
-			console.log('[marketOrderExecution] executing oracle calldata path', {
-				oracleInputCount: oracleInputs.length,
-				mode
-			});
-			await transactionStore.handleOracleOrders(
-				oracleInputs,
-				mode,
-				primaryOrder.order,
-				takerPaysInfo.symbol,
-				oracleParams
-			);
-			return { success: true };
-		}
-		console.log('[marketOrderExecution] executing takeOrders fallback path', {
-			orderCount: takeOrderConfigs.length,
-			raindexOrderCount: takeOrderRaindexOrders.length,
-			signedContextLengths: JSON.stringify(
-				takeOrderConfigs.map((o) => o.signedContext?.length ?? 0)
-			),
-			requiredApprovalAmount: requiredApprovalAmount.toString()
-		});
-
-		// 9. Build TakeOrdersConfig
-		// Output-cap: maximumIO is exact spend amount (IOIsInput=false)
-		// Input-cap: maximumIO is exact receive amount (IOIsInput=true)
-		const maximumIOAmount = useOutputCap ? amount : inputAmountFilled;
-		const maximumIODecimals = useOutputCap ? outputDecimals : inputDecimals;
-		const maximumIOFloat = Float.fromFixedDecimalLossy(maximumIOAmount, maximumIODecimals);
-
-		const takeOrdersConfig: TakeOrdersConfigV5 = {
-			minimumIO: MINIMUM_IO,
-			maximumIO: maximumIOFloat.float.asHex(),
-			maximumIORatio: maximumIORatioHex,
-			IOIsInput: !useOutputCap as unknown as string,
-			orders: takeOrderConfigs,
-			data: '0x'
+		const takeRequest: TakeOrdersRequest = {
+			taker: takerAddress,
+			chainId: network.id,
+			sellToken: orderSide === 'Buy' ? paymentToken.address : assetToken.address,
+			buyToken: orderSide === 'Buy' ? assetToken.address : paymentToken.address,
+			mode,
+			amount: formatUnits(amount, amountDecimals),
+			priceCap: priceCapStrForSdk
 		};
-
-		// 10. Determine taker perspective tokens
+		// Opportunistically prefetch aggregated calldata while we build final params.
+		void transactionStore.preloadAggregatedTakeOrdersCalldata(takeRequest);
+		const { inputAmountFilled } = walkResult;
 		const toTokenInfo = ({ address, decimals, symbol }: TokenInfo): TokenInfo => ({
 			address,
 			decimals,
 			symbol
 		});
-		const takerWantsInfo = toTokenInfo(isBuy ? assetToken : paymentToken);
-		const takerPaysInfo = toTokenInfo(isBuy ? paymentToken : assetToken);
-
-		// 11. Calculate requested amount
-		// Buy+amount: user specified exact asset quantity
-		// Buy+spend or Sell: estimated receive from orderbook walk
-		const requestedTakerWantsAmount = isBuy && inputMode !== 'spend' ? amount : inputAmountFilled;
-
-		// 12. Build recalculate callback if needed
-		// Output-cap mode recalculates maximumIO after approval wait; ratio cap stays max-IO (PR #150).
-		const recalculateConfig =
-			useOutputCap && refreshQuotes
-				? async (): Promise<TakeOrdersConfigV5 | null> => {
-						try {
-							const freshQuotes = await refreshQuotes();
-
-							const freshWalkResult = walkOrderbook({
-								quotes: sortQuotesByPrice(freshQuotes, orderSide),
-								orderSide,
-								selectedAmount: amount,
-								assetDecimals: assetToken.decimals,
-								paymentDecimals: paymentToken.decimals,
-								mode: inputMode === 'spend' ? 'spend' : 'receive'
-							});
-
-							if (!freshWalkResult || freshWalkResult.inputAmountFilled === 0n) {
-								return null;
-							}
-
-							const freshMaximumIO = Float.fromFixedDecimalLossy(
-								amount,
-								freshWalkResult.outputDecimals
-							);
-
-							return {
-								minimumIO: MINIMUM_IO,
-								maximumIO: freshMaximumIO.float.asHex(),
-								maximumIORatio: getMaximumIORatioHex(emergencyRatioHex),
-								IOIsInput: false as unknown as string,
-								orders: takeOrderConfigs,
-								data: '0x'
-							};
-						} catch {
-							return null;
-						}
-					}
-				: undefined;
-
-		// 13. Execute transaction
-		const params: TakeOrdersParams = {
-			orderData: primaryOrder.orderData,
-			ioIndexes: { input: primaryOrder.inputIOIndex, output: primaryOrder.outputIOIndex },
-			takerWantsToken: takerWantsInfo,
-			takerPaysToken: takerPaysInfo,
-			requestedTakerWantsAmount,
-			simulation: walkResult,
-			orderFillAmounts,
-			orderFillDecimals: useOutputCap ? outputDecimals : inputDecimals,
-			requiredPayerAllowance: requiredApprovalAmount
+		const aggregatedParams: TakeOrdersParams = {
+			orderData: firstQuote.orderData as OrderV4,
+			ioIndexes: { input: firstQuote.inputIOIndex ?? 0, output: firstQuote.outputIOIndex ?? 0 },
+			takerWantsToken: toTokenInfo(isBuy ? assetToken : paymentToken),
+			takerPaysToken: toTokenInfo(isBuy ? paymentToken : assetToken),
+			requestedTakerWantsAmount: isBuy && inputMode !== 'spend' ? amount : inputAmountFilled,
+			simulation: walkResult
 		};
-
-		await transactionStore.handleTakeOrders(
-			takeOrdersConfig,
-			primaryOrder.order,
-			requiredApprovalAmount,
-			params,
-			recalculateConfig,
-			takeOrderRaindexOrders
+		const aggregatedHandled = await transactionStore.handleAggregatedTakeOrdersCalldata(
+			takeRequest,
+			firstQuote.sgOrder as SgOrder,
+			aggregatedParams,
+			isBuy ? paymentToken.symbol : assetToken.symbol
 		);
-
-		return { success: true };
+		if (!aggregatedHandled) {
+			return {
+				success: false,
+				error: 'Unable to prepare aggregated order transaction. Please refresh quotes and retry.'
+			};
+		}
+		const { status, error: txError } = get(transactionStore);
+		if (status === TransactionStatus.SUCCESS) {
+			return { success: true };
+		}
+		if (status === TransactionStatus.ERROR) {
+			return {
+				success: false,
+				error: txError || 'Order failed'
+			};
+		}
+		return {
+			success: false,
+			error: 'Order did not complete. Please try again.'
+		};
 	} catch (error) {
 		console.error('Market order execution error:', error);
 		return {
@@ -692,32 +310,62 @@ export function filterQuotesForSide(
 ): ProcessedQuote[] {
 	const normalizedAsset = assetAddress.toLowerCase();
 	const normalizedPayment = paymentAddress.toLowerCase();
+	const debugHashes = new Set([
+		'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
+		'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
+	]);
 
 	return quotes.filter((quote) => {
 		const inputAddr = quote.inputTokenAddress?.toLowerCase();
 		const outputAddr = quote.outputTokenAddress?.toLowerCase();
 		const price = quote.quotePerAsset;
+		const orderHashLc = quote.orderHash?.toLowerCase();
+		const isDebug = !!orderHashLc && debugHashes.has(orderHashLc);
+		if (isDebug) {
+			console.log('[orders-debug] filterQuotesForSide incoming', {
+				orderHash: quote.orderHash,
+				orderSide,
+				inputAddr,
+				outputAddr,
+				normalizedAsset,
+				normalizedPayment,
+				side: quote.side,
+				price
+			});
+		}
 
 		if (orderSide === 'Buy') {
 			// For Buy: we need ASK orders (seller offering asset for payment)
-			return (
+			const include =
 				inputAddr === normalizedPayment &&
 				outputAddr === normalizedAsset &&
 				quote.side === 'ask' &&
 				price !== undefined &&
 				Number.isFinite(price) &&
-				price > 0
-			);
+				price > 0;
+			if (isDebug) {
+				console.log('[orders-debug] filterQuotesForSide buy decision', {
+					orderHash: quote.orderHash,
+					include
+				});
+			}
+			return include;
 		} else {
 			// For Sell: we need BID orders (buyer offering payment for asset)
-			return (
+			const include =
 				inputAddr === normalizedAsset &&
 				outputAddr === normalizedPayment &&
 				quote.side === 'bid' &&
 				price !== undefined &&
 				Number.isFinite(price) &&
-				price > 0
-			);
+				price > 0;
+			if (isDebug) {
+				console.log('[orders-debug] filterQuotesForSide sell decision', {
+					orderHash: quote.orderHash,
+					include
+				});
+			}
+			return include;
 		}
 	});
 }

--- a/src/lib/services/orderDeployment.ts
+++ b/src/lib/services/orderDeployment.ts
@@ -17,8 +17,33 @@ import type { Network } from '$lib/config/network';
 import type { Hex } from 'viem';
 import { formatUnits } from 'viem';
 import { getPeriodInSeconds } from '$lib/utils/derivations';
-import { DotrainRainlang } from '@rainlanguage/orderbook';
+import * as orderbookModule from '@rainlanguage/orderbook';
 import { walletAddress } from '$lib/stores/authStore';
+const DotrainRegistry =
+	(orderbookModule as { DotrainRegistry?: unknown }).DotrainRegistry ??
+	(
+		orderbookModule as unknown as {
+			default?: { DotrainRegistry?: unknown };
+		}
+	).default?.DotrainRegistry;
+if (!DotrainRegistry) {
+	throw new Error('DotrainRegistry not available from @rainlanguage/orderbook');
+}
+type DotrainRegistryInstance = {
+	getGui: (orderKey: string, deploymentKey: string) => Promise<{
+		error?: { readableMsg: string };
+		value: {
+			setSelectToken: (key: string, address: string) => Promise<unknown>;
+			setFieldValue: (key: string, value: string) => unknown;
+			setDeposit: (key: string, value: string) => unknown;
+			setVaultId: (type: 'input' | 'output', key: string, vaultId: Hex) => unknown;
+			getComposedRainlang: () => Promise<{ error?: { readableMsg: string }; value: string }>;
+			getDeploymentTransactionArgs: (
+				owner: string
+			) => Promise<{ error?: { readableMsg: string }; value: unknown }>;
+		};
+	}>;
+};
 
 /** Pinned commit for rain.strategies registry (holds strategy order definitions). */
 const RAIN_STRATEGIES_COMMIT = '9dd64902161158395d588335f0a02e3a6d52f772';
@@ -41,12 +66,12 @@ function getDeploymentKey(raindexNetworkSlug: string): string {
 }
 
 /** Cached registry instance to avoid repeated network fetches. */
-let registryPromise: Promise<DotrainRainlang> | null = null;
+let registryPromise: Promise<DotrainRegistryInstance> | null = null;
 
-async function getRegistry(): Promise<DotrainRainlang> {
+async function getRegistry(): Promise<DotrainRegistryInstance> {
 	if (!registryPromise) {
 		registryPromise = (async () => {
-			const result = await DotrainRainlang.new(REGISTRY_URL);
+			const result = await (DotrainRegistry as { new: (url: string) => Promise<any> }).new(REGISTRY_URL);
 			if (result.error) {
 				registryPromise = null;
 				throw new Error(result.error.readableMsg);

--- a/src/lib/stores/transaction.ts
+++ b/src/lib/stores/transaction.ts
@@ -16,8 +16,18 @@ import {
 } from '$lib/services/walletService';
 import { withRetry } from '$lib/utils/retry';
 
-/** After a take confirms, wait before the next leg so RPC/oracle match on-chain state (multi-tx routes). */
-const SETTLE_MS_BEFORE_NEXT_TAKE_ORDER_LEG = 2500;
+/** Retry cadence for SDK/oracle readiness checks. */
+const TAKE_ORDER_PREPARE_RETRY_MS = 400;
+/** Retry cadence for transient post-confirmation oracle/preflight failures on later legs. */
+const TAKE_ORDER_TRANSIENT_RETRY_MS = 600;
+/** Confirmations required before submitting the next market-take leg. */
+const TAKE_TX_CONFIRMATIONS = 1;
+/** TTL for cached aggregated calldata preparation results. */
+const AGGREGATED_TAKE_CACHE_TTL_MS = 10_000;
+/** Max retries for aggregated calldata readiness checks. */
+const AGGREGATED_PREPARE_MAX_RETRIES = 1;
+/** Retry delay for aggregated calldata readiness checks. */
+const AGGREGATED_PREPARE_RETRY_MS = 200;
 
 // Wrapped wagmi functions with retry logic
 const readContract: typeof wagmiReadContract = ((...args: Parameters<typeof wagmiReadContract>) =>
@@ -222,6 +232,64 @@ function buildLegRerouteMessage(args: {
 		return `Maker leg ${fromHash} is not executable now. Routing to ${toHash} at updated ratio (${fromPrice} -> ${toPrice}).`;
 	}
 	return `Maker leg ${fromHash} is not executable now. Routing remaining size to ${toHash}.`;
+}
+
+function sumBigints(values: bigint[] | undefined): bigint {
+	if (!values?.length) return 0n;
+	return values.reduce((acc, value) => acc + value, 0n);
+}
+
+function deriveTakeRequestAmountWei(
+	mode: TakeOrdersMode,
+	params: TakeOrdersParams,
+	requiredPayerAllowance?: bigint
+): bigint {
+	if (mode === 'buyExact' || mode === 'buyUpTo') {
+		return params.requestedTakerWantsAmount;
+	}
+	if (mode === 'spendExact' || mode === 'spendUpTo') {
+		const fromAllowance = requiredPayerAllowance ?? params.requiredPayerAllowance ?? 0n;
+		if (fromAllowance > 0n) return fromAllowance;
+		return sumBigints(params.orderFillAmounts);
+	}
+	return 0n;
+}
+
+function buildTakeOrdersRequest(args: {
+	mode: TakeOrdersMode;
+	params: TakeOrdersParams;
+	network: Network;
+	priceCapStr: string;
+	requiredPayerAllowance?: bigint;
+	taker: string;
+}): TakeOrdersRequest | null {
+	const { mode, params, network, priceCapStr, requiredPayerAllowance, taker } = args;
+	const amountWei = deriveTakeRequestAmountWei(mode, params, requiredPayerAllowance);
+	if (amountWei <= 0n) return null;
+	const amountDecimals =
+		mode === 'buyExact' || mode === 'buyUpTo'
+			? params.takerWantsToken.decimals
+			: params.takerPaysToken.decimals;
+	return {
+		taker,
+		chainId: network.id,
+		sellToken: params.takerPaysToken.address,
+		buyToken: params.takerWantsToken.address,
+		mode,
+		amount: formatUnits(amountWei, amountDecimals),
+		priceCap: priceCapStr
+	};
+}
+
+type AggregatedTakeCacheEntry = {
+	expiresAt: number;
+	value: Awaited<ReturnType<Awaited<ReturnType<typeof createRaindexClient>>['getTakeOrdersCalldata']>>;
+};
+
+const aggregatedTakeCalldataCache = new Map<string, AggregatedTakeCacheEntry>();
+
+function getAggregatedTakeCacheKey(takeRequest: TakeOrdersRequest): string {
+	return JSON.stringify(takeRequest);
 }
 
 // Find a vault by matching both vault ID and token address
@@ -654,7 +722,7 @@ const transactionStore = () => {
 			});
 			awaitWalletConfirmation(`Awaiting transaction confirmation...`);
 
-			await waitForTransaction(hash);
+			await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
 
 			const $signer = get(walletAddress);
 			const raindexLink = {
@@ -1368,6 +1436,35 @@ const transactionStore = () => {
 		return transactionSuccess(hash, undefined, { marketOrderSummary: summary, raindexLink });
 	};
 
+	const fetchAggregatedTakeOrdersCalldata = async (
+		takeRequest: TakeOrdersRequest,
+		options: { preferCache: boolean }
+	) => {
+		const cacheKey = getAggregatedTakeCacheKey(takeRequest);
+		const now = Date.now();
+		if (options.preferCache) {
+			const cached = aggregatedTakeCalldataCache.get(cacheKey);
+			if (cached && cached.expiresAt > now) {
+				return cached.value;
+			}
+		}
+		const client = await createRaindexClient();
+		const result = await client.getTakeOrdersCalldata(takeRequest);
+		aggregatedTakeCalldataCache.set(cacheKey, {
+			expiresAt: now + AGGREGATED_TAKE_CACHE_TTL_MS,
+			value: result
+		});
+		return result;
+	};
+
+	const preloadAggregatedTakeOrdersCalldata = async (takeRequest: TakeOrdersRequest) => {
+		try {
+			await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: false });
+		} catch {
+			// Preload is opportunistic only; execution path handles failures explicitly.
+		}
+	};
+
 	/**
 	 * Single-tx market take via RaindexClient.getTakeOrdersCalldata(): subgraph discovery +
 	 * one takeOrders4 call that can aggregate multiple maker orders (solves thin top-of-book).
@@ -1395,8 +1492,7 @@ const transactionStore = () => {
 		awaitWalletConfirmation(`Preparing order...`);
 		const TX_LOG_PREFIX = '[handleAggregatedTakeOrdersCalldata]';
 
-		const client = await createRaindexClient();
-		let calldataWrapped = await client.getTakeOrdersCalldata(takeRequest);
+		let calldataWrapped = await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: true });
 		if (calldataWrapped.error || !calldataWrapped.value) {
 			console.log(`${TX_LOG_PREFIX} skipping fallback: SDK returned no aggregated calldata`, {
 				msg: calldataWrapped.error?.readableMsg
@@ -1415,7 +1511,7 @@ const transactionStore = () => {
 			});
 			awaitApprovalTx(approvalHash);
 			await waitForTransaction(approvalHash, { confirmations: APPROVAL_TX_CONFIRMATIONS });
-			calldataWrapped = await client.getTakeOrdersCalldata(takeRequest);
+			calldataWrapped = await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: false });
 			if (calldataWrapped.error || !calldataWrapped.value) {
 				transactionError(
 					(calldataWrapped.error?.readableMsg ||
@@ -1427,9 +1523,9 @@ const transactionStore = () => {
 		}
 
 		if (!result.isReady || !result.takeOrdersInfo) {
-			for (let retry = 0; retry < 2; retry++) {
-				await new Promise((resolve) => setTimeout(resolve, 1200));
-				calldataWrapped = await client.getTakeOrdersCalldata(takeRequest);
+			for (let retry = 0; retry < AGGREGATED_PREPARE_MAX_RETRIES; retry++) {
+				await new Promise((resolve) => setTimeout(resolve, AGGREGATED_PREPARE_RETRY_MS));
+				calldataWrapped = await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: false });
 				if (!calldataWrapped.error && calldataWrapped.value?.isReady && calldataWrapped.value?.takeOrdersInfo) {
 					result = calldataWrapped.value;
 					break;
@@ -1461,7 +1557,7 @@ const transactionStore = () => {
 				data: calldata as Hex
 			});
 			awaitWalletConfirmation(`Awaiting transaction confirmation...`);
-			await waitForTransaction(hash);
+			await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
 			await pollAndFinalizeTakeOrders([hash], primaryOrder, params, network);
 			return true;
 		} catch (txError) {
@@ -1523,6 +1619,27 @@ const transactionStore = () => {
 
 		// Send one transaction per oracle order; getTakeCalldata() calls oracle server internally
 		awaitWalletConfirmation(`Preparing order...`);
+		const oraclePriceCapStr = oracleInputs[0]?.priceCapStr ?? '1';
+		const aggregatedTakeRequest = buildTakeOrdersRequest({
+			mode,
+			params,
+			network,
+			priceCapStr: oraclePriceCapStr,
+			requiredPayerAllowance: params.requiredPayerAllowance,
+			taker: $signerAddress
+		});
+		if (aggregatedTakeRequest) {
+			const handled = await handleAggregatedTakeOrdersCalldata(
+				aggregatedTakeRequest,
+				primaryOrder,
+				params,
+				approvalTokenSymbol
+			);
+			if (handled) {
+				return;
+			}
+		}
+
 		const allTransactionHashes: Hash[] = [];
 		const TX_LOG_PREFIX = '[handleOracleOrders]';
 		const expectedPriceByOrderHash = buildExpectedPriceByOrderHash(params.simulation);
@@ -1579,10 +1696,7 @@ const transactionStore = () => {
 			);
 
 			if (i > 0) {
-				await new Promise((resolve) => setTimeout(resolve, SETTLE_MS_BEFORE_NEXT_TAKE_ORDER_LEG));
-				awaitWalletConfirmation(
-					`Waiting for network to settle before preparing order ${i + 1} of ${oracleInputs.length}...`
-				);
+				awaitWalletConfirmation(`Preparing order ${i + 1} of ${oracleInputs.length}...`);
 			}
 
 			let calldataResult = await oracleInput.raindexOrder.getTakeCalldata(
@@ -1653,7 +1767,7 @@ const transactionStore = () => {
 			const notReadyRetries = i === 0 ? 2 : 4;
 			if (!calldataResult.error && (!calldataResult.value?.isReady || !calldataResult.value?.takeOrdersInfo)) {
 				for (let retry = 0; retry < notReadyRetries; retry++) {
-					await new Promise((resolve) => setTimeout(resolve, 1200));
+					await new Promise((resolve) => setTimeout(resolve, TAKE_ORDER_PREPARE_RETRY_MS));
 					calldataResult = await oracleInput.raindexOrder.getTakeCalldata(
 						oracleInput.inputIndex,
 						oracleInput.outputIndex,
@@ -1670,7 +1784,7 @@ const transactionStore = () => {
 			// Second+ legs: transient SDK/oracle errors (common right after leg 1 confirms).
 			if (calldataResult.error && i > 0) {
 				for (let retry = 0; retry < 3; retry++) {
-					await new Promise((resolve) => setTimeout(resolve, 1500));
+					await new Promise((resolve) => setTimeout(resolve, TAKE_ORDER_TRANSIENT_RETRY_MS));
 					calldataResult = await oracleInput.raindexOrder.getTakeCalldata(
 						oracleInput.inputIndex,
 						oracleInput.outputIndex,
@@ -1757,7 +1871,7 @@ const transactionStore = () => {
 				});
 
 				awaitWalletConfirmation(`Awaiting transaction confirmation${batchLabel}...`);
-				await waitForTransaction(hash);
+				await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
 				allTransactionHashes.push(hash);
 				carryForwardFillAmount = 0n;
 
@@ -1873,6 +1987,25 @@ const transactionStore = () => {
 		const mode: TakeOrdersMode = finalConfig.IOIsInput ? 'buyExact' : 'spendExact';
 		const priceCapFloat = Float.fromHex(finalConfig.maximumIORatio as `0x${string}`);
 		const priceCapStr = String(priceCapFloat.value?.format().value ?? '1');
+		const aggregatedTakeRequest = buildTakeOrdersRequest({
+			mode,
+			params,
+			network,
+			priceCapStr,
+			requiredPayerAllowance: requiredApprovalAmount,
+			taker: $signerAddress
+		});
+		if (aggregatedTakeRequest) {
+			const handled = await handleAggregatedTakeOrdersCalldata(
+				aggregatedTakeRequest,
+				raindexOrder,
+				params,
+				approvalTokenSymbol
+			);
+			if (handled) {
+				return;
+			}
+		}
 
 		const ordersToExecute = raindexOrders ?? [];
 		if (ordersToExecute.length === 0) {
@@ -1958,10 +2091,7 @@ const transactionStore = () => {
 				return transactionError('Order config mismatch' as TransactionErrorMessage);
 			}
 			if (orderIndex > 0) {
-				await new Promise((resolve) => setTimeout(resolve, SETTLE_MS_BEFORE_NEXT_TAKE_ORDER_LEG));
-				awaitWalletConfirmation(
-					`Waiting for network to settle before preparing order ${orderIndex + 1} of ${ordersToExecute.length}...`
-				);
+				awaitWalletConfirmation(`Preparing order ${orderIndex + 1} of ${ordersToExecute.length}...`);
 			}
 			const isMultiBatch = ordersToExecute.length > 1;
 			const batchLabel = isMultiBatch ? ` (${orderIndex + 1}/${ordersToExecute.length})` : '';
@@ -2051,7 +2181,7 @@ const transactionStore = () => {
 				if (readyCalldataResult.error || !readyCalldataResult.value?.takeOrdersInfo) {
 					if (orderIndex > 0) {
 						for (let retry = 0; retry < 3; retry++) {
-							await new Promise((resolve) => setTimeout(resolve, 1500));
+							await new Promise((resolve) => setTimeout(resolve, TAKE_ORDER_TRANSIENT_RETRY_MS));
 							readyCalldataResult = await orderToExecute.getTakeCalldata(
 								Number(orderConfig.inputIOIndex),
 								Number(orderConfig.outputIOIndex),
@@ -2127,7 +2257,7 @@ const transactionStore = () => {
 				});
 
 				awaitWalletConfirmation(`Awaiting transaction confirmation${batchLabel}...`, progressData);
-				await waitForTransaction(hash);
+				await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
 
 				console.log(`${TX_LOG_PREFIX} Order ${orderIndex + 1} transaction confirmed`, { hash });
 
@@ -2216,6 +2346,7 @@ const transactionStore = () => {
 		handleDsfDeploy,
 		handleFolioDeploy,
 		handleOracleOrders,
+		preloadAggregatedTakeOrdersCalldata,
 		handleAggregatedTakeOrdersCalldata,
 		handleTakeOrders,
 		handleWithdraw,

--- a/src/lib/stores/transaction.ts
+++ b/src/lib/stores/transaction.ts
@@ -17,9 +17,9 @@ import {
 import { withRetry } from '$lib/utils/retry';
 
 /** Retry cadence for SDK/oracle readiness checks. */
-const TAKE_ORDER_PREPARE_RETRY_MS = 400;
+const TAKE_ORDER_PREPARE_RETRY_MS = 100;
 /** Retry cadence for transient post-confirmation oracle/preflight failures on later legs. */
-const TAKE_ORDER_TRANSIENT_RETRY_MS = 600;
+const TAKE_ORDER_TRANSIENT_RETRY_MS = 150;
 /** Confirmations required before submitting the next market-take leg. */
 const TAKE_TX_CONFIRMATIONS = 1;
 /** TTL for cached aggregated calldata preparation results. */
@@ -27,7 +27,7 @@ const AGGREGATED_TAKE_CACHE_TTL_MS = 10_000;
 /** Max retries for aggregated calldata readiness checks. */
 const AGGREGATED_PREPARE_MAX_RETRIES = 1;
 /** Retry delay for aggregated calldata readiness checks. */
-const AGGREGATED_PREPARE_RETRY_MS = 200;
+const AGGREGATED_PREPARE_RETRY_MS = 100;
 
 // Wrapped wagmi functions with retry logic
 const readContract: typeof wagmiReadContract = ((...args: Parameters<typeof wagmiReadContract>) =>

--- a/src/lib/utils/quoteBatcher.ts
+++ b/src/lib/utils/quoteBatcher.ts
@@ -28,6 +28,11 @@ export const QUOTE_BATCH_CONFIG = {
 	quoteTimeoutMs: 8000 // Timeout for individual quote request
 };
 
+const DEBUG_ORDER_HASHES = new Set([
+	'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
+	'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
+]);
+
 /**
  * Add random jitter to a delay to prevent synchronized requests
  */
@@ -274,6 +279,11 @@ export async function fetchQuotesWithBatching(
 	// Log error types for debugging
 	if (allFailed.size > 0) {
 		const errorTypes = new Map<string, number>();
+		const failedOrders = Array.from(allFailed.entries()).map(([order, error]) => ({
+			orderHash: order.orderHash,
+			error: error?.message ?? String(error),
+			debugTracked: DEBUG_ORDER_HASHES.has(order.orderHash?.toLowerCase?.() ?? '')
+		}));
 		allFailed.forEach((error) => {
 			let errorType = 'unknown';
 			if (isRateLimitError(error)) errorType = 'rate_limit';
@@ -284,6 +294,7 @@ export async function fetchQuotesWithBatching(
 		});
 
 		console.warn('[QuoteBatcher] Error breakdown:', Object.fromEntries(errorTypes));
+		console.warn('[QuoteBatcher] Failed order details:', failedOrders);
 	}
 
 	// If rate-limited, accept whatever we got (even 0%) — throwing would discard
@@ -291,9 +302,9 @@ export async function fetchQuotesWithBatching(
 	const wasRateLimited =
 		hasRateLimitErrors || Array.from(allFailed.values()).some(isRateLimitError);
 
-	if (!wasRateLimited && successRate < 90) {
+	if (!wasRateLimited && allSuccessful.size === 0) {
 		throw new Error(
-			`Quote fetch failed: only ${successRate.toFixed(1)}% successful (${allSuccessful.size}/${
+			`Quote fetch failed: no successful quotes (${allSuccessful.size}/${
 				orders.length
 			}). ` + `Failed orders: ${allFailed.size}`
 		);

--- a/src/lib/utils/quoteBatcher.ts
+++ b/src/lib/utils/quoteBatcher.ts
@@ -28,11 +28,6 @@ export const QUOTE_BATCH_CONFIG = {
 	quoteTimeoutMs: 8000 // Timeout for individual quote request
 };
 
-const DEBUG_ORDER_HASHES = new Set([
-	'0x560f94e25b5f7023862e8ba37a928c91e675de082c1fff41ea68f6da3d9ca2e8',
-	'0x3848e87a452747f3ab43158cfa706d449326c5024c28e6ce00818438a8519e4e'
-]);
-
 /**
  * Add random jitter to a delay to prevent synchronized requests
  */
@@ -279,11 +274,6 @@ export async function fetchQuotesWithBatching(
 	// Log error types for debugging
 	if (allFailed.size > 0) {
 		const errorTypes = new Map<string, number>();
-		const failedOrders = Array.from(allFailed.entries()).map(([order, error]) => ({
-			orderHash: order.orderHash,
-			error: error?.message ?? String(error),
-			debugTracked: DEBUG_ORDER_HASHES.has(order.orderHash?.toLowerCase?.() ?? '')
-		}));
 		allFailed.forEach((error) => {
 			let errorType = 'unknown';
 			if (isRateLimitError(error)) errorType = 'rate_limit';
@@ -294,7 +284,6 @@ export async function fetchQuotesWithBatching(
 		});
 
 		console.warn('[QuoteBatcher] Error breakdown:', Object.fromEntries(errorTypes));
-		console.warn('[QuoteBatcher] Failed order details:', failedOrders);
 	}
 
 	// If rate-limited, accept whatever we got (even 0%) — throwing would discard


### PR DESCRIPTION
## Summary
- Bump `@rainlanguage/orderbook` to `0.0.1-alpha.231` and adapt app integration to the new SDK surface (`DotrainRegistry` usage in deployment flow).
- Move market take execution to aggregated calldata-first (`getTakeOrdersCalldata`) and simplify execution flow for faster order processing.
- Add latency improvements for take flow: lower retry intervals, cached aggregated calldata reuse, and 1-confirmation progression for take transactions.
- Fix quote visibility for stock/payment pairs (including `wtSTOX`/`USDC`) by broadening token filters and making quote batching tolerate partial quote failures (throw only when zero quotes succeed).
- Remove temporary debug instrumentation after validating quote pipeline behavior.

## Key Changes
- `src/lib/services/orderDeployment.ts`
  - Replace `DotrainRainlang` dependency path with `DotrainRegistry` integration compatible with SDK `alpha.231`.
- `src/lib/clients/raindex.ts`
  - Keep `RaindexClient` integration aligned with upgraded package exports.
- `src/lib/stores/transaction.ts`
  - Aggregated take calldata cache/preload support.
  - Faster retry constants for preparation/transient retries.
  - `TAKE_TX_CONFIRMATIONS` set to `1` for quicker progression.
- `src/lib/services/marketOrderExecution.ts`
  - Aggregated execution path improvements and cleanup after debugging.
- `src/lib/api/orders.ts`
  - Token filter fix to include both stock and payment tokens on both sides.
- `src/lib/utils/quoteBatcher.ts`
  - Partial-success handling improved; only fail hard when no quotes succeed.

## Why
- Restore compatibility with updated orderbook SDK.
- Reduce perceived and actual latency in order preparation and execution.
- Prevent valid stock/payment orders from being hidden due to restrictive token filters or partial quote failures.

## Test Plan
- [x] Open trade page for `wtSTOX` and verify quotes render when active orders exist.
- [x] Validate market buy flow from quote load → prepare → wallet prompt → submit with improved speed.
- [x] Validate market sell flow on same pair.
- [x] Verify aggregated take path executes successfully with single transaction where expected.
- [x] Confirm fallback/error messaging remains user-friendly when quote retrieval partially fails.
- [x] Run project lint/type checks and ensure no new errors in touched files.