### PR TITLE
RAI-841 expose token and swap proxy endpoints

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -18,6 +18,54 @@ export interface ApiTokenRef {
 	decimals: number;
 }
 
+export interface ApiToken extends ApiTokenRef {
+	name?: string | null;
+	isin?: string | null;
+	label?: string;
+	network?: unknown;
+	[key: string]: unknown;
+}
+
+// ============================================================================
+// Swap Types
+// ============================================================================
+
+export interface ApiSwapQuoteRequest {
+	inputToken: string;
+	outputToken: string;
+	outputAmount: string;
+}
+
+export interface ApiSwapQuoteResponse {
+	inputToken: string;
+	outputToken: string;
+	outputAmount: string;
+	estimatedOutput: string;
+	estimatedInput: string;
+	estimatedIoRatio: string;
+}
+
+export interface ApiSwapCalldataRequest extends ApiSwapQuoteRequest {
+	taker: string;
+	maximumIoRatio: string;
+}
+
+export interface ApiApproval {
+	token: string;
+	spender: string;
+	amount: string;
+	symbol: string;
+	approvalData: string;
+}
+
+export interface ApiSwapCalldataResponse {
+	to: string;
+	data: string;
+	value: string;
+	estimatedInput: string;
+	approvals: ApiApproval[];
+}
+
 // ============================================================================
 // Order Types
 // ============================================================================
@@ -146,6 +194,40 @@ export async function apiGetOrdersByToken(
 		side: options?.side
 	});
 	return fetchJson<ApiOrdersListResponse>(url);
+}
+
+/**
+ * Fetch the canonical supported token list from the REST API.
+ */
+export async function apiGetTokens(): Promise<ApiToken[]> {
+	assertBrowser('apiGetTokens');
+	return fetchJson<ApiToken[]>(apiUrl('/v1/tokens'));
+}
+
+/**
+ * Fetch a fresh API-built swap quote.
+ */
+export async function apiGetSwapQuote(request: ApiSwapQuoteRequest): Promise<ApiSwapQuoteResponse> {
+	assertBrowser('apiGetSwapQuote');
+	return fetchJson<ApiSwapQuoteResponse>(apiUrl('/v1/swap/quote'), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(request)
+	});
+}
+
+/**
+ * Fetch ready-to-send swap calldata from the API.
+ */
+export async function apiGetSwapCalldata(
+	request: ApiSwapCalldataRequest
+): Promise<ApiSwapCalldataResponse> {
+	assertBrowser('apiGetSwapCalldata');
+	return fetchJson<ApiSwapCalldataResponse>(apiUrl('/v1/swap/calldata'), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(request)
+	});
 }
 
 /**

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -29,6 +29,7 @@ function getAuthHeader(): string {
 
 const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
+	{ method: 'GET', pattern: /^v1\/tokens$/ },
 	// Shared endpoints — same response for all users, cache at Vercel edge
 	{
 		method: 'GET',
@@ -44,7 +45,9 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },
 	{ method: 'GET', pattern: /^v1\/trades\/(?!taker\/|query$)[^/]+$/ },
 	{ method: 'GET', pattern: /^v1\/trades\/taker\/[^/]+$/ },
-	{ method: 'POST', pattern: /^v1\/trades\/query$/ }
+	{ method: 'POST', pattern: /^v1\/trades\/query$/ },
+	{ method: 'POST', pattern: /^v1\/swap\/quote$/ },
+	{ method: 'POST', pattern: /^v1\/swap\/calldata$/ }
 ];
 
 function matchProxyRoute(method: string, pathSuffix: string): { cache?: string } | null {

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequestEvent } from '../../hooks/_helpers';
+import { env } from '$env/dynamic/private';
+import { GET, POST } from '../../../src/routes/api/st0x/[...path]/+server';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {}
+}));
+
+type St0xProxyEvent = Parameters<typeof GET>[0];
+
+function proxyEvent(method: string, path: string, body?: BodyInit): St0xProxyEvent {
+	const event = createMockRequestEvent({
+		method,
+		url: `http://localhost/api/st0x/${path}?page=1`,
+		body
+	});
+	return {
+		...event,
+		params: { path }
+	} as St0xProxyEvent;
+}
+
+describe('/api/st0x proxy', () => {
+	beforeEach(() => {
+		env.ST0X_API_URL = 'https://api.example.test/';
+		env.ST0X_API_KEY = 'test-key';
+		env.ST0X_API_SECRET = 'test-secret';
+		vi.restoreAllMocks();
+	});
+
+	it('allows GET /v1/tokens without adding a proxy cache header', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify([{ address: '0xToken', symbol: 'TOK', decimals: 18 }]), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(proxyEvent('GET', 'v1/tokens'));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/tokens?page=1',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.any(Headers)
+			})
+		);
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect((init.headers as Headers).get('Authorization')).toBe(
+			'Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ='
+		);
+	});
+
+	it('allows POST /v1/swap/quote and forwards the JSON body without caching', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ estimatedInput: '100' }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const body = JSON.stringify({
+			inputToken: '0xIn',
+			outputToken: '0xOut',
+			outputAmount: '1'
+		});
+
+		const response = await POST(proxyEvent('POST', 'v1/swap/quote', body));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/swap/quote?page=1',
+			expect.objectContaining({ method: 'POST' })
+		);
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(await new Response(init.body).text()).toBe(body);
+	});
+
+	it('allows POST /v1/swap/calldata without caching', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ to: '0xOrderbook', data: '0x', value: '0', approvals: [] }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await POST(proxyEvent('POST', 'v1/swap/calldata', '{}'));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/swap/calldata?page=1',
+			expect.objectContaining({ method: 'POST' })
+		);
+	});
+
+	it('keeps wrap-ratio endpoints blocked until their API PRs land', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(proxyEvent('GET', 'v1/tokens/wrap-ratio'));
+
+		expect(response.status).toBe(404);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Linear
- Closes RAI-841: https://linear.app/makeitrain/issue/RAI-841/expose-token-and-swap-rest-endpoints-through-the-st0x-website

## Motivation

The ST0x website proxy only allowed health, orders, and trades endpoints. That meant browser code could not safely access the REST token and swap endpoints through the authenticated server-side proxy, even though these endpoints are needed for the API-first migration.

## Solution

- Allow GET /v1/tokens, POST /v1/swap/quote, and POST /v1/swap/calldata through /api/st0x.
- Keep wrap-ratio endpoints blocked for the separate wrap-ratio PR series.
- Add typed REST client helpers for tokens, swap quotes, and swap calldata.
- Add focused proxy tests covering auth injection, body forwarding, no proxy-level caching, and wrap-ratio rejection.

## Checks

- npm run test -- run tests/lib/api/st0x-proxy.test.ts
- Local dev proxy smoke test against configured API:
  - GET /api/st0x/v1/tokens returned 200 OK
  - POST /api/st0x/v1/swap/quote returned 200 OK
  - POST /api/st0x/v1/swap/calldata returned 200 OK

Note: npm run check still fails on pre-existing @playwright/test type-resolution errors in tests/integration/ui/*; the new proxy test errors are clear.