### PR TITLE
fix(ui): reduce orderbook API bursts and improve trade load

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -25,6 +25,10 @@ import {
 	walkOrderbook
 } from '$lib/utils/orderbook';
 import { apiGetOrdersByToken, type ApiOrderSummary } from '$lib/api/st0xApi';
+import { mapWithConcurrency } from '$lib/utils/mapWithConcurrency';
+
+/** Max parallel `orders/token` requests when loading the global book (avoids API bursts). */
+export const TOKEN_ORDER_FETCH_CONCURRENCY = 4;
 
 export type { ProcessedQuote, TokenPriceSummary };
 export { OrderV4_ABI, normalizeOrderData, walkOrderbook };
@@ -200,38 +204,44 @@ export async function fetchAndQuotePaymentTokenOrders(
 	const processedQuotes: ProcessedQuote[] = [];
 	const seen = new Set<string>();
 
-	const results = await Promise.allSettled(
-		stockTokens.map(async (token) => {
-			let page = 1;
-			let hasMore = true;
-			while (hasMore && page <= MAX_ORDER_PAGES) {
-				const response = await apiGetOrdersByToken(token.address, { page, pageSize: 50 });
-				for (const order of response.orders) {
-					if (seen.has(order.orderHash)) continue;
-					seen.add(order.orderHash);
-					const quote = convertApiOrderToProcessedQuote(
-						order,
-						paymentToken.address,
-						allTokens,
-						networkId
-					);
-					if (quote) processedQuotes.push(quote);
-				}
-				hasMore = response.pagination.hasMore;
-				page++;
-			}
-			if (hasMore) {
-				console.warn(
-					`[orders] Hit pagination cap (${MAX_ORDER_PAGES} pages) for token ${token.address}`
+	const results = await mapWithConcurrency(stockTokens, TOKEN_ORDER_FETCH_CONCURRENCY, async (token) => {
+		const tokenQuotes: ProcessedQuote[] = [];
+		const tokenSeen = new Set<string>();
+		let page = 1;
+		let hasMore = true;
+		while (hasMore && page <= MAX_ORDER_PAGES) {
+			const response = await apiGetOrdersByToken(token.address, { page, pageSize: 50 });
+			for (const order of response.orders) {
+				if (tokenSeen.has(order.orderHash)) continue;
+				tokenSeen.add(order.orderHash);
+				const quote = convertApiOrderToProcessedQuote(
+					order,
+					paymentToken.address,
+					allTokens,
+					networkId
 				);
+				if (quote) tokenQuotes.push(quote);
 			}
-		})
-	);
+			hasMore = response.pagination.hasMore;
+			page++;
+		}
+		if (hasMore) {
+			console.warn(
+				`[orders] Hit pagination cap (${MAX_ORDER_PAGES} pages) for token ${token.address}`
+			);
+		}
+		return tokenQuotes;
+	});
 
-	// Log any failed token fetches
 	for (const result of results) {
 		if (result.status === 'rejected') {
 			console.warn('[orders] Token fetch failed:', result.reason);
+			continue;
+		}
+		for (const quote of result.value) {
+			if (quote.orderHash && seen.has(quote.orderHash)) continue;
+			if (quote.orderHash) seen.add(quote.orderHash);
+			processedQuotes.push(quote);
 		}
 	}
 

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -7,7 +7,7 @@
 	import { erc20Abi, formatUnits, parseUnits } from 'viem';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onMount, onDestroy } from 'svelte';
-	import { createTokenOrderbookQuotesQuery, prefetchGlobalOrders } from '$lib/queries/orderbook';
+	import { createTokenOrderbookQuotesQuery } from '$lib/queries/orderbook';
 	import { walletRegistered, promptLogin } from '$lib/stores/accessStore';
 	import { openAuthModal } from '$lib/stores/dynamicStore';
 	import { normalizeAddress, parseFloatHex } from '$lib/utils/tokenMath';
@@ -116,9 +116,6 @@
 			token_selected: selectedToken?.symbol
 		});
 
-		if ($currentNetwork) {
-			prefetchGlobalOrders($currentNetwork.id).catch(console.warn);
-		}
 	});
 
 	// Track abandonment on unmount

--- a/src/lib/queries/oracleQuotes.ts
+++ b/src/lib/queries/oracleQuotes.ts
@@ -32,10 +32,10 @@ async function fetchSpymPrice(): Promise<{
 	}
 }
 
