### PR TITLE
fix(tokens): use AMEX:SPYM for wtSPYM TradingView chart

### DIFF
--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -161,7 +161,7 @@ export const TOKENS: CategorizedToken[] = [
 		// Using a hardcoded fallback until a replacement feed is wired up.
 		fallbackPrice: 82.5,
 		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SPLG',
+		tradingViewSymbol: 'AMEX:SPYM',
 		tradingViewMarket: 'america',
 		limitOrders: []
 	},


### PR DESCRIPTION
## Summary

- Updates `wtSPYM` `tradingViewSymbol` from `AMEX:SPLG` to `AMEX:SPYM`.
- The State Street SPDR Portfolio S&P 500 ETF renamed its ticker from SPLG to SPYM (effective Oct 31, 2025). TradingView no longer serves chart data for the old symbol, which caused the trade page symbol-overview widget to show "No data here yet".

## Test plan

- [ ] Open `/trade/0x31C2C14134e6E3B7ef9478297F199331133Fc2d8` (wtSPYM) and confirm the TradingView chart loads with price history.
- [ ] Open another token trade page (e.g. wtNVDA) and confirm charts still work.
- [ ] Open Advanced Chart modal and confirm full TradingView widget loads for wtSPYM.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the trading symbol mapping for the wtSPYM token to ensure accurate market data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->