### PR TITLE
fix: orderbook still stale on prod after #183

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -33,8 +33,8 @@
 - Base URL: env `ST0X_API_URL`
 - Auth: HTTP Basic via `ST0X_API_KEY` + `ST0X_API_SECRET` (`btoa('key:secret')`, server-only)
 - Allowlist of proxied routes (with per-route Vercel edge cache):
-  - `GET v1/orders/token/:address` — `s-maxage=15, stale-while-revalidate=15`
-  - `GET v1/trades/token/:address` — `s-maxage=15, stale-while-revalidate=15`
+  - `GET v1/orders/token/:address` — browser `private, no-cache`; edge `CDN-Cache-Control: s-maxage=15, stale-while-revalidate=15`
+  - `GET v1/trades/token/:address` — same as orders/token
   - `GET v1/orders/owner/:address`, `GET v1/trades/:address`, `GET v1/trades/taker/:address` — no shared cache
   - `POST v1/trades/batch` — no cache
   - `GET health`

--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -193,7 +193,7 @@ export async function apiGetOrdersByToken(
 		pageSize: options?.pageSize,
 		side: options?.side
 	});
-	return fetchJson<ApiOrdersListResponse>(url);
+	return fetchJson<ApiOrdersListResponse>(url, { cache: 'no-store' });
 }
 
 /**
@@ -275,6 +275,7 @@ export async function apiGetTradesByToken(
 	if (startTime !== undefined) params.set('startTime', String(startTime));
 	if (endTime !== undefined) params.set('endTime', String(endTime));
 	return fetchJson<ApiTradesByAddressResponse>(
-		`/api/st0x/v1/trades/token/${tokenAddress}?${params}`
+		`/api/st0x/v1/trades/token/${tokenAddress}?${params}`,
+		{ cache: 'no-store' }
 	);
 }

--- a/src/lib/queries/orderbook.ts
+++ b/src/lib/queries/orderbook.ts
@@ -261,14 +261,28 @@ export function createTokenOrderbookQuotesQuery(
 		refetchInterval: pollInterval, // Poll every 15s by default on trade pages
 		refetchOnWindowFocus: true, // Only refetch on focus if stale
 		refetchIntervalInBackground: false,
-		// Use global cache as initial data for instant display
+		// Seed from global cache only when it was updated recently (avoid minutes-old books).
 		initialData: () => {
 			if (!network || !tokenAddress) return undefined;
+			const globalState = queryClient.getQueryState(['orderbookQuotes', network.id]);
+			if (
+				!globalState?.dataUpdatedAt ||
+				Date.now() - globalState.dataUpdatedAt > 15_000
+			) {
+				return undefined;
+			}
 			return getQuotesForToken(network.id, tokenAddress);
 		},
 		initialDataUpdatedAt: () => {
 			if (!network) return undefined;
-			return queryClient.getQueryState(['orderbookQuotes', network.id])?.dataUpdatedAt;
+			const globalState = queryClient.getQueryState(['orderbookQuotes', network.id]);
+			if (
+				!globalState?.dataUpdatedAt ||
+				Date.now() - globalState.dataUpdatedAt > 15_000
+			) {
+				return undefined;
+			}
+			return globalState.dataUpdatedAt;
 		},
 		queryFn: async () => {
 			if (!network || !tokenAddress) {
@@ -288,15 +302,20 @@ export function createTokenOrderbookQuotesQuery(
  */
 export function invalidateOrderQueries(networkId?: number, tokenAddress?: string) {
 	if (tokenAddress && networkId) {
-		// Token-specific: fetch fresh data for this token and merge
+		queryClient.invalidateQueries({
+			queryKey: ['tokenOrderbookQuotes', networkId, tokenAddress]
+		});
 		refreshTokenQuotes(networkId, tokenAddress).catch((err) =>
 			console.error('[OrderbookQueries] Token refresh failed:', err)
 		);
 	} else {
-		// Full invalidation: refetch entire global cache
 		queryClient.invalidateQueries({ queryKey: ['orderbookQuotes'] });
+		if (networkId !== undefined) {
+			queryClient.invalidateQueries({ queryKey: ['tokenOrderbookQuotes', networkId] });
+		} else {
+			queryClient.invalidateQueries({ queryKey: ['tokenOrderbookQuotes'] });
+		}
 	}
-	// Always invalidate closed orders query
 	queryClient.invalidateQueries({ queryKey: ['closedOrders'] });
 }
 

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -27,18 +27,31 @@ function getAuthHeader(): string {
 	return 'Basic ' + btoa(`${key}:${secret}`);
 }
 
