### PR TITLE
perf(ui): defer homepage load work

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -7,23 +7,46 @@
 	import { erc20Abi, formatUnits, parseUnits } from 'viem';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onMount, onDestroy } from 'svelte';
-	import { createTokenOrderbookQuotesQuery } from '$lib/queries/orderbook';
+	import { browser } from '$app/environment';
+	import type { OrderbookQuoteCache } from '$lib/queries/orderbook';
 	import { walletRegistered, promptLogin } from '$lib/stores/accessStore';
 	import { openAuthModal } from '$lib/stores/dynamicStore';
-	import { normalizeAddress, parseFloatHex } from '$lib/utils/tokenMath';
 	import type { ProcessedQuote } from '$lib/utils/orderbook';
 	import {
 		getMakerInputTokenAddress,
 		getMakerOutputTokenAddress
 	} from '$lib/types/orderPerspective';
 	import Button from './ui/Button.svelte';
-	import {
-		executeMarketOrder,
-		filterQuotesForSide,
-		sortQuotesByPrice
-	} from '$lib/services/marketOrderExecution';
 	import { isOutsideMarketHours } from '$lib/utils/marketHours';
 	import { track } from '$lib/services/analytics';
+
+	type ParseFloatHex = typeof import('$lib/utils/tokenMath').parseFloatHex;
+
+	let parseFloatHexFn: ParseFloatHex | null = null;
+	let parseFloatVersion = 0;
+	let parseFloatImportPromise: Promise<ParseFloatHex> | null = null;
+
+	function normalizeAddress(value: string | null | undefined): string | null {
+		const trimmed = value?.trim();
+		return trimmed ? trimmed.toLowerCase() : null;
+	}
+
+	function loadParseFloatHex(): Promise<ParseFloatHex> {
+		parseFloatImportPromise ??= import('$lib/utils/tokenMath').then((mod) => {
+			parseFloatHexFn = mod.parseFloatHex;
+			parseFloatVersion += 1;
+			return mod.parseFloatHex;
+		});
+		return parseFloatImportPromise;
+	}
+
+	function parseQuoteFloat(hexAmount: string, decimals: number): bigint {
+		if (!parseFloatHexFn) {
+			void loadParseFloatHex();
+			return 0n;
+		}
+		return parseFloatHexFn(hexAmount, decimals);
+	}
 
 	// Analytics tracking
 	let panelOpenTime = Date.now();
@@ -103,7 +126,24 @@
 	$: paymentToken = $currentNetwork?.defaultPaymentToken;
 
 	// TanStack Query for quotes — polls every 15s, retries on failure, preserves stale data
-	$: orderbookQuery = createTokenOrderbookQuotesQuery($currentNetwork, selectedTokenAddress);
+	$: orderbookQuery = createQuery<OrderbookQuoteCache>({
+		queryKey: ['tokenOrderbookQuotes', $currentNetwork?.id, selectedTokenAddress],
+		enabled: browser && Boolean($currentNetwork && selectedTokenAddress),
+		staleTime: 30_000,
+		retry: 2,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
+		refetchOnMount: 'always',
+		refetchInterval: 15_000,
+		refetchOnWindowFocus: true,
+		refetchIntervalInBackground: false,
+		queryFn: async () => {
+			if (!browser || !$currentNetwork || !selectedTokenAddress) {
+				return { summary: {}, quotes: [] };
+			}
+			const { refreshTokenQuotes } = await import('$lib/queries/orderbook');
+			return refreshTokenQuotes($currentNetwork.id, selectedTokenAddress);
+		}
+	});
 	$: quotes = $orderbookQuery.data?.quotes ?? [];
 	$: isLoadingQuotes = $orderbookQuery.isPending && !$orderbookQuery.data;
 	$: quoteFetchError = $orderbookQuery.isError;