-export function createOracleQuotesQuery(network: Network | null) {
+export function createOracleQuotesQuery(network: Network | null, enabled: boolean = true) {
 	return createQuery<Record<string, OracleQuote>>({
 		queryKey: ['oracleQuotes', network?.id],
-		enabled: Boolean(network),
+		enabled: Boolean(enabled && network),
 		refetchInterval: 15_000,
 		queryFn: async () => {
 			if (!network) return {};

--- a/src/lib/queries/orderbook.ts
+++ b/src/lib/queries/orderbook.ts
@@ -114,6 +114,12 @@ export function getQuotesForToken(
 /** Minimum age (ms) of cached data before we re-fetch. Prevents redundant fetches. */
 const TOKEN_QUOTE_FRESHNESS_MS = 20_000;
 
+/** Dashboard global orderbook poll interval (keep in sync with staleTime). */
+export const GLOBAL_ORDERBOOK_POLL_MS = 30_000;
+
+/** Trade page per-token orderbook poll interval. */
+export const TOKEN_ORDERBOOK_POLL_MS = 15_000;
+
 /**
  * Fetch fresh quotes for a specific token and merge into global cache.
  * Only fetches the wrapped (primary) address on regular polls to reduce load.
@@ -257,7 +263,7 @@ export function createTokenOrderbookQuotesQuery(
 		staleTime: 30_000, // Stale after 30s (server caches at 15s)
 		retry: 2,
 		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
-		refetchOnMount: 'always', // Always refresh when component mounts
+		refetchOnMount: true, // Refetch on mount only when stale (respects staleTime)
 		refetchInterval: pollInterval, // Poll every 15s by default on trade pages
 		refetchOnWindowFocus: true, // Only refetch on focus if stale
 		refetchIntervalInBackground: false,
@@ -288,12 +294,23 @@ export function createTokenOrderbookQuotesQuery(
  */
 export function invalidateOrderQueries(networkId?: number, tokenAddress?: string) {
 	if (tokenAddress && networkId) {
-		// Token-specific: fetch fresh data for this token and merge
-		refreshTokenQuotes(networkId, tokenAddress).catch((err) =>
-			console.error('[OrderbookQueries] Token refresh failed:', err)
-		);
+		// Token-scoped: one orders/token flow (active queries refetch via queryFn)
+		queryClient.invalidateQueries({
+			queryKey: ['tokenOrderbookQuotes', networkId, tokenAddress]
+		});
+		// If no observer is mounted, still refresh cache for dashboard merge
+		if (
+			queryClient.getQueryCache().findAll({
+				queryKey: ['tokenOrderbookQuotes', networkId, tokenAddress],
+				type: 'active'
+			}).length === 0
+		) {
+			refreshTokenQuotes(networkId, tokenAddress).catch((err) =>
+				console.error('[OrderbookQueries] Token refresh failed:', err)
+			);
+		}
 	} else {
-		// Full invalidation: refetch entire global cache
+		// Full invalidation: refetch entire global cache (concurrency-limited in orders.ts)
 		queryClient.invalidateQueries({ queryKey: ['orderbookQuotes'] });
 	}
 	// Always invalidate closed orders query

--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -18,7 +18,8 @@ const WINDOW_SECONDS = 30 * 24 * 60 * 60; // 30 days
 export function createTokenTradeActivityQuery(
 	network: Network | null,
 	tokenAddress: string | null,
-	pollInterval: number = 300_000
+	pollInterval: number = 300_000,
+	enabled: boolean = true
 ) {
 	// Resolve to wrapped (primary) address — the SFT subgraph returns the unwrapped
 	// vault address, but trades are indexed by the wrapped ERC20 token address.
@@ -28,7 +29,7 @@ export function createTokenTradeActivityQuery(
 
 	return createQuery<TokenTradeActivityPayload>({
 		queryKey: ['tokenTradeActivity', network?.id, tokenAddress],
-		enabled: Boolean(network && primaryAddress),
+		enabled: Boolean(enabled && network && primaryAddress),
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
 		queryFn: async () => {
@@ -60,14 +61,15 @@ export function createTokenTradeActivityQuery(
 export function createBatchTradesQuery(
 	network: Network | null,
 	orderHashes: string[],
-	pollInterval: number = 600_000
+	pollInterval: number = 600_000,
+	enabled: boolean = true
 ) {
 	// Stable query key: sort hashes so order doesn't matter
 	const sortedKey = orderHashes.slice().sort().join(',');
 
 	return createQuery<Map<string, ApiTradeByAddress[]>>({
 		queryKey: ['batchTrades', network?.id, sortedKey],
-		enabled: Boolean(network && orderHashes.length > 0),
+		enabled: Boolean(enabled && network && orderHashes.length > 0),
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
 		queryFn: async () => {
@@ -88,11 +90,12 @@ export type TakerTradesPayload = {
 export function createTakerTradesQuery(
 	network: Network | null,
 	walletAddress: string | null,
-	pollInterval: number = 600_000
+	pollInterval: number = 600_000,
+	enabled: boolean = true
 ) {
 	return createQuery<TakerTradesPayload>({
 		queryKey: ['takerTrades', network?.id, walletAddress],
-		enabled: Boolean(network && walletAddress),
+		enabled: Boolean(enabled && network && walletAddress),
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
 		retry: 2,

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -294,7 +294,9 @@ export const handleStrategyDeployment = async (
 	// Immediate attempt before scheduling interval
 	const immediateLink = await tryFetchOrderLink();
 	if (immediateLink) {
-		invalidateOrderQueries();
+		if (assetTokenInfo?.address) {
+			invalidateOrderQueries(network.id, assetTokenInfo.address);
+		}
 		invalidateDashboardBalances();
 		return transactionSuccess(hash, undefined, buildMetadata(immediateLink));
 	}
@@ -314,7 +316,9 @@ export const handleStrategyDeployment = async (
 			// Stop polling after max attempts.
 			if (attempts >= maxAttempts) {
 				clearInterval(interval);
-				invalidateOrderQueries();
+				if (assetTokenInfo?.address) {
+					invalidateOrderQueries(network.id, assetTokenInfo.address);
+				}
 				invalidateDashboardBalances();
 				transactionSuccess(hash, 'Order deployed successfully!', buildMetadata());
 				return;
@@ -323,7 +327,9 @@ export const handleStrategyDeployment = async (
 			const link = await tryFetchOrderLink();
 			if (link) {
 				clearInterval(interval);
-				invalidateOrderQueries();
+				if (assetTokenInfo?.address) {
+					invalidateOrderQueries(network.id, assetTokenInfo.address);
+				}
 				invalidateDashboardBalances();
 				transactionSuccess(hash, undefined, buildMetadata(link));
 			}

--- a/src/lib/utils/mapWithConcurrency.ts
+++ b/src/lib/utils/mapWithConcurrency.ts
@@ -1,0 +1,29 @@
+/**
+ * Run async tasks over items with a maximum number in flight.
+ * Prevents bursting the API when many tokens are fetched in parallel.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: T[],
+	concurrency: number,
+	fn: (item: T, index: number) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+	if (items.length === 0) return [];
+	const limit = Math.max(1, Math.min(concurrency, items.length));
+	const results: PromiseSettledResult<R>[] = new Array(items.length);
+	let nextIndex = 0;
+
+	async function worker(): Promise<void> {
+		while (nextIndex < items.length) {
+			const index = nextIndex++;
+			try {
+				const value = await fn(items[index], index);
+				results[index] = { status: 'fulfilled', value };
+			} catch (reason) {
+				results[index] = { status: 'rejected', reason };
+			}
+		}
+	}
+
+	await Promise.all(Array.from({ length: limit }, () => worker()));
+	return results;
+}

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -35,7 +35,7 @@
 		getMakerOutputTokenAddress
 	} from '$lib/types/orderPerspective';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
-	import { createOrderbookQuotesQuery } from '$lib/queries/orderbook';
+	import { createOrderbookQuotesQuery, GLOBAL_ORDERBOOK_POLL_MS } from '$lib/queries/orderbook';
 	import { createUserVaultsQuery } from '$lib/queries/vaults';
 	import { createTakerTradesQuery, createBatchTradesQuery } from '$lib/queries/tradeActivity';
 	import { createCostBasisQuery } from '$lib/queries/costBasis';
@@ -927,7 +927,7 @@
 	})();
 
 	// Orders: Fetch orderbook quotes for all tokens
-	$: orderbookQuotesQuery = createOrderbookQuotesQuery($currentNetwork, 15_000);
+	$: orderbookQuotesQuery = createOrderbookQuotesQuery($currentNetwork, GLOBAL_ORDERBOOK_POLL_MS);
 
 	// Taker trades for market orders - poll every 10 minutes
 	$: takerTradesQuery = createTakerTradesQuery($currentNetwork, $walletAddress, 600_000);

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -49,8 +49,8 @@
 	type ResourceStatus = 'idle' | 'loading' | 'ready' | 'error';
 	import {
 		createTokenOrderbookQuotesQuery,
-		prefetchGlobalOrders,
 		refreshLegacyTokenQuotes,
+		TOKEN_ORDERBOOK_POLL_MS,
 		type OrderbookQuoteCache
 	} from '$lib/queries/orderbook';
 	import type { QueryObserverResult } from '@tanstack/query-core';
@@ -84,48 +84,65 @@
 	import { addTokenToWallet } from '$lib/utils/walletUtils';
 	$: tokenId = $page.params.id;
 
+	const SECONDARY_QUERIES_DELAY_MS = 1_500;
+
 	// Hide track in wallet buttons for embedded wallets
 	$: isEmbeddedWallet = $authMethod === 'dynamic' && $dynamicSession?.walletType === 'embedded';
+
+	// Config lookup is synchronous — do not block the page on subgraph SFT metadata
+	$: currentPythToken = (() => {
+		if (!tokenId || !$currentNetwork?.chainId) return undefined;
+		const match = getTokenByAnyAddress(tokenId);
+		return match?.chainId === $currentNetwork.chainId ? match : undefined;
+	})();
 
 	// Get queryClient for cache lookup
 	const queryClient = useQueryClient();
 
-	// Use single token query - checks global cache first, falls back to single fetch
+	// Subgraph SFT enriches supply/mints tabs; trading UI uses currentPythToken from config
 	$: singleTokenQuery = createSingleSftQuery(tokenId, $currentNetwork, queryClient);
 	$: currentToken = $singleTokenQuery.data;
-	const tokensLookup = createTokenLookup(TOKENS);
-	let orderbookQuotesQuery = createTokenOrderbookQuotesQuery(
-		$currentNetwork,
-		currentToken?.address ?? null
-	);
-	let tokenTradeQuery = createTokenTradeActivityQuery(
-		$currentNetwork,
-		currentToken?.address ?? null
-	);
-	let oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
-	$: {
-		orderbookQuotesQuery = createTokenOrderbookQuotesQuery(
-			$currentNetwork,
-			currentToken?.address ?? null
-		);
-		tokenTradeQuery = createTokenTradeActivityQuery($currentNetwork, currentToken?.address ?? null);
-		oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
-	}
+	$: tradeTokenAddress = currentPythToken?.address ?? currentToken?.address ?? null;
 
-	// One-shot: fetch legacy address quotes once per token
+	const tokensLookup = createTokenLookup(TOKENS);
+
+	let loadSecondaryQueries = false;
+
+	$: orderbookQuotesQuery = createTokenOrderbookQuotesQuery(
+		$currentNetwork,
+		tradeTokenAddress,
+		TOKEN_ORDERBOOK_POLL_MS
+	);
+
+	$: tokenTradeQuery = createTokenTradeActivityQuery(
+		$currentNetwork,
+		tradeTokenAddress,
+		300_000,
+		loadSecondaryQueries
+	);
+
+	$: oracleQuotesQuery = createOracleQuotesQuery($currentNetwork, loadSecondaryQueries);
+
+	// One-shot: legacy orderbook address after primary book + secondary defer
 	let legacyQuotesFetchedFor: string | null = null;
 	$: if (
 		browser &&
+		loadSecondaryQueries &&
 		$currentNetwork &&
-		currentToken?.address &&
-		legacyQuotesFetchedFor !== currentToken.address
+		tradeTokenAddress &&
+		legacyQuotesFetchedFor !== tradeTokenAddress
 	) {
-		legacyQuotesFetchedFor = currentToken.address;
-		refreshLegacyTokenQuotes($currentNetwork.id, currentToken.address).catch(() => {});
+		legacyQuotesFetchedFor = tradeTokenAddress;
+		refreshLegacyTokenQuotes($currentNetwork.id, tradeTokenAddress).catch(() => {});
 	}
 
-	// Taker trades for market orders (user's executed trades)
-	$: takerTradesQuery = createTakerTradesQuery($currentNetwork, $walletAddress, 600_000);
+	// Taker trades for market orders (user's executed trades) — deferred to reduce load burst
+	$: takerTradesQuery = createTakerTradesQuery(
+		$currentNetwork,
+		$walletAddress,
+		600_000,
+		loadSecondaryQueries
+	);
 
 	// Transform taker trades into display orders (filtered to current token)
 	$: userMarketOrders = (() => {
@@ -149,17 +166,22 @@
 	})();
 
 	// Fetch batch trades for user's orders on this token
-	$: batchTradesQuery = createBatchTradesQuery($currentNetwork, userOrderHashesForToken, 600_000);
+	$: batchTradesQuery = createBatchTradesQuery(
+		$currentNetwork,
+		userOrderHashesForToken,
+		600_000,
+		loadSecondaryQueries
+	);
 
 	// Transform quotes and market orders into DisplayOrder format for OrdersTable
 	// Note: Filtering by owner/type and closed orders are handled by OrdersTable component
 	$: tokenOrders = (() => {
 		const displayOrders: DisplayOrder[] = [];
-		const tokenAddress = currentToken?.address?.toLowerCase() ?? '';
+		const tokenAddress = tradeTokenAddress?.toLowerCase() ?? '';
 		const tradesMap = $batchTradesQuery?.data;
 
 		// Add limit orders from quotes (for current token only; match wrapped or legacy address)
-		if (currentToken?.address && $orderbookQuotesQuery.data?.quotes) {
+		if (tradeTokenAddress && $orderbookQuotesQuery.data?.quotes) {
 			const quotes = $orderbookQuotesQuery.data.quotes;
 
 			// Filter by token (input or output matches current token's wrapped or legacy address)
@@ -227,41 +249,29 @@
 	// User vaults query - no polling, invalidated after order deployment
 	$: userVaultsQuery = createUserVaultsQuery($currentNetwork, $walletAddress);
 
-	// Background prefetch of global caches when page loads
+	// Background prefetch user vaults when wallet is connected
 	$: if (browser && $currentNetwork && $walletAddress) {
-		// Prefetch global orders and vaults in background (non-blocking)
-		prefetchGlobalOrders($currentNetwork.id).catch(() => {});
 		prefetchUserVaults($currentNetwork.id, $walletAddress).catch(() => {});
 	}
 
 	// Wallet balance query for this token
 	$: walletBalanceQuery = createQuery({
-		queryKey: ['walletBalance', $currentNetwork?.id, currentToken?.address, $walletAddress],
+		queryKey: ['walletBalance', $currentNetwork?.id, tradeTokenAddress, $walletAddress],
 		queryFn: async () => {
-			if (!currentToken?.address || !$walletAddress || !$wagmiConfig) {
+			if (!tradeTokenAddress || !$walletAddress || !$wagmiConfig) {
 				return 0n;
 			}
 			const balance = await readContract($wagmiConfig, {
 				abi: erc20Abi,
-				address: currentToken.address as `0x${string}`,
+				address: tradeTokenAddress as `0x${string}`,
 				functionName: 'balanceOf',
 				args: [$walletAddress as `0x${string}`]
 			});
 			return balance as bigint;
 		},
-		enabled: Boolean(currentToken?.address && $walletAddress && $wagmiConfig)
+		enabled: Boolean(tradeTokenAddress && $walletAddress && $wagmiConfig)
 	});
-	// Use tokenId from URL params to find the token config (supports wrapped, legacy, or unwrapped address)
-	// Note: currentToken.address from subgraph may differ from the wrapped token address
-	$: currentPythToken = (() => {
-		if (!tokenId || !$currentNetwork?.chainId) return undefined;
-		// DRIFT-01: getTokenByAnyAddress already matches wrapped/unwrapped/legacy
-		// address variants (and the wrapped-address path is a strict subset of
-		// what it covers), so the previous two-step lookup collapses to one call.
-		const match = getTokenByAnyAddress(tokenId);
-		return match?.chainId === $currentNetwork.chainId ? match : undefined;
-	})();
-	$: baseSymbol = extractBaseSymbol(currentToken?.symbol);
+	$: baseSymbol = extractBaseSymbol(currentPythToken?.symbol ?? currentToken?.symbol);
 	$: tradingViewSymbol = currentPythToken?.tradingViewSymbol ?? baseSymbol;
 	const ASSET_TABS = [
 		{ id: 'company', label: 'Company Info' },
@@ -588,10 +598,14 @@
 	}
 
 	onMount(() => {
-		// Initialize scroll tracking
 		cleanupScrollTracking = initScrollTracking('trade_page');
 
+		const secondaryTimer = setTimeout(() => {
+			loadSecondaryQueries = true;
+		}, SECONDARY_QUERIES_DELAY_MS);
+
 		return () => {
+			clearTimeout(secondaryTimer);
 			if (cleanupScrollTracking) {
 				cleanupScrollTracking();
 			}
@@ -614,6 +628,15 @@
 	function openChartModal(event?: Event) {
 		event?.stopPropagation?.();
 		showChartModal = true;
+	}
+	function handleAddTokenToWallet() {
+		if (!tradeTokenAddress || !currentPythToken) return;
+		addTokenToWallet({
+			address: tradeTokenAddress,
+			symbol: tokenDisplaySymbol || currentPythToken.symbol,
+			decimals: currentPythToken.decimals ?? 18,
+			image: currentPythToken.logoUrl
+		});
 	}
 	const closeTradePanel = () => {
 		panelOpenedFromTerminal = false;
@@ -666,7 +689,7 @@
 		sellPrice = null;
 	};
 	$: {
-		if (!browser || !currentToken || !$currentNetwork) {
+		if (!browser || !tradeTokenAddress || !$currentNetwork) {
 			resetOnChainPrices();
 		} else {
 			const settlementToken = $currentNetwork.defaultPaymentToken;
@@ -711,10 +734,10 @@
 		}
 	}
 	$: tradeHistoryPoints = (() => {
-		if (!browser || !currentToken || !$currentNetwork) return [];
+		if (!browser || !tradeTokenAddress || !$currentNetwork) return [];
 		const settlementToken = $currentNetwork.defaultPaymentToken;
 		if (!settlementToken) return [];
-		const assetAddress = (currentPythToken?.address ?? currentToken.address)?.toLowerCase();
+		const assetAddress = (currentPythToken?.address ?? currentToken?.address)?.toLowerCase();
 		const quoteAddress = settlementToken.address?.toLowerCase();
 		if (!assetAddress || !quoteAddress) return [];
 		const _assetDecimals = Number(currentPythToken?.decimals ?? 18);
@@ -800,7 +823,7 @@
 		tradeVolumeBuckets = tradesToVolumeBuckets(visibleTradeHistoryPoints, candleBucketSeconds);
 	}
 	$: orderbookDepth = (() => {
-		if (!currentToken || !$currentNetwork) return { bids: [], asks: [] };
+		if (!tradeTokenAddress || !$currentNetwork) return { bids: [], asks: [] };
 		const quotes = $orderbookQuotesQuery?.data?.quotes ?? [];
 		if (!quotes.length) {
 			return { bids: [], asks: [] };
@@ -882,8 +905,9 @@
 				? formatResourceError(tradeResource?.error, 'Failed to load trade history.')
 				: null;
 	}
-	$: tokenDisplayName = currentToken?.name ?? currentToken?.symbol ?? 'Token';
-	$: tokenDisplaySymbol = currentToken?.symbol ?? '';
+	$: tokenDisplayName =
+		currentToken?.name ?? currentPythToken?.name ?? currentPythToken?.symbol ?? 'Token';
+	$: tokenDisplaySymbol = currentToken?.symbol ?? currentPythToken?.symbol ?? '';
 	$: pageTitle = `Trade ${tokenDisplayName}`;
 	$: modalTitle = tokenDisplaySymbol
 		? `Advanced Chart — ${tokenDisplayName} (${tokenDisplaySymbol})`
@@ -897,26 +921,28 @@
 	<title>{pageTitle}</title>
 </svelte:head>
 <svelte:window on:keydown={handleGlobalKeydown} />
-{#if $singleTokenQuery.isPending}
-	<div class="flex h-screen items-center justify-center">
-		<LoadingSpinner variant="fullscreen" size="xl" text="Loading token data..." />
-	</div>
-{:else if $singleTokenQuery.isError}
-	<div class="flex h-screen items-center justify-center">
-		<div class="text-center">
-			<p class="text-lg text-red-400">Failed to load token data</p>
-			<p class="mt-2 text-sm text-gray-400">
-				{$singleTokenQuery.error?.message || 'Unknown error'}
-			</p>
+{#if !currentPythToken}
+	{#if $singleTokenQuery.isPending}
+		<div class="flex h-screen items-center justify-center">
+			<LoadingSpinner variant="fullscreen" size="xl" text="Loading token data..." />
 		</div>
-	</div>
-{:else if !currentToken}
-	<div class="flex h-screen items-center justify-center">
-		<div class="text-center">
-			<p class="text-lg text-gray-400">Token not found</p>
-			<p class="mt-2 text-sm text-gray-500">ID: {tokenId}</p>
+	{:else if $singleTokenQuery.isError}
+		<div class="flex h-screen items-center justify-center">
+			<div class="text-center">
+				<p class="text-lg text-red-400">Failed to load token data</p>
+				<p class="mt-2 text-sm text-gray-400">
+					{$singleTokenQuery.error?.message || 'Unknown error'}
+				</p>
+			</div>
 		</div>
-	</div>
+	{:else}
+		<div class="flex h-screen items-center justify-center">
+			<div class="text-center">
+				<p class="text-lg text-gray-400">Token not found</p>
+				<p class="mt-2 text-sm text-gray-500">ID: {tokenId}</p>
+			</div>
+		</div>
+	{/if}
 {:else}
 	<div class="space-y-4 p-3 sm:space-y-6 sm:p-6">
 		<!-- Header Section with Chart -->
@@ -1062,7 +1088,7 @@
 								<TradingViewWidget
 									widgetType="symbol-overview"
 									symbol={tradingViewSymbol}
-									displayName={currentToken.name || currentToken.symbol}
+									displayName={tokenDisplayName}
 									dateRange="1D"
 									showVolume={false}
 									autosize={false}
@@ -1074,7 +1100,7 @@
 								<TradingViewWidget
 									widgetType="symbol-overview"
 									symbol={tradingViewSymbol}
-									displayName={currentToken.name || currentToken.symbol}
+									displayName={tokenDisplayName}
 									dateRange="1D"
 									showVolume={false}
 									autosize={false}
@@ -1121,13 +1147,7 @@
 						{#if $isAuthenticated && !isEmbeddedWallet}
 							<button
 								type="button"
-								on:click={() =>
-									addTokenToWallet({
-										address: currentToken.address,
-										symbol: currentToken.symbol,
-										decimals: 18,
-										image: currentPythToken?.logoUrl
-									})}
+								on:click={handleAddTokenToWallet}
 								class="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs font-medium text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300 sm:gap-2 sm:px-3 sm:py-2 sm:text-sm"
 							>
 								<!-- Wallet icon (mobile only) -->
@@ -1217,7 +1237,7 @@
 								isLoading={$orderbookQuotesQuery.isLoading}
 								isError={$orderbookQuotesQuery.isError}
 								errorMessage={$orderbookQuotesQuery.error?.message ?? ''}
-								tokenAddress={currentToken?.address ?? null}
+								tokenAddress={tradeTokenAddress}
 								showTokenColumn={false}
 							/>
 						</div>
@@ -1240,13 +1260,13 @@
 								</div>
 							{:else}
 								{@const allVaultData = $userVaultsQuery.data?.pages?.flatMap((p) => p.vaults) ?? []}
-								{@const vaults = currentToken
+								{@const vaults = tradeTokenAddress
 									? allVaultData
 											.map((vd) => vd.raindexVault)
 											.filter((v) => {
 												const vaultTokenAddr = (v.token?.address ?? v.token?.id)?.toLowerCase();
 												const isCorrectToken =
-													vaultTokenAddr === currentToken.address.toLowerCase();
+													vaultTokenAddr === tradeTokenAddress.toLowerCase();
 												const hasBalance = vaultBalanceToBigInt(v) > 0n;
 												return isCorrectToken && hasBalance;
 											})
@@ -1477,7 +1497,7 @@
 								</div>
 								<div class="flex justify-between">
 									<span class="text-gray-400">Symbol</span>
-									<span>{currentPythToken?.symbol ?? currentToken.symbol}</span>
+									<span>{tokenDisplaySymbol}</span>
 								</div>
 								<div class="flex justify-between">
 									<span class="text-gray-400">Decimals</span>
@@ -1492,6 +1512,9 @@
 							</div>
 						</div>
 					{:else if activeTokenTab === 'supply'}
+						{#if !currentToken}
+							<LoadingSpinner variant="inline" size="md" text="Loading on-chain supply data…" />
+						{:else}
 						<div>
 							<h3 class="mb-3 font-semibold">Supply & Distribution</h3>
 							<div class="space-y-3 text-sm">
@@ -1509,7 +1532,11 @@
 								</div>
 							</div>
 						</div>
+						{/if}
 					{:else if activeTokenTab === 'mints'}
+						{#if !currentToken}
+							<LoadingSpinner variant="inline" size="md" text="Loading mint history…" />
+						{:else}
 						<div>
 							<div class="mb-2 flex items-center justify-between">
 								<h3 class="font-semibold">Latest Mints</h3>
@@ -1553,7 +1580,11 @@
 								<div class="text-sm text-gray-400">No recent mints.</div>
 							{/if}
 						</div>
+						{/if}
 					{:else}
+						{#if !currentToken}
+							<LoadingSpinner variant="inline" size="md" text="Loading burn history…" />
+						{:else}
 						<div>
 							<div class="mb-2 flex items-center justify-between">
 								<h3 class="font-semibold">Latest Burns</h3>
@@ -1597,6 +1628,7 @@
 								<div class="text-sm text-gray-400">No recent burns.</div>
 							{/if}
 						</div>
+						{/if}
 					{/if}
 				</div>
 				<!-- Underlying Equity (Right) -->

--- a/tests/lib/utils/mapWithConcurrency.test.ts
+++ b/tests/lib/utils/mapWithConcurrency.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { mapWithConcurrency } from '$lib/utils/mapWithConcurrency';
+
+describe('mapWithConcurrency', () => {
+	it('runs all items and preserves order', async () => {
+		const results = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => n * 2);
+		expect(results.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([
+			2, 4, 6, 8, 10
+		]);
+	});
+
+	it('records rejections without stopping other tasks', async () => {
+		const results = await mapWithConcurrency([1, 2, 3], 2, async (n) => {
+			if (n === 2) throw new Error('fail');
+			return n;
+		});
+		expect(results[0]).toEqual({ status: 'fulfilled', value: 1 });
+		expect(results[1].status).toBe('rejected');
+		expect(results[2]).toEqual({ status: 'fulfilled', value: 3 });
+	});
+});


### PR DESCRIPTION
## Summary

Addresses backend load from burst `GET /api/st0x/v1/orders/token/*` traffic (complements server-side caching).

### Request shaping
- **`mapWithConcurrency`** — global orderbook loads at most **4** `orders/token` requests in parallel (was ~14 at once) via `fetchAndQuotePaymentTokenOrders`.
- **Quick Trade (home)** — removed `prefetchGlobalOrders()` on mount (was triggering a full multi-token sweep).
- **Dashboard** — global orderbook poll **15s → 30s** (`GLOBAL_ORDERBOOK_POLL_MS`).
- **Deploy success** — `invalidateOrderQueries(networkId, assetAddress)` only (no full-network refetch).

### Trade page
- Render from static **`tokens.ts`** (`currentPythToken`) immediately; subgraph only for supply/mints/burns tabs.
- Removed global orderbook prefetch when wallet connects.
- **Defer 1.5s** before taker trades, oracle quotes, trade activity, batch trades, and legacy quotes.
- Single reactive `createTokenOrderbookQuotesQuery` (no reassignment loop); `refetchOnMount: true` (respects stale cache).

## Test plan

- [ ] Network tab on `/dashboard`: at most ~4 concurrent `orders/token` requests, then rest; repeats ~every 30s not 15s.
- [ ] Network tab on `/`: no wall of `orders/token` on load (Quick Trade uses selected token only).
- [ ] `/trade/<addr>`: page paints without waiting on subgraph; one primary `orders/token` flow; secondary calls after ~1.5s.
- [ ] Deploy limit/DCA: only one token’s book refreshes, not all tokens.
- [ ] `npm run check`
- [ ] `npm test -- tests/lib/utils/mapWithConcurrency.test.ts --run`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate order data appearing in global order book across tokens.

* **New Features**
  * Trade page now defers secondary market queries for faster initial load.

* **Performance**
  * Optimized global order book loading with controlled concurrent requests.
  * Adjusted polling intervals: 30 seconds for dashboard, 15 seconds for trade pages.
  * Improved order query scoping to reduce unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->