-const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
+/** Vercel CDN TTL for shared token orderbook/trade list responses (~30s max staleness). */
+const TOKEN_LIST_EDGE_CACHE = 'public, s-maxage=15, stale-while-revalidate=15';
+
+/** Browsers must not cache orderbook JSON (fetch respects Cache-Control). */
+const TOKEN_LIST_BROWSER_CACHE = 'private, no-cache, max-age=0, must-revalidate';
+
+const ALLOWED_PROXY_ROUTES: Array<{
+	method: string;
+	pattern: RegExp;
+	edgeCache?: string;
+	browserCache?: string;
+}> = [
 	{ method: 'GET', pattern: /^health$/ },
-	// Token orderbook/trades: short shared edge cache (max ~30s stale vs ~2min before).
+	// Token orderbook/trades: CDN-Cache-Control for edge; no browser HTTP cache.
 	{
 		method: 'GET',
 		pattern: /^v1\/orders\/token\/[^/]+$/,
-		cache: 'public, s-maxage=15, stale-while-revalidate=15'
+		edgeCache: TOKEN_LIST_EDGE_CACHE,
+		browserCache: TOKEN_LIST_BROWSER_CACHE
 	},
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,
-		cache: 'public, s-maxage=15, stale-while-revalidate=15'
+		edgeCache: TOKEN_LIST_EDGE_CACHE,
+		browserCache: TOKEN_LIST_BROWSER_CACHE
 	},
 	// Per-user endpoints — no shared caching
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },
@@ -50,11 +63,13 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 function matchProxyRoute(
 	method: string,
 	pathSuffix: string
-): { cache?: string } | null {
+): { edgeCache?: string; browserCache?: string } | null {
 	const route = ALLOWED_PROXY_ROUTES.find(
 		(r) => r.method === method && r.pattern.test(pathSuffix)
 	);
-	return route ? { cache: route.cache } : null;
+	return route
+		? { edgeCache: route.edgeCache, browserCache: route.browserCache }
+		: null;
 }
 
 const proxyRequest = async ({ request, params, url }: RequestEvent) => {
@@ -109,8 +124,15 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 
 	const responseHeaders = new Headers();
 	responseHeaders.set('Content-Type', response.headers.get('Content-Type') ?? 'application/json');
-	if (matched.cache && response.ok) {
-		responseHeaders.set('Cache-Control', matched.cache);
+	if (response.ok) {
+		if (matched.browserCache) {
+			responseHeaders.set('Cache-Control', matched.browserCache);
+		}
+		if (matched.edgeCache) {
+			// Vercel uses CDN-Cache-Control / Vercel-CDN-Cache-Control for edge; Cache-Control for browsers.
+			responseHeaders.set('CDN-Cache-Control', matched.edgeCache);
+			responseHeaders.set('Vercel-CDN-Cache-Control', matched.edgeCache);
+		}
 	}
 
 	return new Response(response.body, {


### PR DESCRIPTION
## Summary

Follow-up to #183. Prod still showed stale books because:

1. **Vercel was not applying `s-maxage` from `Cache-Control`** — live `curl` showed only `cache-control: public` and `x-vercel-cache: STALE`, not our `s-maxage=15` directive.
2. **Trade pages use `tokenOrderbookQuotes`** — `invalidateOrderQueries()` only invalidated `orderbookQuotes`, so trade/QuickTrade UI could keep old data after fills.
3. **`initialData` from global cache** could show minutes-old depth until the next poll.
4. **Browser HTTP cache** could retain `public` responses without `no-cache`.

### Changes

- **Proxy:** `Cache-Control: private, no-cache` for browsers; `CDN-Cache-Control` + `Vercel-CDN-Cache-Control` with `s-maxage=15, stale-while-revalidate=15` for edge.
- **Client:** Invalidate `tokenOrderbookQuotes` with global invalidation; only use global `initialData` when global cache is &lt; 15s old.
- **API client:** `cache: 'no-store'` on token orders/trades fetches.

## Test plan

- [ ] After deploy: `curl -sS -D - 'https://www.st0x.io/api/st0x/v1/orders/token/<addr>?page=1&pageSize=2' -o /dev/null | grep -i cache` shows `private, no-cache` and `cdn-cache-control` with `s-maxage=15`.
- [ ] Hard refresh trade page — book matches direct API within ~30s.
- [ ] Market take — depth updates without full page reload.
- [ ] Dashboard — still polls ~15s, no request storm.


Made with [Cursor](https://cursor.com)