### PR TITLE
fix: stop serving stale orderbook data on production

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -33,8 +33,8 @@
 - Base URL: env `ST0X_API_URL`
 - Auth: HTTP Basic via `ST0X_API_KEY` + `ST0X_API_SECRET` (`btoa('key:secret')`, server-only)
 - Allowlist of proxied routes (with per-route Vercel edge cache):
-  - `GET v1/orders/token/:address` — `private, no-store` (no Vercel edge cache; upstream ~15s)
-  - `GET v1/trades/token/:address` — `private, no-store`
+  - `GET v1/orders/token/:address` — `s-maxage=15, stale-while-revalidate=15`
+  - `GET v1/trades/token/:address` — `s-maxage=15, stale-while-revalidate=15`
   - `GET v1/orders/owner/:address`, `GET v1/trades/:address`, `GET v1/trades/taker/:address` — no shared cache
   - `POST v1/trades/batch` — no cache
   - `GET health`

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -33,8 +33,8 @@
 - Base URL: env `ST0X_API_URL`
 - Auth: HTTP Basic via `ST0X_API_KEY` + `ST0X_API_SECRET` (`btoa('key:secret')`, server-only)
 - Allowlist of proxied routes (with per-route Vercel edge cache):
-  - `GET v1/orders/token/:address` — `s-maxage=5, stale-while-revalidate=120`
-  - `GET v1/trades/token/:address` — `s-maxage=5, stale-while-revalidate=120`
+  - `GET v1/orders/token/:address` — `private, no-store` (no Vercel edge cache; upstream ~15s)
+  - `GET v1/trades/token/:address` — `private, no-store`
   - `GET v1/orders/owner/:address`, `GET v1/trades/:address`, `GET v1/trades/taker/:address` — no shared cache
   - `POST v1/trades/batch` — no cache
   - `GET health`