@@ -221,6 +261,7 @@
 	// ============ MAX LIQUIDITY CALCULATION ============
 	// Calculate maximum USDC that can be spent when buying
 	$: maxBuyUsdcAvailable = (() => {
+		parseFloatVersion;
 		if (askQuotes.length === 0 || !selectedToken || !paymentToken) return 0;
 		let totalUsdc = 0n;
 		const paymentDecimals = paymentToken.decimals ?? 6;
@@ -232,7 +273,7 @@
 			let maxAssetAvailable = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? assetDecimals;
-				maxAssetAvailable = parseFloatHex(q.maxOutput, outputDecimals);
+				maxAssetAvailable = parseQuoteFloat(q.maxOutput, outputDecimals);
 			}
 			if (maxAssetAvailable <= 0n) continue;
 			const usdcForQuote = BigInt(
@@ -245,6 +286,7 @@
 
 	// Calculate maximum tokens that can be bought (sum of ask maxOutput)
 	$: maxBuyTokensAvailable = (() => {
+		parseFloatVersion;
 		if (askQuotes.length === 0 || !selectedToken) return 0;
 		let totalTokens = 0n;
 		const assetDecimals = selectedToken.decimals ?? 18;
@@ -253,7 +295,7 @@
 			let maxAssetAvailable = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? assetDecimals;
-				maxAssetAvailable = parseFloatHex(q.maxOutput, outputDecimals);
+				maxAssetAvailable = parseQuoteFloat(q.maxOutput, outputDecimals);
 				if (outputDecimals !== assetDecimals) {
 					const scale = 10n ** BigInt(Math.abs(assetDecimals - outputDecimals));
 					maxAssetAvailable =
@@ -267,6 +309,7 @@
 
 	// Calculate maximum tokens that can be sold
 	$: maxSellTokensAvailable = (() => {
+		parseFloatVersion;
 		if (bidQuotes.length === 0 || !selectedToken || !paymentToken) return 0;
 		let totalTokens = 0n;
 		const paymentDecimals = paymentToken.decimals ?? 6;
@@ -278,7 +321,7 @@
 			let maxUsdcFromBid = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? paymentDecimals;
-				maxUsdcFromBid = parseFloatHex(q.maxOutput, outputDecimals);
+				maxUsdcFromBid = parseQuoteFloat(q.maxOutput, outputDecimals);
 			}
 			if (maxUsdcFromBid <= 0n) continue;
 			const tokensForBid = BigInt(
@@ -291,6 +334,7 @@
 
 	// Calculate maximum USDC that can be received when selling (sum of bid maxOutput)
 	$: maxSellUsdcAvailable = (() => {
+		parseFloatVersion;
 		if (bidQuotes.length === 0 || !paymentToken) return 0;
 		let totalUsdc = 0n;
 		const paymentDecimals = paymentToken.decimals ?? 6;
@@ -299,7 +343,7 @@
 			let maxUsdcFromBid = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? paymentDecimals;
-				maxUsdcFromBid = parseFloatHex(q.maxOutput, outputDecimals);
+				maxUsdcFromBid = parseQuoteFloat(q.maxOutput, outputDecimals);
 				if (outputDecimals !== paymentDecimals) {
 					const scale = 10n ** BigInt(Math.abs(paymentDecimals - outputDecimals));
 					maxUsdcFromBid =
@@ -312,15 +356,18 @@
 	})();
 
 	// ============ QUOTE CALCULATION ============
-	$: quote = computeQuote(
-		isBuying,
-		lastEditedField,
-		topAmount,
-		bottomAmount,
-		askQuotes,
-		bidQuotes,
-		selectedToken,
-		paymentToken
+	$: quote = (
+		parseFloatVersion,
+		computeQuote(
+			isBuying,
+			lastEditedField,
+			topAmount,
+			bottomAmount,
+			askQuotes,
+			bidQuotes,
+			selectedToken,
+			paymentToken
+		)
 	);
 
 	$: syncOtherField(quote, lastEditedField);
@@ -471,7 +518,7 @@
 			let maxAssetAvailable = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? assetDecimals;
-				maxAssetAvailable = parseFloatHex(q.maxOutput, outputDecimals);
+				maxAssetAvailable = parseQuoteFloat(q.maxOutput, outputDecimals);
 				if (outputDecimals !== assetDecimals) {
 					const scale = 10n ** BigInt(Math.abs(assetDecimals - outputDecimals));
 					maxAssetAvailable =
@@ -523,7 +570,7 @@
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals =
 					q.outputTokenDecimals ?? (direction === 'buy' ? assetDecimals : paymentDecimals);
-				maxAvailable = parseFloatHex(q.maxOutput, outputDecimals);
+				maxAvailable = parseQuoteFloat(q.maxOutput, outputDecimals);
 			}
 			if (maxAvailable <= 0n) continue;
 
@@ -582,7 +629,7 @@
 			let maxUsdcFromBid = 0n;
 			if (typeof q.maxOutput === 'string' && q.maxOutput.startsWith('0x')) {
 				const outputDecimals = q.outputTokenDecimals ?? paymentDecimals;
-				maxUsdcFromBid = parseFloatHex(q.maxOutput, outputDecimals);
+				maxUsdcFromBid = parseQuoteFloat(q.maxOutput, outputDecimals);
 			}
 			if (maxUsdcFromBid <= 0n) continue;
 
@@ -689,6 +736,9 @@
 		tradeError = null;
 
 		try {
+			const { executeMarketOrder, filterQuotesForSide, sortQuotesByPrice } = await import(
+				'$lib/services/marketOrderExecution'
+			);
 			const relevantQuotes = filterQuotesForSide(
 				quotes,
 				orderSide,

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -1,31 +1,91 @@
 <script lang="ts">
 	import '../../app.css';
 	import { onMount } from 'svelte';
-	import TransactionModal from '$lib/components/TransactionModal.svelte';
-	import RainlangConfirmationModal from '$lib/components/RainlangConfirmationModal.svelte';
-	import TokenSwapAnnouncementModal from '$lib/components/announcements/TokenSwapAnnouncementModal.svelte';
-	import ReferralJoinModal from '$lib/components/referrals/ReferralJoinModal.svelte';
-	import ReferralDashboardModal from '$lib/components/referrals/ReferralDashboardModal.svelte';
-	import ReferralLeaderboardModal from '$lib/components/referrals/ReferralLeaderboardModal.svelte';
 	import { initTokenSwapAnnouncement } from '$lib/stores/announcementStore';
-	import AccessCodeModal from '$lib/components/AccessCodeModal.svelte';
-	import WalletConnectionModal from '$lib/components/WalletConnectionModal.svelte';
-	import Tutorial from '$lib/components/Tutorial.svelte';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Header from '$lib/components/Header.svelte';
 	import TickerTape from '$lib/components/TickerTape.svelte';
-	import LowFundsBanner from '$lib/components/LowFundsBanner.svelte';
-	import OldTokensBanner from '$lib/components/OldTokensBanner.svelte';
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { rainlangConfirmationModal, tradePanelOpen } from '$lib/stores';
 	import { checkAndStoreAccessCodeFromUrl } from '$lib/utils/accessCodeStorage';
 	// Note: Access check is handled by accessStore's subscription to walletAddress
 
+	type TransactionModalComponent = typeof import('$lib/components/TransactionModal.svelte').default;
+	type RainlangConfirmationModalComponent =
+		typeof import('$lib/components/RainlangConfirmationModal.svelte').default;
+	type TokenSwapAnnouncementModalComponent =
+		typeof import('$lib/components/announcements/TokenSwapAnnouncementModal.svelte').default;
+	type ReferralJoinModalComponent =
+		typeof import('$lib/components/referrals/ReferralJoinModal.svelte').default;
+	type ReferralDashboardModalComponent =
+		typeof import('$lib/components/referrals/ReferralDashboardModal.svelte').default;
+	type ReferralLeaderboardModalComponent =
+		typeof import('$lib/components/referrals/ReferralLeaderboardModal.svelte').default;
+	type AccessCodeModalComponent = typeof import('$lib/components/AccessCodeModal.svelte').default;
+	type WalletConnectionModalComponent =
+		typeof import('$lib/components/WalletConnectionModal.svelte').default;
+	type TutorialComponent = typeof import('$lib/components/Tutorial.svelte').default;
+	type LowFundsBannerComponent = typeof import('$lib/components/LowFundsBanner.svelte').default;
+	type OldTokensBannerComponent = typeof import('$lib/components/OldTokensBanner.svelte').default;
+
+	let TransactionModal: TransactionModalComponent | null = null;
+	let RainlangConfirmationModal: RainlangConfirmationModalComponent | null = null;
+	let TokenSwapAnnouncementModal: TokenSwapAnnouncementModalComponent | null = null;
+	let ReferralJoinModal: ReferralJoinModalComponent | null = null;
+	let ReferralDashboardModal: ReferralDashboardModalComponent | null = null;
+	let ReferralLeaderboardModal: ReferralLeaderboardModalComponent | null = null;
+	let AccessCodeModal: AccessCodeModalComponent | null = null;
+	let WalletConnectionModal: WalletConnectionModalComponent | null = null;
+	let Tutorial: TutorialComponent | null = null;
+	let LowFundsBanner: LowFundsBannerComponent | null = null;
+	let OldTokensBanner: OldTokensBannerComponent | null = null;
+
+	async function loadDeferredLayoutComponents() {
+		const [
+			transactionModal,
+			rainlangConfirmationModalComponent,
+			tokenSwapAnnouncementModal,
+			referralJoinModal,
+			referralDashboardModal,
+			referralLeaderboardModal,
+			accessCodeModal,
+			walletConnectionModal,
+			tutorial,
+			lowFundsBanner,
+			oldTokensBanner
+		] = await Promise.all([
+			import('$lib/components/TransactionModal.svelte'),
+			import('$lib/components/RainlangConfirmationModal.svelte'),
+			import('$lib/components/announcements/TokenSwapAnnouncementModal.svelte'),
+			import('$lib/components/referrals/ReferralJoinModal.svelte'),
+			import('$lib/components/referrals/ReferralDashboardModal.svelte'),
+			import('$lib/components/referrals/ReferralLeaderboardModal.svelte'),
+			import('$lib/components/AccessCodeModal.svelte'),
+			import('$lib/components/WalletConnectionModal.svelte'),
+			import('$lib/components/Tutorial.svelte'),
+			import('$lib/components/LowFundsBanner.svelte'),
+			import('$lib/components/OldTokensBanner.svelte')
+		]);
+
+		TransactionModal = transactionModal.default;
+		RainlangConfirmationModal = rainlangConfirmationModalComponent.default;
+		TokenSwapAnnouncementModal = tokenSwapAnnouncementModal.default;
+		ReferralJoinModal = referralJoinModal.default;
+		ReferralDashboardModal = referralDashboardModal.default;
+		ReferralLeaderboardModal = referralLeaderboardModal.default;
+		AccessCodeModal = accessCodeModal.default;
+		WalletConnectionModal = walletConnectionModal.default;
+		Tutorial = tutorial.default;
+		LowFundsBanner = lowFundsBanner.default;
+		OldTokensBanner = oldTokensBanner.default;
+	}
+
 	// Check for access code in URL params on mount
 	onMount(() => {
 		checkAndStoreAccessCodeFromUrl();
 		initTokenSwapAnnouncement();
+		void loadDeferredLayoutComponents();
 	});
 
 	let sidebarExpanded = true;
@@ -150,10 +210,14 @@
 		/>
 
 		<!-- Low funds banner (shown when wallet has no USDC) -->
-		<LowFundsBanner />
+		{#if LowFundsBanner}
+			<svelte:component this={LowFundsBanner} />
+		{/if}
 
 		<!-- Old tokens banner (shown when user has legacy tokens that need to be swapped) -->
-		<OldTokensBanner />
+		{#if OldTokensBanner}
+			<svelte:component this={OldTokensBanner} />
+		{/if}
 
 		<!-- Ticker tape underneath header (trade pages only) -->
 		{#if isTradePage}
@@ -161,26 +225,45 @@
 		{/if}
 
 		<slot {sidebarExpanded} />
-		<TransactionModal />
-		<RainlangConfirmationModal
-			show={$rainlangConfirmationModal.show}
-			rainlangCode={$rainlangConfirmationModal.rainlangCode}
-			onDeploy={$rainlangConfirmationModal.onDeploy || (() => {})}
-			onCancel={$rainlangConfirmationModal.onCancel || (() => {})}
-		/>
+		{#if TransactionModal}
+			<svelte:component this={TransactionModal} />
+		{/if}
+		{#if RainlangConfirmationModal}
+			<svelte:component
+				this={RainlangConfirmationModal}
+				show={$rainlangConfirmationModal.show}
+				rainlangCode={$rainlangConfirmationModal.rainlangCode}
+				onDeploy={$rainlangConfirmationModal.onDeploy || (() => {})}
+				onCancel={$rainlangConfirmationModal.onCancel || (() => {})}
+			/>
+		{/if}
 	</div>
 
-	<TokenSwapAnnouncementModal />
+	{#if TokenSwapAnnouncementModal}
+		<svelte:component this={TokenSwapAnnouncementModal} />
+	{/if}
 
 	<!-- Referral Modals -->
-	<ReferralJoinModal />
-	<ReferralDashboardModal />
-	<ReferralLeaderboardModal />
+	{#if ReferralJoinModal}
+		<svelte:component this={ReferralJoinModal} />
+	{/if}
+	{#if ReferralDashboardModal}
+		<svelte:component this={ReferralDashboardModal} />
+	{/if}
+	{#if ReferralLeaderboardModal}
+		<svelte:component this={ReferralLeaderboardModal} />
+	{/if}
 
 	<!-- Access/Connection Modals -->
-	<AccessCodeModal />
-	<WalletConnectionModal />
+	{#if AccessCodeModal}
+		<svelte:component this={AccessCodeModal} />
+	{/if}
+	{#if WalletConnectionModal}
+		<svelte:component this={WalletConnectionModal} />
+	{/if}
 
 	<!-- Tutorial Overlay -->
-	<Tutorial />
+	{#if Tutorial}
+		<svelte:component this={Tutorial} />
+	{/if}
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,27 +3,43 @@
 	import { QueryClientProvider } from '@tanstack/svelte-query';
 	import { queryClient } from '$lib/clients/queryClient';
 	import { env as publicEnv } from '$env/dynamic/public';
-	import { defaultConfig } from 'svelte-wagmi';
-	import { base } from '@wagmi/core/chains';
-	import { injected, walletConnect } from '@wagmi/connectors';
 	import { onMount } from 'svelte';
 	import { injectAnalytics } from '@vercel/analytics/sveltekit';
 	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 
-	// Dynamic integration
-	import DynamicSvelteWrapper from '$lib/dynamic/DynamicSvelteWrapper.svelte';
-	import AuthModal from '$lib/components/AuthModal.svelte';
-	import SendFundsModal from '$lib/components/SendFundsModal.svelte';
-	import DepositModal from '$lib/components/DepositModal.svelte';
-	import CookieConsent from '$lib/components/CookieConsent.svelte';
-
-	// Auth store for wallet address tracking
-	import { walletAddress } from '$lib/stores/authStore';
-
 	// PostHog analytics
 	import { initAnalytics } from '$lib/services/analytics';
 
+	type DynamicSvelteWrapperComponent =
+		typeof import('$lib/dynamic/DynamicSvelteWrapper.svelte').default;
+	type AuthModalComponent = typeof import('$lib/components/AuthModal.svelte').default;
+	type SendFundsModalComponent = typeof import('$lib/components/SendFundsModal.svelte').default;
+	type DepositModalComponent = typeof import('$lib/components/DepositModal.svelte').default;
+	type CookieConsentComponent = typeof import('$lib/components/CookieConsent.svelte').default;
+
+	let DynamicSvelteWrapper: DynamicSvelteWrapperComponent | null = null;
+	let AuthModal: AuthModalComponent | null = null;
+	let SendFundsModal: SendFundsModalComponent | null = null;
+	let DepositModal: DepositModalComponent | null = null;
+	let CookieConsent: CookieConsentComponent | null = null;
 	let analyticsInjected = false;
+
+	async function loadRootComponents() {
+		const [dynamicSvelteWrapper, authModal, sendFundsModal, depositModal, cookieConsent] =
+			await Promise.all([
+				import('$lib/dynamic/DynamicSvelteWrapper.svelte'),
+				import('$lib/components/AuthModal.svelte'),
+				import('$lib/components/SendFundsModal.svelte'),
+				import('$lib/components/DepositModal.svelte'),
+				import('$lib/components/CookieConsent.svelte')
+			]);
+
+		DynamicSvelteWrapper = dynamicSvelteWrapper.default;
+		AuthModal = authModal.default;
+		SendFundsModal = sendFundsModal.default;
+		DepositModal = depositModal.default;
+		CookieConsent = cookieConsent.default;
+	}
 
 	function enableAnalytics() {
 		if (!analyticsInjected) {
@@ -41,6 +57,11 @@
 	}
 
 	const initWallet = async () => {
+		const [{ defaultConfig }, { base }, { injected, walletConnect }] = await Promise.all([
+			import('svelte-wagmi'),
+			import('@wagmi/core/chains'),
+			import('@wagmi/connectors')
+		]);
 		const projectId = publicEnv?.PUBLIC_WALLETCONNECT_ID || '';
 		const connectorsList = [injected()];
 		if (projectId && projectId.trim().length > 0) {
@@ -85,15 +106,20 @@
 	}
 
 	onMount(() => {
-		initWallet();
+		let unsubscribe: (() => void) | undefined;
+
+		void initWallet();
+		void loadRootComponents();
 
 		// Subscribe to wallet address changes and sync to cookie
-		const unsubscribe = walletAddress.subscribe((address) => {
-			setWalletCookie(address);
+		void import('$lib/stores/authStore').then(({ walletAddress }) => {
+			unsubscribe = walletAddress.subscribe((address) => {
+				setWalletCookie(address);
+			});
 		});
 
 		return () => {
-			unsubscribe();
+			unsubscribe?.();
 			document.body.style.overflow = '';
 		};
 	});
@@ -101,15 +127,25 @@
 
 <QueryClientProvider client={queryClient}>
 	<!-- Dynamic SDK wrapper (invisible, handles auth state) -->
-	<DynamicSvelteWrapper />
+	{#if DynamicSvelteWrapper}
+		<svelte:component this={DynamicSvelteWrapper} />
+	{/if}
 
 	<!-- Global modals -->
-	<AuthModal />
-	<SendFundsModal />
-	<DepositModal />
+	{#if AuthModal}
+		<svelte:component this={AuthModal} />
+	{/if}
+	{#if SendFundsModal}
+		<svelte:component this={SendFundsModal} />
+	{/if}
+	{#if DepositModal}
+		<svelte:component this={DepositModal} />
+	{/if}
 
 	<!-- Cookie consent banner -->
-	<CookieConsent onAnalyticsAccepted={enableAnalytics} />
+	{#if CookieConsent}
+		<svelte:component this={CookieConsent} onAnalyticsAccepted={enableAnalytics} />
+	{/if}
 
 	<slot />
 </QueryClientProvider>

--- a/vite.config.js
+++ b/vite.config.js
@@ -47,7 +47,25 @@ export default defineConfig(({ mode }) => ({
 	},
 	build: {
 	  target: 'es2022',
-	  modulePreload: { polyfill: false }
+	  modulePreload: { polyfill: false },
+	  rollupOptions: {
+		output: {
+		  manualChunks(id) {
+			if (!id.includes('node_modules')) return;
+			if (id.includes('@tanstack/')) return 'tanstack-query';
+			if (
+			  id.includes('svelte-wagmi') ||
+			  id.includes('@wagmi/') ||
+			  id.includes('@web3modal/') ||
+			  id.includes('@walletconnect/') ||
+			  id.includes('viem') ||
+			  id.includes('ethers')
+			) {
+			  return 'wallet';
+			}
+		  }
+		}
+	  }
 	},
 	test: {
 	  server: {


### PR DESCRIPTION
## Dependent PR

- Depends on #195

## Motivation

The parent PR removes the broad homepage orderbook prefetch, but the homepage still pays for several expensive pieces of work during the initial load path:

- `QuickTrade` still creates the selected-token orderbook query during SSR, which can hit browser-only orderbook code and leave noisy server logs.
- The homepage bundle/import path still pulls token math and market-order execution code before the user actually trades.
- Root and main layouts eagerly import wallet/bootstrap modals, transaction modals, announcements, banners, and tutorial UI even when none of those are visible on the first paint.
- Vite was grouping required TanStack Query plumbing with large wallet dependencies, making the initial route harder to reason about and heavier than necessary.

This PR narrows the work needed to render `/` so the initial request can serve the landing page without evaluating orderbook execution paths or layout-only modal code.

## What Changed

### `QuickTrade.svelte`

- Keeps the selected-token quote query, but gates it with `browser` so it does not run during SSR.
- Converts orderbook query loading to a dynamic import of `refreshTokenQuotes`.
- Defers `tokenMath` parsing until liquidity math actually needs it.
- Defers `marketOrderExecution` until `handleTrade()` runs.
- Keeps the visible quote behavior client-side while preventing server-side orderbook fetch attempts for `/`.

### Root Layout

- Dynamically loads wallet/bootstrap components after mount:
  - `DynamicSvelteWrapper`
  - `AuthModal`
  - `SendFundsModal`
  - `DepositModal`
  - `CookieConsent`
- Dynamically imports wallet setup dependencies (`svelte-wagmi`, `@wagmi/core/chains`, `@wagmi/connectors`) inside the client-only wallet init path.
- Dynamically subscribes to `authStore` after mount for the wallet-address cookie sync.
- Result: the SSR root layout output drops to a tiny route shell instead of evaluating wallet modal setup up front.

### Main Layout

- Dynamically loads global banners/modals after mount:
  - transaction and Rainlang confirmation modals
  - token swap/referral/access/wallet/tutorial modals
  - low-funds and old-token banners
- Keeps the rendered page structure the same, but avoids pulling those components into the initial SSR layout path.

### Vite Chunking

- Adds a conservative manual chunk split for:
  - `tanstack-query`
  - wallet/Web3 dependencies (`svelte-wagmi`, wagmi, Web3Modal/WalletConnect, viem, ethers)
- This makes the bundle composition easier to inspect and prevents the required query provider from being merged into the wallet chunk.

## Benchmarks

### Local Production Preview

Command:

```sh
SESSION_SECRET=local-dev-session-secret BASE_RPC_URL=https://base-rpc.publicnode.com nix develop -c npm run build
SESSION_SECRET=local-dev-session-secret BASE_RPC_URL=https://base-rpc.publicnode.com nix develop -c npm run preview -- --host 127.0.0.1 --port 4173
```

Before this branch, on top of #195:

- Cold `/` no cookie: `ttfb=3.255s total=3.255s`
- Fake-session request: `ttfb=1.508s total=1.508s`
- Warm `/`: about `2.5-5.8ms`

After this branch:

- Cold `/` no cookie: `ttfb=0.575s total=0.575s`
- Fake-session request: `ttfb=0.0048s total=0.0049s`
- Warm `/`: about `2.1-3.5ms`

The final local preview logs no longer show selected-token orderbook SSR fetch attempts for `/`.

### Vercel Preview

Compared PR #196 against the parent PR #195 preview with cache-busting query strings.

PR #196:

- First probe: `1.45s`
- Repeated probes: `0.52s`, `0.96s`, `0.52s`, `0.55s`, `0.52s`

Parent PR #195:

- First probe: `61.0s`
- Repeated probes: `0.43s`, `0.40s`, `0.42s`, `0.48s`

Warm responses are similar. The improvement is primarily in the slow/cold initial-load path, where #196 avoids the severe first-request behavior reproduced on the parent preview.

## Test Plan

- [x] Production build with local env:
  `SESSION_SECRET=local-dev-session-secret BASE_RPC_URL=https://base-rpc.publicnode.com nix develop -c npm run build`
- [x] Local production preview benchmark with `npm run preview -- --host 127.0.0.1 --port 4173`
- [x] Confirm local preview logs do not include selected-token orderbook SSR fetch errors for `/`
- [x] Benchmark Vercel Preview for #196 against parent #195
- [ ] Inspect browser waterfall on Vercel Preview for remaining client-side wallet/chunk loading opportunities
