### PR TITLE
revert: roll back stale-orderbook cache changes (#183–#185)

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -33,10 +33,10 @@
 - Base URL: env `ST0X_API_URL`
 - Auth: HTTP Basic via `ST0X_API_KEY` + `ST0X_API_SECRET` (`btoa('key:secret')`, server-only)
 - Allowlist of proxied routes (with per-route Vercel edge cache):
-  - `GET v1/orders/token/:address` — `private, no-store` (browser + Vercel CDN; upstream API caches ~15s)
-  - `GET v1/trades/token/:address` — same as orders/token
+  - `GET v1/orders/token/:address` — `s-maxage=5, stale-while-revalidate=120`
+  - `GET v1/trades/token/:address` — `s-maxage=5, stale-while-revalidate=120`
   - `GET v1/orders/owner/:address`, `GET v1/trades/:address`, `GET v1/trades/taker/:address` — no shared cache
-  - `POST v1/trades/batch` — no cache
+  - `POST v1/trades/query` — no cache
   - `GET health`
 - Client wrapper: `src/lib/api/st0xApi.ts` (typed `apiGet*` functions; all gated to browser context)
 

--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -145,7 +145,7 @@ export async function apiGetOrdersByToken(
 		pageSize: options?.pageSize,
 		side: options?.side
 	});
-	return fetchJson<ApiOrdersListResponse>(url, { cache: 'no-store' });
+	return fetchJson<ApiOrdersListResponse>(url);
 }
 
 /**
@@ -226,7 +226,6 @@ export async function apiGetTradesByToken(
 	if (startTime !== undefined) params.set('startTime', String(startTime));
 	if (endTime !== undefined) params.set('endTime', String(endTime));
 	return fetchJson<ApiTradesByAddressResponse>(
-		`/api/st0x/v1/trades/token/${tokenAddress}?${params}`,
-		{ cache: 'no-store' }
+		`/api/st0x/v1/trades/token/${tokenAddress}?${params}`
 	);
 }

--- a/src/lib/queries/orderbook.ts
+++ b/src/lib/queries/orderbook.ts
@@ -69,7 +69,7 @@ export function createOrderbookQuotesQuery(
 	return createQuery<OrderbookQuoteCache>({
 		queryKey: ['orderbookQuotes', network?.id],
 		enabled: Boolean(browser && network),
-		staleTime: 15_000, // Match 15s poll; upstream API caches ~15s
+		staleTime: 30_000, // Stale after 30s (server caches at 15s)
 		retry: 2,
 		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
 		refetchInterval: pollInterval,
@@ -112,7 +112,7 @@ export function getQuotesForToken(
 }
 
 /** Minimum age (ms) of cached data before we re-fetch. Prevents redundant fetches. */
-const TOKEN_QUOTE_FRESHNESS_MS = 5_000;
+const TOKEN_QUOTE_FRESHNESS_MS = 20_000;
 
 /**
  * Fetch fresh quotes for a specific token and merge into global cache.
@@ -254,29 +254,21 @@ export function createTokenOrderbookQuotesQuery(
 	return createQuery<OrderbookQuoteCache>({
 		queryKey: ['tokenOrderbookQuotes', network?.id, tokenAddress],
 		enabled: Boolean(browser && network && tokenAddress),
-		staleTime: 15_000, // Match 15s poll; upstream API caches ~15s
+		staleTime: 30_000, // Stale after 30s (server caches at 15s)
 		retry: 2,
 		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
 		refetchOnMount: 'always', // Always refresh when component mounts
 		refetchInterval: pollInterval, // Poll every 15s by default on trade pages
 		refetchOnWindowFocus: true, // Only refetch on focus if stale
 		refetchIntervalInBackground: false,
-		// Seed from global cache only when it was updated recently (avoid minutes-old books).
+		// Use global cache as initial data for instant display
 		initialData: () => {
 			if (!network || !tokenAddress) return undefined;
-			const globalState = queryClient.getQueryState(['orderbookQuotes', network.id]);
-			if (!globalState?.dataUpdatedAt || Date.now() - globalState.dataUpdatedAt > 15_000) {
-				return undefined;
-			}
 			return getQuotesForToken(network.id, tokenAddress);
 		},
 		initialDataUpdatedAt: () => {
 			if (!network) return undefined;
-			const globalState = queryClient.getQueryState(['orderbookQuotes', network.id]);
-			if (!globalState?.dataUpdatedAt || Date.now() - globalState.dataUpdatedAt > 15_000) {
-				return undefined;
-			}
-			return globalState.dataUpdatedAt;
+			return queryClient.getQueryState(['orderbookQuotes', network.id])?.dataUpdatedAt;
 		},
 		queryFn: async () => {
 			if (!network || !tokenAddress) {
@@ -296,20 +288,15 @@ export function createTokenOrderbookQuotesQuery(
  */
 export function invalidateOrderQueries(networkId?: number, tokenAddress?: string) {
 	if (tokenAddress && networkId) {
-		queryClient.invalidateQueries({
-			queryKey: ['tokenOrderbookQuotes', networkId, tokenAddress]
-		});
+		// Token-specific: fetch fresh data for this token and merge
 		refreshTokenQuotes(networkId, tokenAddress).catch((err) =>
 			console.error('[OrderbookQueries] Token refresh failed:', err)
 		);
 	} else {
+		// Full invalidation: refetch entire global cache
 		queryClient.invalidateQueries({ queryKey: ['orderbookQuotes'] });
-		if (networkId !== undefined) {
-			queryClient.invalidateQueries({ queryKey: ['tokenOrderbookQuotes', networkId] });
-		} else {
-			queryClient.invalidateQueries({ queryKey: ['tokenOrderbookQuotes'] });
-		}
 	}
+	// Always invalidate closed orders query
 	queryClient.invalidateQueries({ queryKey: ['closedOrders'] });
 }
 
