### PR TITLE
chore: gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ AGENTS.md
 CLAUDE.md
 .env*.local
 
+# Claude Code (per-user/per-machine settings, runtime locks, local worktrees)
+.claude/
+
 # Playwright
 .playwright-mcp/
 *.png


### PR DESCRIPTION
Adds `.claude/` to `.gitignore`. Contains per-user Claude Code settings, runtime locks, and worktree metadata — should not be in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration files to improve development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->