### PR TITLE
Fix oracle order market buys failing aggregated preflight

### DIFF
--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -128,6 +128,17 @@ function isSkippableMakerLegError(message: string | undefined): boolean {
 	);
 }
 
+/**
+ * Aggregated `getTakeOrdersCalldata` often fails for Pyth-oracle maker orders (needs signed
+ * context). Return false from handleAggregatedTakeOrdersCalldata so callers use per-order
+ * `getTakeCalldata` / handleOracleOrders instead of surfacing a terminal error.
+ */
+function shouldFallbackFromAggregatedTake(sdkMsg: string | undefined): boolean {
+	if (!sdkMsg) return false;
+	if (sdkMsg.includes('No liquidity')) return true;
+	return isSkippableMakerLegError(sdkMsg);
+}
+
 function extractAvailableLiquidityAmount(
 	message: string | undefined,
 	decimals: number
@@ -504,10 +515,9 @@ export const handleAggregatedTakeOrdersCalldata = async (
 		const sdkMsg = calldataWrapped.error?.readableMsg;
 		console.log(`${TX_LOG_PREFIX} SDK error`, { msg: sdkMsg, request: takeRequest });
 		if (sdkMsg) {
-			// "No liquidity" from SDK is often a false negative when subgraph vault
-			// balances are stale. Return false to let callers try per-order fallback.
-			if (sdkMsg.includes('No liquidity')) {
-				console.warn(`${TX_LOG_PREFIX} SDK reported no liquidity — allowing per-order fallback`);
+			// Stale subgraph / oracle orders: aggregated simulation fails but per-order take may work.
+			if (shouldFallbackFromAggregatedTake(sdkMsg)) {
+				console.warn(`${TX_LOG_PREFIX} SDK error — allowing per-order fallback`, { msg: sdkMsg });
 				return false;
 			}
 			transactionError(sdkMsg as TransactionErrorMessage);


### PR DESCRIPTION
## Summary

- When `getTakeOrdersCalldata` fails on aggregated preflight/simulation (common for Pyth-oracle maker orders that need signed context), fall back to per-order `handleOracleOrders` instead of surfacing a terminal `aggregated_failed` error.
- Extends the existing “No liquidity” fallback to all skippable maker-leg errors (`preflight check failed`, `order failed simulation`, reverts).

## Problem

Buying wtNVDA against an active ask with Pyth oracle Rainlang failed with:

```
Preflight check failed: All orders failed simulation … array out-of-bounds access (0x32)
```

On-chain pre-flight (`getOrderQuotesBatch`) showed vault liquidity (~6 wtNVDA), but aggregated take simulation cannot run oracle orders without signed context.

## Solution

`handleAggregatedTakeOrdersCalldata` now uses `shouldFallbackFromAggregatedTake()` so simulation-class SDK errors return `false`, allowing `executeMarketOrder` → `handleOracleOrders` → `getTakeCalldata()` (oracle-signed path).

## Test plan

- [ ] Buy wtNVDA on `/trade/0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7` against order `0x875b1665…` — should prompt wallet via per-order path, not immediate `aggregated_failed`
- [ ] Confirm non-oracle aggregated takes still work
- [ ] `npm test -- tests/lib/services/marketOrderExecution.test.ts --run`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced error handling for order aggregation with improved fallback mechanism. The system now gracefully handles "No liquidity" and other non-critical errors by reverting to per-order execution when needed, improving reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SARKEX/st0x/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->