@@ -318,13 +305,8 @@ export function invalidateOrderQueries(networkId?: number, tokenAddress?: string
  * Call this after priority data loads to ensure global cache is populated.
  */
 export async function prefetchGlobalOrders(networkId: number) {
-	const state = queryClient.getQueryState(['orderbookQuotes', networkId]);
 	const existing = queryClient.getQueryData<OrderbookQuoteCache>(['orderbookQuotes', networkId]);
-	const isFresh =
-		Boolean(existing?.quotes?.length) &&
-		Boolean(state?.dataUpdatedAt) &&
-		Date.now() - state!.dataUpdatedAt! < 15_000;
-	if (isFresh) {
+	if (existing?.quotes?.length) {
 		return;
 	}
 
@@ -335,6 +317,6 @@ export async function prefetchGlobalOrders(networkId: number) {
 			const summary = buildSummaryFromQuotes(quotes, networkId);
 			return { summary, quotes };
 		},
-		staleTime: 15_000
+		staleTime: 30_000
 	});
 }

--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -38,7 +38,6 @@ import { ensureAllowance } from './approvalStore';
 import { parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
 import { createRaindexClient } from '$lib/clients/raindex';
 import { invalidateDashboardBalances } from '$lib/queries/balances';
-import { invalidateOrderQueries } from '$lib/queries/orderbook';
 import { walletAddress, authMethod } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { getTrades } from '$lib/api/subgraph';
@@ -440,7 +439,6 @@ export const pollAndFinalizeTakeOrders = async (
 	// could render with stale on-chain balance reads (the user just got tokens
 	// the cache hasn't seen yet).
 	invalidateDashboardBalances();
-	invalidateOrderQueries(network.id);
 
 	// Partial-fill detection anchors on whichever side the user typed their amount.
 	// For spend modes (Sell-by-asset, Buy-by-spend) the anchor is the pays side; for

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -27,24 +27,18 @@ function getAuthHeader(): string {
 	return 'Basic ' + btoa(`${key}:${secret}`);
 }
 
-/** No browser or Vercel edge cache — prod CDN was serving stale books vs upstream API. */
-const TOKEN_LIST_NO_STORE = 'private, no-store, max-age=0, must-revalidate';
-
-const ALLOWED_PROXY_ROUTES: Array<{
-	method: string;
-	pattern: RegExp;
-	noStore?: boolean;
-}> = [
+const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
+	// Shared endpoints — same response for all users, cache at Vercel edge
 	{
 		method: 'GET',
 		pattern: /^v1\/orders\/token\/[^/]+$/,
-		noStore: true
+		cache: 'public, s-maxage=5, stale-while-revalidate=120'
 	},
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,
-		noStore: true
+		cache: 'public, s-maxage=5, stale-while-revalidate=120'
 	},
 	// Per-user endpoints — no shared caching
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },
@@ -53,9 +47,14 @@ const ALLOWED_PROXY_ROUTES: Array<{
 	{ method: 'POST', pattern: /^v1\/trades\/query$/ }
 ];
 
-function matchProxyRoute(method: string, pathSuffix: string): { noStore?: boolean } | null {
-	const route = ALLOWED_PROXY_ROUTES.find((r) => r.method === method && r.pattern.test(pathSuffix));
-	return route ? { noStore: route.noStore } : null;
+function matchProxyRoute(
+	method: string,
+	pathSuffix: string
+): { cache?: string } | null {
+	const route = ALLOWED_PROXY_ROUTES.find(
+		(r) => r.method === method && r.pattern.test(pathSuffix)
+	);
+	return route ? { cache: route.cache } : null;
 }
 
 const proxyRequest = async ({ request, params, url }: RequestEvent) => {
@@ -88,9 +87,7 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 	const init: RequestInit = {
 		method: request.method,
 		headers: headers as HeadersInit,
-		signal: request.signal,
-		// Bypass any runtime fetch cache when proxying live orderbook data.
-		...(matched.noStore ? { cache: 'no-store' as RequestCache } : {})
+		signal: request.signal
 	};
 
 	if (!['GET', 'HEAD'].includes(request.method)) {
@@ -112,10 +109,8 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 
 	const responseHeaders = new Headers();
 	responseHeaders.set('Content-Type', response.headers.get('Content-Type') ?? 'application/json');
-	if (response.ok && matched.noStore) {
-		responseHeaders.set('Cache-Control', TOKEN_LIST_NO_STORE);
-		responseHeaders.set('CDN-Cache-Control', TOKEN_LIST_NO_STORE);
-		responseHeaders.set('Vercel-CDN-Cache-Control', TOKEN_LIST_NO_STORE);
+	if (matched.cache && response.ok) {
+		responseHeaders.set('Cache-Control', matched.cache);
 	}
 
 	return new Response(response.body, {


### PR DESCRIPTION
## Summary

Reverts the client + proxy changes from [#183](https://github.com/SARKEX/st0x/pull/183), [#184](https://github.com/SARKEX/st0x/pull/184), and [#185](https://github.com/SARKEX/st0x/pull/185) after reports of **~30 req/s** to the same orders endpoint overloading the API DB.

### Restored behavior

| Area | Before (183–185) | After this PR |
|------|------------------|---------------|
| Proxy `orders/token`, `trades/token` | `no-store` (every client poll hits origin) | Vercel edge `s-maxage=5, stale-while-revalidate=120` |
| Client `staleTime` | 15s | 30s |
| `TOKEN_QUOTE_FRESHNESS_MS` | 5s | 20s |
| `prefetchGlobalOrders` | Re-fetch unless global cache < 15s old | Skip when global cache already has quotes |
| `invalidateOrderQueries` | Also invalidates all `tokenOrderbookQuotes` | Global invalidation only (token path: `refreshTokenQuotes` only) |
| Market take finalize | `invalidateOrderQueries(network.id)` | Removed (balances still invalidated) |
| `fetchJson` orders/trades | `cache: 'no-store'` | Default fetch cache |

**Not reverted:** `POST v1/trades/query` route (from #177) — kept as-is.

### Likely burst cause

#184 added invalidation of **all** `tokenOrderbookQuotes` on any book refresh; #183 added the same after every market take. Combined with shorter client `staleTime` and proxy `no-store`, active trade/dashboard views could refetch the same token orders endpoint many times per second.

## Test plan

- [ ] Deploy preview; watch API logs during dashboard + trade page — orders/token should be ~1 req / 15s per tab, not bursts
- [ ] Market buy/sell still completes; book may be slightly staler (acceptable tradeoff)
- [ ] `curl -sSI 'https://<preview>/api/st0x/v1/orders/token/<addr>?page=1&pageSize=2' | grep -i cache` shows `s-maxage=5`
- [ ] `npm run check`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enabled shared edge caching for token quote endpoints to improve response times
  * Increased cache freshness thresholds for orderbook queries
  * Removed forced no-cache behavior on token-related API calls
  * Optimized cache invalidation strategies to balance data freshness with performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SARKEX/st0x/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->