### PR TITLE
Stop showing phantom zero-volume rows in depth chart tooltip

### DIFF
--- a/src/lib/components/charts/TokenMarketCharts.svelte
+++ b/src/lib/components/charts/TokenMarketCharts.svelte
@@ -494,19 +494,16 @@
 		const cumulative: Array<{ x: number; y: number }> = [];
 		let running = 0;
 
-		// Get the starting price (max for bids, min for asks)
-		const startPrice = sorted.length > 0 ? sorted[0].price : 0;
-
-		// Start at the first price with 0 volume
-		cumulative.push({ x: startPrice, y: 0 });
-
-		// For each point, add the cumulative volume step
+		// Two points per order — pre-step at the running total before this order,
+		// post-step at the running total after. The pre-step on the first iteration
+		// is implicitly the y=0 anchor (`running` starts at 0), so no separate
+		// anchor point is needed. Emitting one would just duplicate the pre-step
+		// at the same (price, 0) coordinate, which Chart.js's `nearest` hover mode
+		// reports as two `0.0000 @ $price` tooltip rows and confuses users into
+		// thinking those are real zero-volume orders.
 		for (const point of sorted) {
-			// Point at current price with volume before this order
 			cumulative.push({ x: point.price, y: running });
-			// Add this order's volume to running total
 			running += point.quantity;
-			// Point at current price with volume after this order
 			cumulative.push({ x: point.price, y: running });
 		}
 
@@ -569,6 +566,17 @@
 					plugins: {
 						legend: { position: 'bottom', labels: { color: '#d1d5db' } },
 						tooltip: {
+							// Drop any data points whose cumulative volume is zero. The
+							// step-function representation puts a `(price, 0)` point at
+							// the leading edge of each side so the line falls back to the
+							// x-axis. Those points carry no information for the user but
+							// `interaction.mode = 'nearest'` will still surface them as
+							// `0.0000 @ $price` rows on hover, which reads as a real
+							// zero-volume order.
+							filter: (item: {
+								raw?: { y?: number };
+								parsed?: { y?: number };
+							}) => Number(item.raw?.y ?? item.parsed?.y ?? 0) > 0,
 							callbacks: {
 								label: (context: {
 									dataset?: { candlestick?: boolean; label?: string };


### PR DESCRIPTION
## Summary

Users were reading the orderbook depth tooltip as if it showed real zero-volume orders. Hovering near the best ask produced two rows like:

```
Asks: 0.0000 @ $194.13
Asks: 0.0000 @ $194.13
```

…which reads as "two stuck zero-volume orders at the best ask." There are no such orders — the rows come from how `buildDepthDataset` lays out cumulative-volume points and how Chart.js's `nearest` hover mode picks up identical-coordinate points.

## Two surgical fixes

### 1. Drop the redundant leading anchor point

\`buildDepthDataset\` was pushing \`{startPrice, 0}\` before the loop, then the first loop iteration immediately pushed \`{startPrice, 0}\` *again* as its pre-step (since \`running\` is still 0). Two y=0 points stacked at the same x → two \`0.0000 @ \$price\` rows on hover.

Safe to remove because the first loop iteration's pre-step is structurally identical, and \`fill: 'origin'\` already handles the visual baseline. **Chart shape, fill area, and hover behaviour are all visually identical** — only the duplicate hover row is gone.

I traced through every case (empty side, single order, multi-order; bids and asks separately) — the line geometry, step direction, area-fill polygon, and \`extendWithTail\` behaviour are unchanged.

### 2. Filter zero-volume rows from the tooltip

Even after removing the anchor, the per-order \`(price, 0)\` pre-step still exists at the leading edge of each side (the bottom of the step-function vertical wall). Those points are essential for rendering but carry no information on hover, so the new \`tooltip.filter\` callback drops them.

Belt-and-braces — kills the user-reported confusion at the *display* layer regardless of any future data-shape changes.

## What's NOT in this PR

I considered (and dropped) a third change to reframe the tooltip as cumulative depth (\"Cumulative asks ≤ \$194.13: 450\") instead of per-row \"Asks: 450 @ $194.13\". That's a bigger UX shift — defer to a separate PR if (1) + (2) don't fully resolve the user feedback.

## Verification

- \`npm run check\`: same 4 pre-existing \`showRainlangConfirmation\` type errors only; no new errors.
- \`npm test\`: all 429 tests pass.
- Visual: depth chart on \`/trade/{wtMSTR}\` and \`/trade/{wtSPYM}\` already verified earlier in the session — bid/ask walls render correctly at $164.85–$166.50 around the $165.67 oracle peg, no shape change expected from this PR.

## Related context

Builds on the depth-chart correctness work in commit \`aabeee3\` (\"api: drop orders that fail to quote, surface parsedMeta\") that already eliminated phantom *orders* synthesised at oracle price. This PR eliminates phantom *tooltip rows* on legitimate orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed orderbook depth chart tooltip displaying misleading zero-volume order points when hovering over step edges, improving chart interaction accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->