### PR TITLE
Fix: spurious 'Insufficient liquidity' errors from Float precision

### DIFF
--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -251,16 +251,20 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		if (!firstQuote.orderData || !firstQuote.sgOrder) {
 			return { success: false, error: 'Unable to prepare aggregated order route. Please refresh and retry.' };
 		}
+		// Use *UpTo modes instead of *Exact to tolerate tiny Float precision gaps
+		// where the SDK's internal quote discovery computes available liquidity as
+		// e.g. 0.999...999 instead of exactly 1. *UpTo fills as much as available
+		// up to the requested amount, avoiding spurious "Insufficient liquidity" errors.
 		let mode: TakeOrdersMode;
 		let amountDecimals: number;
 		if (orderSide === 'Sell') {
-			mode = 'spendExact';
+			mode = 'spendUpTo';
 			amountDecimals = assetToken.decimals;
 		} else if (inputMode === 'spend') {
-			mode = 'spendExact';
+			mode = 'spendUpTo';
 			amountDecimals = paymentToken.decimals;
 		} else {
-			mode = 'buyExact';
+			mode = 'buyUpTo';
 			amountDecimals = assetToken.decimals;
 		}
 		const takeRequest: TakeOrdersRequest = {
@@ -272,6 +276,18 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			amount: formatUnits(amount, amountDecimals),
 			priceCap: priceCapStrForSdk
 		};
+		console.log('[executeMarketOrder] TakeOrdersRequest', {
+			mode: takeRequest.mode,
+			amount: takeRequest.amount,
+			priceCap: takeRequest.priceCap,
+			sellToken: takeRequest.sellToken,
+			buyToken: takeRequest.buyToken,
+			orderSide,
+			inputMode,
+			fillCount: walkResult.fills.length,
+			walkOutputGiven: walkResult.outputAmountGiven?.toString(),
+			walkInputFilled: walkResult.inputAmountFilled?.toString()
+		});
 		// Opportunistically prefetch aggregated calldata while we build final params.
 		void transactionStore.preloadAggregatedTakeOrdersCalldata(takeRequest);
 		const { inputAmountFilled } = walkResult;

--- a/src/lib/stores/transaction.ts
+++ b/src/lib/stores/transaction.ts
@@ -1502,9 +1502,12 @@ const transactionStore = () => {
 
 		let calldataWrapped = await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: true });
 		if (calldataWrapped.error || !calldataWrapped.value) {
-			console.log(`${TX_LOG_PREFIX} skipping fallback: SDK returned no aggregated calldata`, {
-				msg: calldataWrapped.error?.readableMsg
-			});
+			const sdkMsg = calldataWrapped.error?.readableMsg;
+			console.log(`${TX_LOG_PREFIX} SDK error`, { msg: sdkMsg, request: takeRequest });
+			if (sdkMsg) {
+				transactionError(sdkMsg as TransactionErrorMessage);
+				return true;
+			}
 			return false;
 		}
 
@@ -1991,7 +1994,7 @@ const transactionStore = () => {
 		awaitWalletConfirmation(`Preparing order...`);
 		const isDynamicWallet = get(authMethod) === 'dynamic';
 		const fillDecimals = params.orderFillDecimals ?? params.takerWantsToken.decimals;
-		const mode: TakeOrdersMode = finalConfig.IOIsInput ? 'buyExact' : 'spendExact';
+		const mode: TakeOrdersMode = finalConfig.IOIsInput ? 'buyUpTo' : 'spendUpTo';
 		const priceCapFloat = Float.fromHex(finalConfig.maximumIORatio as `0x${string}`);
 		const priceCapStr = String(priceCapFloat.value?.format().value ?? '1');
 		const aggregatedTakeRequest = buildTakeOrdersRequest({


### PR DESCRIPTION
## Summary

- **Switch all `TakeOrdersMode` from `*Exact` to `*UpTo`** in both the aggregated path (`marketOrderExecution.ts`) and per-order path (`handleTakeOrders` in `transaction.ts`). The Rain SDK's Float arithmetic can compute available liquidity as `0.999...999` instead of exactly `1.0`, causing `spendExact`/`buyExact` to reject valid orders with "Insufficient liquidity: requested 1, but only 0.99...999 available" even when there is ample orderbook depth. `*UpTo` fills as much as available up to the requested amount, tolerating precision gaps.

- **Surface actual SDK error messages** to users instead of the generic "Unable to prepare aggregated order transaction. Please refresh quotes and retry." when the SDK returns a readable error.

- **Add diagnostic logging** of `TakeOrdersRequest` parameters (mode, amount, priceCap, tokens, walk results) to aid debugging future execution issues.

## Test plan

- [ ] Execute a sell market order for exactly 1 token when bid liquidity >> 1 — should succeed without "Insufficient liquidity" error
- [ ] Execute a buy market order — should succeed with `buyUpTo` mode
- [ ] Execute a spend-mode buy — should succeed with `spendUpTo` mode
- [ ] Verify console shows `[executeMarketOrder] TakeOrdersRequest` log with correct parameters
- [ ] When SDK returns an error, verify user sees the SDK's actual error message (not generic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)