### PR TITLE
fix: prod proxy must match upstream API (no edge cache)

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -33,7 +33,7 @@
 - Base URL: env `ST0X_API_URL`
 - Auth: HTTP Basic via `ST0X_API_KEY` + `ST0X_API_SECRET` (`btoa('key:secret')`, server-only)
 - Allowlist of proxied routes (with per-route Vercel edge cache):
-  - `GET v1/orders/token/:address` — browser `private, no-cache`; edge `CDN-Cache-Control: s-maxage=15, stale-while-revalidate=15`
+  - `GET v1/orders/token/:address` — `private, no-store` (browser + Vercel CDN; upstream API caches ~15s)
   - `GET v1/trades/token/:address` — same as orders/token
   - `GET v1/orders/owner/:address`, `GET v1/trades/:address`, `GET v1/trades/taker/:address` — no shared cache
   - `POST v1/trades/batch` — no cache

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -27,31 +27,24 @@ function getAuthHeader(): string {
 	return 'Basic ' + btoa(`${key}:${secret}`);
 }
 
-/** Vercel CDN TTL for shared token orderbook/trade list responses (~30s max staleness). */
-const TOKEN_LIST_EDGE_CACHE = 'public, s-maxage=15, stale-while-revalidate=15';
-
-/** Browsers must not cache orderbook JSON (fetch respects Cache-Control). */
-const TOKEN_LIST_BROWSER_CACHE = 'private, no-cache, max-age=0, must-revalidate';
+/** No browser or Vercel edge cache — prod CDN was serving stale books vs upstream API. */
+const TOKEN_LIST_NO_STORE = 'private, no-store, max-age=0, must-revalidate';
 
 const ALLOWED_PROXY_ROUTES: Array<{
 	method: string;
 	pattern: RegExp;
-	edgeCache?: string;
-	browserCache?: string;
+	noStore?: boolean;
 }> = [
 	{ method: 'GET', pattern: /^health$/ },
-	// Token orderbook/trades: CDN-Cache-Control for edge; no browser HTTP cache.
 	{
 		method: 'GET',
 		pattern: /^v1\/orders\/token\/[^/]+$/,
-		edgeCache: TOKEN_LIST_EDGE_CACHE,
-		browserCache: TOKEN_LIST_BROWSER_CACHE
+		noStore: true
 	},
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,
-		edgeCache: TOKEN_LIST_EDGE_CACHE,
-		browserCache: TOKEN_LIST_BROWSER_CACHE
+		noStore: true
 	},
 	// Per-user endpoints — no shared caching
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },
@@ -63,13 +56,11 @@ const ALLOWED_PROXY_ROUTES: Array<{
 function matchProxyRoute(
 	method: string,
 	pathSuffix: string
-): { edgeCache?: string; browserCache?: string } | null {
+): { noStore?: boolean } | null {
 	const route = ALLOWED_PROXY_ROUTES.find(
 		(r) => r.method === method && r.pattern.test(pathSuffix)
 	);
-	return route
-		? { edgeCache: route.edgeCache, browserCache: route.browserCache }
-		: null;
+	return route ? { noStore: route.noStore } : null;
 }
 
 const proxyRequest = async ({ request, params, url }: RequestEvent) => {
@@ -102,7 +93,9 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 	const init: RequestInit = {
 		method: request.method,
 		headers: headers as HeadersInit,
-		signal: request.signal
+		signal: request.signal,
+		// Bypass any runtime fetch cache when proxying live orderbook data.
+		...(matched.noStore ? { cache: 'no-store' as RequestCache } : {})
 	};
 
 	if (!['GET', 'HEAD'].includes(request.method)) {
@@ -124,15 +117,10 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 
 	const responseHeaders = new Headers();
 	responseHeaders.set('Content-Type', response.headers.get('Content-Type') ?? 'application/json');
-	if (response.ok) {
-		if (matched.browserCache) {
-			responseHeaders.set('Cache-Control', matched.browserCache);
-		}
-		if (matched.edgeCache) {
-			// Vercel uses CDN-Cache-Control / Vercel-CDN-Cache-Control for edge; Cache-Control for browsers.
-			responseHeaders.set('CDN-Cache-Control', matched.edgeCache);
-			responseHeaders.set('Vercel-CDN-Cache-Control', matched.edgeCache);
-		}
+	if (response.ok && matched.noStore) {
+		responseHeaders.set('Cache-Control', TOKEN_LIST_NO_STORE);
+		responseHeaders.set('CDN-Cache-Control', TOKEN_LIST_NO_STORE);
+		responseHeaders.set('Vercel-CDN-Cache-Control', TOKEN_LIST_NO_STORE);
 	}
 
 	return new Response(response.body, {


### PR DESCRIPTION
## Problem

Confirmed: direct `ST0X_API_URL` order list **≠** `www.st0x.io/api/st0x/...` (same base URL in Vercel env). Preview matches upstream; prod proxy was serving **CDN-stale** JSON (`x-vercel-cache: STALE` / `s-maxage=15` SWR).

## Fix

For `GET v1/orders/token/*` and `GET v1/trades/token/*`:

- `Cache-Control`, `CDN-Cache-Control`, and `Vercel-CDN-Cache-Control` → `private, no-store, max-age=0, must-revalidate`
- Upstream `fetch(..., { cache: 'no-store' })`

Upstream API still has its own ~15s cache; this only removes the **extra** Vercel layer that made prod diverge from curl.

## Test plan

- [ ] After deploy, same token at same time:
  - `curl` direct API `orderHash` list
  - `curl` `https://www.st0x.io/api/st0x/v1/orders/token/...`
  - Lists should match (within upstream ~15s), headers show `no-store` and `x-vercel-cache: MISS`
- [ ] Dashboard / trade orderbook in prod incognito

## Load

No Vercel edge dedup on these URLs; origin sees one request per client poll (~15s). Acceptable for correctness.


Made with [Cursor](https://cursor.com)