### PR TITLE
update market order exec

### DIFF
--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -137,6 +137,26 @@ interface OrderInfo {
 	raindexOrder?: RaindexOrder;
 }
 
+function getQuoteMakerAddress(quote: ProcessedQuote): string | null {
+	const ownerFromOrderData = quote.orderData?.owner;
+	if (typeof ownerFromOrderData === 'string' && ownerFromOrderData.length > 0) {
+		return ownerFromOrderData;
+	}
+	const ownerFromSgOrder = (quote.sgOrder as { owner?: unknown } | undefined)?.owner;
+	if (typeof ownerFromSgOrder === 'string' && ownerFromSgOrder.length > 0) {
+		return ownerFromSgOrder;
+	}
+	return null;
+}
+
+export function excludeTakerOwnedQuotes(quotes: ProcessedQuote[], takerAddress: string): ProcessedQuote[] {
+	const normalizedTaker = takerAddress.toLowerCase();
+	return quotes.filter((quote) => {
+		const maker = getQuoteMakerAddress(quote);
+		return !maker || maker.toLowerCase() !== normalizedTaker;
+	});
+}
+
 /**
  * Execute a market order by walking the orderbook and taking available orders
  */
@@ -153,10 +173,18 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 	} = input;
 
 	try {
+		const takerAddress = getSignerAddress();
+		if (!takerAddress) {
+			return { success: false, error: 'Wallet not connected. Please reconnect and try again.' };
+		}
+		const externalQuotes = excludeTakerOwnedQuotes(quotes, takerAddress);
+		if (externalQuotes.length === 0) {
+			return { success: false, error: 'No external orders available to fill' };
+		}
 		// 1. Walk the orderbook to get fills (best-priced quotes first — required for correct splitting
 		// across multiple maker orders: e.g. take all available at the thin 0x846f… leg, then the rest
 		// from the deep 0x4bc4… leg).
-		const orderedQuotes = sortQuotesByPrice(quotes, orderSide);
+		const orderedQuotes = sortQuotesByPrice(externalQuotes, orderSide);
 		const walkResult = walkOrderbook({
 			quotes: orderedQuotes,
 			orderSide,
@@ -219,10 +247,6 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		// order (see handleTakeOrders / handleOracleOrders). A failure preparing the *first* leg
 		// (often the best-priced, thin order) aborts the whole flow even when a later order could cover
 		// the remainder — hence aggressive quote freshness + conservative per-leg fill (haircut).
-		const takerAddress = getSignerAddress();
-		if (!takerAddress) {
-			return { success: false, error: 'Wallet not connected. Please reconnect and try again.' };
-		}
 		const firstQuote = walkResult.fills[0].quote as ProcessedQuote;
 		if (!firstQuote.orderData || !firstQuote.sgOrder) {
 			return { success: false, error: 'Unable to prepare aggregated order route. Please refresh and retry.' };

--- a/src/lib/stores/transaction.ts
+++ b/src/lib/stores/transaction.ts
@@ -241,15 +241,12 @@ function sumBigints(values: bigint[] | undefined): bigint {
 
 function deriveTakeRequestAmountWei(
 	mode: TakeOrdersMode,
-	params: TakeOrdersParams,
-	requiredPayerAllowance?: bigint
+	params: TakeOrdersParams
 ): bigint {
 	if (mode === 'buyExact' || mode === 'buyUpTo') {
 		return params.requestedTakerWantsAmount;
 	}
 	if (mode === 'spendExact' || mode === 'spendUpTo') {
-		const fromAllowance = requiredPayerAllowance ?? params.requiredPayerAllowance ?? 0n;
-		if (fromAllowance > 0n) return fromAllowance;
 		return sumBigints(params.orderFillAmounts);
 	}
 	return 0n;
@@ -260,11 +257,10 @@ function buildTakeOrdersRequest(args: {
 	params: TakeOrdersParams;
 	network: Network;
 	priceCapStr: string;
-	requiredPayerAllowance?: bigint;
 	taker: string;
 }): TakeOrdersRequest | null {
-	const { mode, params, network, priceCapStr, requiredPayerAllowance, taker } = args;
-	const amountWei = deriveTakeRequestAmountWei(mode, params, requiredPayerAllowance);
+	const { mode, params, network, priceCapStr, taker } = args;
+	const amountWei = deriveTakeRequestAmountWei(mode, params);
 	if (amountWei <= 0n) return null;
 	const amountDecimals =
 		mode === 'buyExact' || mode === 'buyUpTo'
@@ -290,6 +286,16 @@ const aggregatedTakeCalldataCache = new Map<string, AggregatedTakeCacheEntry>();
 
 function getAggregatedTakeCacheKey(takeRequest: TakeOrdersRequest): string {
 	return JSON.stringify(takeRequest);
+}
+
+function shouldCacheAggregatedTakeResult(
+	result: Awaited<ReturnType<Awaited<ReturnType<typeof createRaindexClient>>['getTakeOrdersCalldata']>>
+): boolean {
+	if (!result || typeof result !== 'object') return false;
+	const maybeWrapped = result as { error?: unknown; value?: unknown };
+	if (maybeWrapped.error || !maybeWrapped.value || typeof maybeWrapped.value !== 'object') return false;
+	const value = maybeWrapped.value as { isReady?: unknown; isNeedsApproval?: unknown };
+	return typeof value.isReady === 'boolean' || typeof value.isNeedsApproval === 'boolean';
 }
 
 // Find a vault by matching both vault ID and token address
@@ -1450,10 +1456,12 @@ const transactionStore = () => {
 		}
 		const client = await createRaindexClient();
 		const result = await client.getTakeOrdersCalldata(takeRequest);
-		aggregatedTakeCalldataCache.set(cacheKey, {
-			expiresAt: now + AGGREGATED_TAKE_CACHE_TTL_MS,
-			value: result
-		});
+		if (shouldCacheAggregatedTakeResult(result)) {
+			aggregatedTakeCalldataCache.set(cacheKey, {
+				expiresAt: now + AGGREGATED_TAKE_CACHE_TTL_MS,
+				value: result
+			});
+		}
 		return result;
 	};
 
@@ -1625,7 +1633,6 @@ const transactionStore = () => {
 			params,
 			network,
 			priceCapStr: oraclePriceCapStr,
-			requiredPayerAllowance: params.requiredPayerAllowance,
 			taker: $signerAddress
 		});
 		if (aggregatedTakeRequest) {
@@ -1992,7 +1999,6 @@ const transactionStore = () => {
 			params,
 			network,
 			priceCapStr,
-			requiredPayerAllowance: requiredApprovalAmount,
 			taker: $signerAddress
 		});
 		if (aggregatedTakeRequest) {

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { ProcessedQuote } from '$lib/utils/orderbook';
+import { excludeTakerOwnedQuotes } from '$lib/services/marketOrderExecution';
+
+function quoteWithOwner(orderHash: string, owner?: string): ProcessedQuote {
+	return {
+		orderHash,
+		maxOutput: '0x0',
+		ratio: '0x0',
+		inputTokenSymbol: 'USDC',
+		outputTokenSymbol: 'wtSTOX',
+		inputTokenAddress: '0x1111111111111111111111111111111111111111',
+		outputTokenAddress: '0x2222222222222222222222222222222222222222',
+		inputIOIndex: 0,
+		outputIOIndex: 0,
+		orderData: owner
+			? ({
+					owner,
+					evaluable: {
+						interpreter: '0x3333333333333333333333333333333333333333',
+						store: '0x4444444444444444444444444444444444444444',
+						bytecode: '0x'
+					},
+					validInputs: [],
+					validOutputs: [],
+					nonce: '0x0'
+				} as unknown as ProcessedQuote['orderData'])
+			: undefined
+	};
+}
+
+describe('excludeTakerOwnedQuotes', () => {
+	it('removes quotes owned by the taker address', () => {
+		const taker = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa';
+		const quotes: ProcessedQuote[] = [
+			quoteWithOwner('0x-self', '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+			quoteWithOwner('0x-external', '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+		];
+
+		const filtered = excludeTakerOwnedQuotes(quotes, taker);
+
+		expect(filtered.map((q) => q.orderHash)).toEqual(['0x-external']);
+	});
+});


### PR DESCRIPTION
## Summary
- Harden market order execution by excluding taker-owned orders from aggregated routing, preventing self-trades before calldata preparation.
- Correct aggregated take request sizing for spend modes so request `amount` is derived from actual simulated fills (`sum(orderFillAmounts)`) instead of allowance values.
- Make aggregated calldata caching safer by caching only valid, non-error SDK responses to avoid stale/poisoned preload results.

## What Changed
- `src/lib/services/marketOrderExecution.ts`
  - Added taker-vs-maker ownership filtering before quote sorting/walk.
  - Ensures `takeRequest` / `getTakeOrdersCalldata` flow only sees external maker orders.
- `src/lib/stores/transaction.ts`
  - Updated `deriveTakeRequestAmountWei` to always use order fill sums for `spendExact` / `spendUpTo`.
  - Removed allowance-driven amount derivation from `buildTakeOrdersRequest` path.
  - Added response guard so `aggregatedTakeCalldataCache` stores only successful/valid payloads.
- `tests/lib/services/marketOrderExecution.test.ts`
  - Added unit test covering self-owned maker order exclusion for taker address.

## Why
- Prevents accidental self-matching when SDK request schema has no explicit owner exclusion field.
- Keeps `TakeOrdersRequest.amount` aligned with intended executable fill amount semantics.
- Reduces risk of preload cache poisoning causing later execution to reuse invalid calldata responses.

## Test Plan
- [ ] Run `npx vitest run tests/lib/services/marketOrderExecution.test.ts`.
- [ ] Validate Buy flow excludes taker-owned orders from execution route.
- [ ] Validate Sell flow excludes taker-owned orders from execution route.
- [ ] Confirm aggregated path still prepares and executes successfully when external orders exist.
- [ ] Confirm cache miss/retry behavior remains correct after approval and readiness polling.