--- a/src/lib/queries/orderbook.ts
+++ b/src/lib/queries/orderbook.ts
@@ -69,7 +69,7 @@ export function createOrderbookQuotesQuery(
 	return createQuery<OrderbookQuoteCache>({
 		queryKey: ['orderbookQuotes', network?.id],
 		enabled: Boolean(browser && network),
-		staleTime: 30_000, // Stale after 30s (server caches at 15s)
+		staleTime: 15_000, // Match 15s poll; upstream API caches ~15s
 		retry: 2,
 		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
 		refetchInterval: pollInterval,
@@ -112,7 +112,7 @@ export function getQuotesForToken(
 }
 
 /** Minimum age (ms) of cached data before we re-fetch. Prevents redundant fetches. */
-const TOKEN_QUOTE_FRESHNESS_MS = 20_000;
+const TOKEN_QUOTE_FRESHNESS_MS = 5_000;
 
 /**
  * Fetch fresh quotes for a specific token and merge into global cache.
@@ -254,7 +254,7 @@ export function createTokenOrderbookQuotesQuery(
 	return createQuery<OrderbookQuoteCache>({
 		queryKey: ['tokenOrderbookQuotes', network?.id, tokenAddress],
 		enabled: Boolean(browser && network && tokenAddress),
-		staleTime: 30_000, // Stale after 30s (server caches at 15s)
+		staleTime: 15_000, // Match 15s poll; upstream API caches ~15s
 		retry: 2,
 		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
 		refetchOnMount: 'always', // Always refresh when component mounts
@@ -305,8 +305,13 @@ export function invalidateOrderQueries(networkId?: number, tokenAddress?: string
  * Call this after priority data loads to ensure global cache is populated.
  */
 export async function prefetchGlobalOrders(networkId: number) {
+	const state = queryClient.getQueryState(['orderbookQuotes', networkId]);
 	const existing = queryClient.getQueryData<OrderbookQuoteCache>(['orderbookQuotes', networkId]);
-	if (existing?.quotes?.length) {
+	const isFresh =
+		Boolean(existing?.quotes?.length) &&
+		Boolean(state?.dataUpdatedAt) &&
+		Date.now() - state!.dataUpdatedAt! < 15_000;
+	if (isFresh) {
 		return;
 	}
 
@@ -317,6 +322,6 @@ export async function prefetchGlobalOrders(networkId: number) {
 			const summary = buildSummaryFromQuotes(quotes, networkId);
 			return { summary, quotes };
 		},
-		staleTime: 30_000
+		staleTime: 15_000
 	});
 }

--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -44,6 +44,7 @@ import { ensureAllowance } from './approvalStore';
 import { parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
 import { createRaindexClient } from '$lib/clients/raindex';
 import { invalidateDashboardBalances } from '$lib/queries/balances';
+import { invalidateOrderQueries } from '$lib/queries/orderbook';
 import { walletAddress, authMethod } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { getTrades } from '$lib/api/subgraph';
@@ -451,6 +452,7 @@ export const pollAndFinalizeTakeOrders = async (
 	// could render with stale on-chain balance reads (the user just got tokens
 	// the cache hasn't seen yet).
 	invalidateDashboardBalances();
+	invalidateOrderQueries(network.id);
 
 	// Partial-fill detection anchors on whichever side the user typed their amount.
 	// For spend modes (Sell-by-asset, Buy-by-spend) the anchor is the pays side; for

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -29,17 +29,16 @@ function getAuthHeader(): string {
 
 const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
-	// Token orderbook/trades: no Vercel edge cache — upstream API already caches ~15s.
-	// (Previously s-maxage=5 + stale-while-revalidate=120 served books up to ~2min stale.)
+	// Token orderbook/trades: short shared edge cache (max ~30s stale vs ~2min before).
 	{
 		method: 'GET',
 		pattern: /^v1\/orders\/token\/[^/]+$/,
-		cache: 'private, no-store'
+		cache: 'public, s-maxage=15, stale-while-revalidate=15'
 	},
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,
-		cache: 'private, no-store'
+		cache: 'public, s-maxage=15, stale-while-revalidate=15'
 	},
 	// Per-user endpoints — no shared caching
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -29,16 +29,17 @@ function getAuthHeader(): string {
 
 const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
-	// Shared endpoints — same response for all users, cache at Vercel edge
+	// Token orderbook/trades: no Vercel edge cache — upstream API already caches ~15s.
+	// (Previously s-maxage=5 + stale-while-revalidate=120 served books up to ~2min stale.)
 	{
 		method: 'GET',
 		pattern: /^v1\/orders\/token\/[^/]+$/,
-		cache: 'public, s-maxage=5, stale-while-revalidate=120'
+		cache: 'private, no-store'
 	},
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,
-		cache: 'public, s-maxage=5, stale-while-revalidate=120'
+		cache: 'private, no-store'
 	},
 	// Per-user endpoints — no shared caching
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },


### PR DESCRIPTION
## Summary

Production orderbooks could lag the upstream st0x API by up to **~2 minutes** while direct `ST0X_API_URL` curls were correct. Root cause was layered caching: Vercel edge (`s-maxage=5`, `stale-while-revalidate=120`) plus client TanStack Query holding data longer than the 15s poll.

### Proxy (`src/routes/api/st0x/[...path]/+server.ts`)

- `GET v1/orders/token/*` and `GET v1/trades/token/*` now use:
  - `Cache-Control: public, s-maxage=15, stale-while-revalidate=15`
- **Before:** up to ~2 min stale at the edge.
- **After:** ~15s fresh at edge, then up to ~15s SWR → **~30s max staleness**, with cross-user CDN dedup for the same token URL.

### Client (`src/lib/queries/orderbook.ts`)

- `staleTime` **30s → 15s** (global + per-token queries) to match dashboard/trade polling.
- `TOKEN_QUOTE_FRESHNESS_MS` **20s → 5s** (only dedupes rapid repeat fetches, not poll interval).
- `prefetchGlobalOrders`: skip only when global cache is **< 15s** old (was: skip whenever any quotes existed).

### Market takes (`src/lib/stores/marketTakeStore.ts`)

- `invalidateOrderQueries(network.id)` after a successful take (limit/DCA deploy already invalidated; market takes did not).

## Test plan

- [ ] Preview/prod: `curl -sSI 'https://<host>/api/st0x/v1/orders/token/<addr>?page=1&pageSize=50' | grep -i cache-control` → `public, s-maxage=15, stale-while-revalidate=15` (no `stale-while-revalidate=120`).
- [ ] After a book change, compare proxy JSON to direct `ST0X_API_URL` curl — should align within ~30s worst case (edge + upstream).
- [ ] Dashboard: network tab — global orderbook still refetches ~every 15s, not a burst of duplicate token calls within 5s.
- [ ] Trade page: market buy/sell → depth updates after fill without hard refresh.
- [ ] `npm run check` / `npm test` per CI.

## Load / ops notes

- Per-user request rate is largely unchanged (already polled every 15s).
- Short edge cache **reduces** origin load vs `no-store` when many users hit the same token endpoints; vs the old 120s SWR, origin load increases but staleness is bounded.
- Upstream API still caches ~15s; edge TTL is aligned with that.