### PR TITLE
fix(ui): reduce homepage initial request load

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -7,7 +7,7 @@
 	import { erc20Abi, formatUnits, parseUnits } from 'viem';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onMount, onDestroy } from 'svelte';
-	import { createTokenOrderbookQuotesQuery, prefetchGlobalOrders } from '$lib/queries/orderbook';
+	import { createTokenOrderbookQuotesQuery } from '$lib/queries/orderbook';
 	import { walletRegistered, promptLogin } from '$lib/stores/accessStore';
 	import { openAuthModal } from '$lib/stores/dynamicStore';
 	import { normalizeAddress, parseFloatHex } from '$lib/utils/tokenMath';
@@ -108,17 +108,13 @@
 	$: isLoadingQuotes = $orderbookQuery.isPending && !$orderbookQuery.data;
 	$: quoteFetchError = $orderbookQuery.isError;
 
-	// On mount: analytics + background prefetch of all tokens
+	// On mount: analytics only. The selected-token query above fetches the visible quote data.
 	onMount(() => {
 		panelOpenTime = Date.now();
 		track('quick_trade_panel_viewed', {
 			has_wallet: Boolean($walletAddress),
 			token_selected: selectedToken?.symbol
 		});
-
-		if ($currentNetwork) {
-			prefetchGlobalOrders($currentNetwork.id).catch(console.warn);
-		}
 	});
 
 	// Track abandonment on unmount

--- a/src/lib/queries/oracleQuotes.ts
+++ b/src/lib/queries/oracleQuotes.ts
@@ -1,4 +1,5 @@
 import { createQuery } from '@tanstack/svelte-query';
+import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
 import { TOKENS, CRYPTO_TOKENS } from '$lib/config/network';
 import { getNetworkOracleSnapshots, type OracleSnapshot } from '$lib/api/pyth';
@@ -35,7 +36,7 @@ async function fetchSpymPrice(): Promise<{
 export function createOracleQuotesQuery(network: Network | null) {
 	return createQuery<Record<string, OracleQuote>>({
 		queryKey: ['oracleQuotes', network?.id],
-		enabled: Boolean(network),
+		enabled: Boolean(browser && network),
 		refetchInterval: 15_000,
 		queryFn: async () => {
 			if (!network) return {};

--- a/src/lib/queries/priceFeeds.ts
+++ b/src/lib/queries/priceFeeds.ts
@@ -1,4 +1,5 @@
 import { createQuery } from '@tanstack/svelte-query';
+import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
 import { TOKENS } from '$lib/config/network';
 import { getPythQuotes } from '$lib/api/pyth';
@@ -39,7 +40,7 @@ async function fetchSpymQuote(network: Network): Promise<TradingViewQuote | null
 export function createPriceFeedsQuery(network: Network | null) {
 	return createQuery<TradingViewQuote[]>({
 		queryKey: ['priceFeeds', network?.id],
-		enabled: Boolean(network),
+		enabled: Boolean(browser && network),
 		refetchInterval: 15_000,
 		queryFn: async () => {
 			const net = network as Network;

--- a/src/lib/queries/vaults.ts
+++ b/src/lib/queries/vaults.ts
@@ -4,6 +4,7 @@ import {
 	type QueryClient,
 	type InfiniteData
 } from '@tanstack/svelte-query';
+import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
 import { getSfts, getSftById } from '$lib/api/subgraph';
 import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
@@ -18,7 +19,7 @@ import type { RaindexVault, SgVault } from '@rainlanguage/orderbook';
 export function createSftsQuery(network: Network | null) {
 	return createQuery<OffchainAssetReceiptVault[]>({
 		queryKey: ['sfts', network?.id],
-		enabled: Boolean(network?.subgraph_url),
+		enabled: Boolean(browser && network?.subgraph_url),
 		staleTime: Infinity,
 		refetchInterval: false,
 		queryFn: () => getSfts(network as Network)


### PR DESCRIPTION
## Summary

- Stop QuickTrade on the homepage from prefetching every ST0x token orderbook on mount; the visible selected-token quote still loads normally.
- Gate price feed, oracle quote, and SFT queries to the browser so they do not issue eager fetches during SSR.
- Keeps trade-page/background orderbook behavior unchanged while reducing landing-page request volume.

## Benchmark

- Before: homepage reload showed the SSR eager-fetch warning, `/` request latency around 4.75s-4.97s locally, and an initial burst across token order endpoints.
- After: warm homepage reload served `/` in about 28-32ms locally and issued only one selected-token `/api/st0x/v1/orders/token/...` request.

## Test plan

- [x] Open `/` locally and confirm initial order calls drop to one selected-token request.
- [x] Warm reload `/` locally and confirm server latency is ~28-32ms.
- [x] Confirm SSR eager-fetch warning is gone after browser-gating client queries.
- [ ] `npm run check` (blocked: existing missing `@playwright/test` types in `node_modules` cause integration test type errors).

Made with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary background order data prefetching on component load.

* **Performance**
  * Optimized multiple data-fetching operations to execute only in browser environments, improving server-side rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->