### PR TITLE
RAI-338 use API token list across website

### DIFF
--- a/src/lib/components/LowFundsBanner.svelte
+++ b/src/lib/components/LowFundsBanner.svelte
@@ -6,18 +6,30 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { erc20Abi } from 'viem';
 	import { readContracts } from '@wagmi/core';
-	import { PAYMENT_TOKENS_BY_NETWORK } from '$lib/config/tokens';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 
 	let dismissed = false;
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: paymentTokens = ($apiTokensQuery.data ?? []).filter((token) => token.category === 'CRYPTO');
 
 	// Share the same query key as dashboard to avoid duplicate RPC calls
 	// Uses same settings as dashboard - invalidation happens after transactions
 	$: usdcBalanceQuery = createQuery({
-		queryKey: ['usdcWalletBalance', $walletAddress, $currentNetwork?.chainId],
-		enabled: !!($isAuthenticated && $walletAddress && $currentNetwork && $wagmiConfig),
+		queryKey: [
+			'usdcWalletBalance',
+			$walletAddress,
+			$currentNetwork?.chainId,
+			paymentTokens.map((token) => token.address).join(',')
+		],
+		enabled: !!(
+			$isAuthenticated &&
+			$walletAddress &&
+			$currentNetwork &&
+			$wagmiConfig &&
+			paymentTokens.length
+		),
 		staleTime: 30_000, // Consider data fresh for 30 seconds
 		queryFn: async () => {
-			const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork?.chainId ?? 0] ?? [];
 			if (paymentTokens.length === 0 || !$walletAddress) return [];
 
 			// Build multicall contracts array

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -2,13 +2,13 @@
 	import { web3Modal, wagmiConfig } from 'svelte-wagmi';
 	import { walletAddress, isAuthenticated } from '$lib/stores/authStore';
 	import { currentNetwork } from '$lib/stores';
-	import { getAllTokensByNetwork } from '$lib/config/network';
 	import { readContract } from '@wagmi/core';
 	import { erc20Abi, formatUnits, parseUnits } from 'viem';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import type { OrderbookQuoteCache } from '$lib/queries/orderbook';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import { walletRegistered, promptLogin } from '$lib/stores/accessStore';
 	import { openAuthModal } from '$lib/stores/dynamicStore';
 	import type { ProcessedQuote } from '$lib/utils/orderbook';
@@ -54,14 +54,19 @@
 	let previousTokenSymbol: string | null = null;
 
 	// ============ TOKEN SELECTION (completely independent) ============
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
-	$: tradableTokens = ALL_TOKENS.filter((t) => t.category === 'ST0x');
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: apiTokens = $apiTokensQuery.data ?? [];
+	$: tradableTokens = apiTokens.filter((t) => t.category === 'ST0x');
 
 	let selectedTokenAddress: string | null = null;
 	let isDropdownOpen = false;
 
 	// Auto-select first token on mount
-	$: if (tradableTokens.length > 0 && !selectedTokenAddress) {
+	$: if (
+		tradableTokens.length > 0 &&
+		(!selectedTokenAddress ||
+			!tradableTokens.some((t) => t.address.toLowerCase() === selectedTokenAddress?.toLowerCase()))
+	) {
 		selectedTokenAddress = tradableTokens[0].address;
 	}
 

--- a/src/lib/components/SendFundsModal.svelte
+++ b/src/lib/components/SendFundsModal.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/stores/dynamicStore';
 	import { sendTransaction } from '$lib/services/walletService';
 	import { currentNetwork } from '$lib/stores';
-	import { PAYMENT_TOKENS_BY_NETWORK, TOKENS } from '$lib/config/tokens';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import {
 		parseEther,
 		parseUnits,
@@ -32,32 +32,21 @@
 		logoUrl?: string;
 	}
 
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: apiTokens = $apiTokensQuery.data ?? [];
+
 	// Build available tokens list based on current network
 	$: availableTokens = (() => {
 		const tokens: TokenOption[] = [
 			{ symbol: 'ETH', name: 'Ethereum', address: 'native', decimals: 18 }
 		];
 
-		// Add payment tokens for current network (USDC, etc.)
-		const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork?.chainId ?? 0] ?? [];
-		for (const token of paymentTokens) {
+		for (const token of apiTokens) {
 			tokens.push({
 				symbol: token.symbol,
 				name: token.name,
 				address: token.address as `0x${string}`,
 				decimals: token.decimals,
-				logoUrl: token.logoUrl
-			});
-		}
-
-		// Add asset tokens (tStocks) for current network
-		const assetTokens = TOKENS.filter((t) => t.chainId === $currentNetwork?.chainId);
-		for (const token of assetTokens) {
-			tokens.push({
-				symbol: token.symbol,
-				name: token.name,
-				address: token.address as `0x${string}`,
-				decimals: 18, // tStocks use 18 decimals
 				logoUrl: token.logoUrl
 			});
 		}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { currentNetwork, sfts } from '$lib/stores';
 	import { page } from '$app/stores';
-	import { getAllTokensByNetwork, getTokenByAnyAddress } from '$lib/config/tokens';
+	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
 	import { formatUnits } from 'viem';
 	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
@@ -25,8 +25,8 @@
 
 	let sortedAssets: AssetWithMetrics[] = [];
 
-	// Get all tokens for the current network
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: apiTokens = $apiTokensQuery.data ?? [];
 
 	// Calculate assets sorted by volume
 	$: sortedAssets = $sfts
@@ -43,13 +43,9 @@
 					);
 					const totalVolume = depositVolume + withdrawVolume;
 					// Use token config symbol for price lookup so legacy symbols (e.g. tSTOX) resolve to the wrapped token's price feed (wtSTOX / AMEX:SPLG)
-					const tokenInfo = getTokenByAnyAddress(sft.address);
+					const tokenInfo = findApiTokenByAnyAddress(apiTokens, sft.address);
 					const symbolForPrice = tokenInfo?.symbol ?? sft.symbol;
-					const quote = findQuoteForSymbol(
-						symbolForPrice,
-						$priceFeedsQuery?.data ?? [],
-						ALL_TOKENS
-					);
+					const quote = findQuoteForSymbol(symbolForPrice, $priceFeedsQuery?.data ?? [], apiTokens);
 					const price = quote?.close ?? 0;
 					const volumeInShares = parseFloat(formatUnits(totalVolume, 18));
 					const dollarVolume = volumeInShares * price;
@@ -138,7 +134,7 @@
 			</div>
 			<div class="space-y-0.5">
 				{#each sortedAssets as asset}
-					{@const tokenInfo = getTokenByAnyAddress(asset.address)}
+					{@const tokenInfo = findApiTokenByAnyAddress(apiTokens, asset.address)}
 					<a
 						href={`/trade/${tokenInfo?.address ?? asset.id}`}
 						on:click={() => {

--- a/src/lib/components/TokenSelect.svelte
+++ b/src/lib/components/TokenSelect.svelte
@@ -4,7 +4,7 @@
 	import type { CategorizedToken } from '$lib/config/network';
 
 	export let options: CategorizedToken[] = [];
-	export let selected: CategorizedToken;
+	export let selected: CategorizedToken | undefined;
 	export let placeholder: string = 'Select a token';
 
 	const dispatch = createEventDispatcher();

--- a/src/lib/components/orders/ActiveLiquidity.svelte
+++ b/src/lib/components/orders/ActiveLiquidity.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { getAllTokensByNetwork } from '$lib/config/network';
 	import TokenSelect from '$lib/components/TokenSelect.svelte';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import type { CategorizedToken } from '$lib/config/network';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import {
 		validateBaseline,
 		validateOverrideDepositAmount,
@@ -23,16 +23,18 @@
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
 	import { createOracleQuotesQuery } from '$lib/queries/oracleQuotes';
 
-	// Filter tokens based on current network
-	$: ALL_TOKENS = getAllTokensByNetwork($currentNetwork.id);
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId ?? $currentNetwork?.id);
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
 	// Initialize selected tokens when network changes, but preserve user selections if valid
 	$: if (ALL_TOKENS.length > 0) {
 		// Check if current selections are still valid for the new network
+		const currentToken1 = selectedToken1;
+		const currentToken2 = selectedToken2;
 		const token1StillValid =
-			selectedToken1 && ALL_TOKENS.some((token) => token.address === selectedToken1.address);
+			currentToken1 && ALL_TOKENS.some((token) => token.address === currentToken1.address);
 		const token2StillValid =
-			selectedToken2 && ALL_TOKENS.some((token) => token.address === selectedToken2.address);
+			currentToken2 && ALL_TOKENS.some((token) => token.address === currentToken2.address);
 
 		// Only reset if current selections are not valid for the new network
 		if (!token1StillValid) {
@@ -44,9 +46,8 @@
 	}
 
 	let showAdvancedOptions = false;
-	let selectedToken1: CategorizedToken =
-		getAllTokensByNetwork(42161)[getAllTokensByNetwork(42161).length - 1];
-	let selectedToken2: CategorizedToken = getAllTokensByNetwork(42161)[0];
+	let selectedToken1: CategorizedToken | undefined;
+	let selectedToken2: CategorizedToken | undefined;
 	let isToken1FastExit = false;
 	let isToken2FastExit = false;
 	let inputVaultId1: Hex | undefined;
@@ -96,7 +97,7 @@
 	};
 
 	$: isToken1SameAsToken2 =
-		selectedToken1.address.toLowerCase() === selectedToken2.address.toLowerCase();
+		selectedToken1?.address.toLowerCase() === selectedToken2?.address.toLowerCase();
 
 	$: disableDeploy =
 		!selectedToken1 ||
@@ -119,10 +120,12 @@
 		isToken1SameAsToken2;
 
 	const handleDsfDeploy = () => {
-		if ($isAuthenticated) {
+		const token1 = selectedToken1;
+		const token2 = selectedToken2;
+		if ($isAuthenticated && token1 && token2) {
 			transactionStore.handleDsfDeploy({
-				token1: selectedToken1,
-				token2: selectedToken2,
+				token1,
+				token2,
 				amountIsFastExit: isToken1FastExit,
 				notAmountIsFastExit: isToken2FastExit,
 				initialIo: initialIo,
@@ -155,288 +158,304 @@
 			</div>
 		</div>
 
-		<div class="flex flex-col gap-3 sm:flex-row sm:gap-6">
-			<label class="flex items-center gap-2">
-				<input
-					type="checkbox"
-					class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
-					bind:checked={isToken1FastExit}
-				/>
-				<span class="text-sm">{selectedToken1.symbol || 'Token 1'} Fast Exit</span>
-			</label>
-			<label class="flex items-center gap-2">
-				<input
-					type="checkbox"
-					class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
-					bind:checked={isToken2FastExit}
-				/>
-				<span class="text-sm">{selectedToken2.symbol || 'Token 2'} Fast Exit</span>
-			</label>
-		</div>
-
-		<div>
-			<span class="mb-2 block text-sm font-medium text-gray-300">
-				Initial Ratio {selectedToken1 && selectedToken2
-					? `${selectedToken1.symbol}/${selectedToken2.symbol}`
-					: ''}
-			</span>
-			<div class="relative">
-				<Input
-					type="number"
-					unit={selectedToken1.symbol}
-					bind:amount={initialIo}
-					validate={validateBaseline}
-					bind:isError={initialIoError}
-				/>
+		{#if selectedToken1 && selectedToken2}
+			<div class="flex flex-col gap-3 sm:flex-row sm:gap-6">
+				<label class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
+						bind:checked={isToken1FastExit}
+					/>
+					<span class="text-sm">{selectedToken1.symbol || 'Token 1'} Fast Exit</span>
+				</label>
+				<label class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
+						bind:checked={isToken2FastExit}
+					/>
+					<span class="text-sm">{selectedToken2.symbol || 'Token 2'} Fast Exit</span>
+				</label>
 			</div>
-		</div>
 
-		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
 			<div>
-				<div class="space-y-2">
-					<div class="relative">
-						<span class="text-sm font-medium text-gray-300"
-							>{selectedToken1.symbol} Deposit Amount</span
-						>
-						<TradeAmountInput
-							amountToken={selectedToken1}
-							bind:amount={depositAmount1}
-							validate={validateOverrideDepositAmount}
-							bind:isError={token1DepositAmountError}
-						/>
-					</div>
-					<div class="relative">
-						<span class="text-sm font-medium text-gray-300"
-							>{selectedToken2.symbol} Deposit Amount</span
-						>
-						<TradeAmountInput
-							amountToken={selectedToken2}
-							bind:amount={depositAmount2}
-							validate={validateOverrideDepositAmount}
-							bind:isError={token2DepositAmountError}
-						/>
-					</div>
+				<span class="mb-2 block text-sm font-medium text-gray-300">
+					Initial Ratio {selectedToken1 && selectedToken2
+						? `${selectedToken1.symbol}/${selectedToken2.symbol}`
+						: ''}
+				</span>
+				<div class="relative">
+					<Input
+						type="number"
+						unit={selectedToken1.symbol}
+						bind:amount={initialIo}
+						validate={validateBaseline}
+						bind:isError={initialIoError}
+					/>
 				</div>
 			</div>
-			<div>
-				<div class="space-y-2">
-					<div class="relative">
-						<span class="text-sm font-medium text-gray-300">Minimum Trade Amount</span>
-						<TradeAmountInput
-							amountToken={selectedToken1}
-							bind:amount={minTradeAmount}
-							validate={validateSelectedAmount}
-							bind:isError={minTradeAmountError}
-						/>
-					</div>
-					<div class="relative">
-						<span class="text-sm font-medium text-gray-300">Maximum Trade Amount</span>
-						<TradeAmountInput
-							amountToken={selectedToken1}
-							bind:amount={maxTradeAmount}
-							validate={validateSelectedAmount}
-							bind:isError={maxTradeAmountError}
-						/>
-					</div>
-				</div>
-			</div>
-		</div>
 
-		<div class="mb-6 flex items-center gap-3">
-			<button
-				on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
-				class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
-					? 'bg-blue-500'
-					: 'bg-gray-600'}"
-			>
-				<div
-					class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
-						? 'translate-x-6'
-						: 'translate-x-0.5'}"
-				/>
-			</button>
-			<span class="text-sm font-medium">Show advanced options</span>
-		</div>
-
-		{#if showAdvancedOptions}
-			<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
-				<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
+			<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Strategy Parameters</span>
-					<div class="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
+					<div class="space-y-2">
 						<div class="relative">
-							<span class="mb-1 block text-sm font-medium text-gray-300">Next Trade Multiplier</span>
-							<Input
-								type="number"
-								step="0.0001"
-								bind:amount={nextTradeMultiplier}
-								validate={validatePositiveNumber}
-								bind:isError={nextTradeMultiplierError}
+							<span class="text-sm font-medium text-gray-300"
+								>{selectedToken1.symbol} Deposit Amount</span
+							>
+							<TradeAmountInput
+								amountToken={selectedToken1}
+								bind:amount={depositAmount1}
+								validate={validateOverrideDepositAmount}
+								bind:isError={token1DepositAmountError}
 							/>
 						</div>
 						<div class="relative">
-							<span class="mb-1 block text-sm font-medium text-gray-300">Cost Basis Multiplier</span>
-							<Input
-								type="number"
-								step="0.0001"
-								bind:amount={costBasisMultiplier}
-								validate={validatePositiveNumber}
-								bind:isError={costBasisMultiplierError}
-							/>
-						</div>
-						<div class="relative">
-							<span class="mb-1 block text-sm font-medium text-gray-300">Time Per Epoch (seconds)</span>
-							<Input
-								type="number"
-								step="1"
-								bind:amount={timePerEpoch}
-								validate={validatePositiveInteger}
-								bind:isError={timePerEpochError}
+							<span class="text-sm font-medium text-gray-300"
+								>{selectedToken2.symbol} Deposit Amount</span
+							>
+							<TradeAmountInput
+								amountToken={selectedToken2}
+								bind:amount={depositAmount2}
+								validate={validateOverrideDepositAmount}
+								bind:isError={token2DepositAmountError}
 							/>
 						</div>
 					</div>
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Enter Vault IDs</span>
-					<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
-						<div class="space-y-2">
-							<div class="relative">
-								<span class="text-sm font-medium text-gray-300"
-									>Input {selectedToken1.symbol} Vault ID</span
-								>
-								<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
-							</div>
-							<div class="relative">
-								<span class="text-sm font-medium text-gray-300"
-									>Input {selectedToken2.symbol} Vault ID</span
-								>
-								<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
-							</div>
+					<div class="space-y-2">
+						<div class="relative">
+							<span class="text-sm font-medium text-gray-300">Minimum Trade Amount</span>
+							<TradeAmountInput
+								amountToken={selectedToken1}
+								bind:amount={minTradeAmount}
+								validate={validateSelectedAmount}
+								bind:isError={minTradeAmountError}
+							/>
 						</div>
-						<div class="space-y-2">
-							<div class="relative">
-								<span class="text-sm font-medium text-gray-300"
-									>Output {selectedToken1.symbol} Vault ID</span
-								>
-								<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
-							</div>
-							<div class="relative">
-								<span class="text-sm font-medium text-gray-300"
-									>Output {selectedToken2.symbol} Vault ID</span
-								>
-								<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
-							</div>
+						<div class="relative">
+							<span class="text-sm font-medium text-gray-300">Maximum Trade Amount</span>
+							<TradeAmountInput
+								amountToken={selectedToken1}
+								bind:amount={maxTradeAmount}
+								validate={validateSelectedAmount}
+								bind:isError={maxTradeAmountError}
+							/>
 						</div>
 					</div>
 				</div>
 			</div>
+
+			<div class="mb-6 flex items-center gap-3">
+				<button
+					on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
+					class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
+						? 'bg-blue-500'
+						: 'bg-gray-600'}"
+				>
+					<div
+						class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
+							? 'translate-x-6'
+							: 'translate-x-0.5'}"
+					/>
+				</button>
+				<span class="text-sm font-medium">Show advanced options</span>
+			</div>
+
+			{#if showAdvancedOptions}
+				<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
+					<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
+					<div>
+						<span class="mb-2 block text-sm font-medium text-gray-300">Strategy Parameters</span>
+						<div class="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
+							<div class="relative">
+								<span class="mb-1 block text-sm font-medium text-gray-300"
+									>Next Trade Multiplier</span
+								>
+								<Input
+									type="number"
+									step="0.0001"
+									bind:amount={nextTradeMultiplier}
+									validate={validatePositiveNumber}
+									bind:isError={nextTradeMultiplierError}
+								/>
+							</div>
+							<div class="relative">
+								<span class="mb-1 block text-sm font-medium text-gray-300"
+									>Cost Basis Multiplier</span
+								>
+								<Input
+									type="number"
+									step="0.0001"
+									bind:amount={costBasisMultiplier}
+									validate={validatePositiveNumber}
+									bind:isError={costBasisMultiplierError}
+								/>
+							</div>
+							<div class="relative">
+								<span class="mb-1 block text-sm font-medium text-gray-300"
+									>Time Per Epoch (seconds)</span
+								>
+								<Input
+									type="number"
+									step="1"
+									bind:amount={timePerEpoch}
+									validate={validatePositiveInteger}
+									bind:isError={timePerEpochError}
+								/>
+							</div>
+						</div>
+					</div>
+					<div>
+						<span class="mb-2 block text-sm font-medium text-gray-300">Enter Vault IDs</span>
+						<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+							<div class="space-y-2">
+								<div class="relative">
+									<span class="text-sm font-medium text-gray-300"
+										>Input {selectedToken1.symbol} Vault ID</span
+									>
+									<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
+								</div>
+								<div class="relative">
+									<span class="text-sm font-medium text-gray-300"
+										>Input {selectedToken2.symbol} Vault ID</span
+									>
+									<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
+								</div>
+							</div>
+							<div class="space-y-2">
+								<div class="relative">
+									<span class="text-sm font-medium text-gray-300"
+										>Output {selectedToken1.symbol} Vault ID</span
+									>
+									<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
+								</div>
+								<div class="relative">
+									<span class="text-sm font-medium text-gray-300"
+										>Output {selectedToken2.symbol} Vault ID</span
+									>
+									<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			{/if}
 		{/if}
 	</div>
 
 	<!-- Order Summary and Button: always below form on mobile, side on desktop -->
-	<div class="mt-4 space-y-4 lg:mt-0">
-		<div class={containerStyles.cardBordered}>
-			<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
-			{#if !hasValidPriceFeedId(selectedToken1) && !hasValidPriceFeedId(selectedToken2)}
-				<div class="py-6 text-center text-sm text-gray-400">No price feed data available</div>
-			{:else if !$priceFeedsQuery?.data?.length || !$oracleQuotesQuery?.data}
-				<div class="flex justify-center py-6">
-					<LoadingSpinner size="sm" text="Loading price data..." />
-				</div>
-			{:else}
-				<div class="overflow-x-auto">
-					<table class="min-w-full text-sm text-gray-200">
-						<thead>
-							<tr>
-								<th class="px-2 py-1 text-left">Token</th>
-								<th class="px-2 py-1 text-right">Oracle Price</th>
-								<th class="px-2 py-1 text-right">Price Certainty</th>
-								<th class="px-2 py-1 text-right">Off-chain</th>
-							</tr>
-						</thead>
-						<tbody>
-							{#if hasValidPriceFeedId(selectedToken1)}
-								<PythOracleRow token={selectedToken1} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-							{/if}
-							{#if hasValidPriceFeedId(selectedToken2)}
-								<PythOracleRow token={selectedToken2} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-							{/if}
-						</tbody>
-					</table>
-				</div>
-			{/if}
-		</div>
+	{#if selectedToken1 && selectedToken2}
+		<div class="mt-4 space-y-4 lg:mt-0">
+			<div class={containerStyles.cardBordered}>
+				<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
+				{#if !hasValidPriceFeedId(selectedToken1) && !hasValidPriceFeedId(selectedToken2)}
+					<div class="py-6 text-center text-sm text-gray-400">No price feed data available</div>
+				{:else if !$priceFeedsQuery?.data?.length || !$oracleQuotesQuery?.data}
+					<div class="flex justify-center py-6">
+						<LoadingSpinner size="sm" text="Loading price data..." />
+					</div>
+				{:else}
+					<div class="overflow-x-auto">
+						<table class="min-w-full text-sm text-gray-200">
+							<thead>
+								<tr>
+									<th class="px-2 py-1 text-left">Token</th>
+									<th class="px-2 py-1 text-right">Oracle Price</th>
+									<th class="px-2 py-1 text-right">Price Certainty</th>
+									<th class="px-2 py-1 text-right">Off-chain</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#if hasValidPriceFeedId(selectedToken1)}
+									<PythOracleRow
+										token={selectedToken1}
+										tokenQuotes={$priceFeedsQuery?.data ?? []}
+									/>
+								{/if}
+								{#if hasValidPriceFeedId(selectedToken2)}
+									<PythOracleRow
+										token={selectedToken2}
+										tokenQuotes={$priceFeedsQuery?.data ?? []}
+									/>
+								{/if}
+							</tbody>
+						</table>
+					</div>
+				{/if}
+			</div>
 
-		<div class={containerStyles.cardBordered}>
-			<h4 class="mb-3 text-sm font-medium text-gray-300">Active Liquidity Order Summary</h4>
-			<div class="space-y-2">
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Trading Pair</span>
-					<span class="font-medium text-white"
-						>{selectedToken1 && selectedToken2
-							? `${selectedToken1.symbol}/${selectedToken2.symbol}`
-							: 'Select tokens'}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Initial Ratio</span>
-					<span class="font-medium text-white">{initialIo}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Cost Basis</span>
-					<span class="font-medium text-white">{costBasisMultiplier}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Spread</span>
-					<span class="font-medium text-white">{nextTradeMultiplier}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Time Per Epoch</span>
-					<span class="font-medium text-white">{timePerEpoch}s</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">{selectedToken1.symbol} Fast Exit</span>
-					<span class="font-medium text-white">{isToken1FastExit ? 'Yes' : 'No'}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">{selectedToken2.symbol} Fast Exit</span>
-					<span class="font-medium text-white">{isToken2FastExit ? 'Yes' : 'No'}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">{selectedToken1.symbol} Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(depositAmount1 ?? 0n, selectedToken1.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">{selectedToken2.symbol} Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(depositAmount2 ?? 0n, selectedToken2.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Minimum Trade Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(minTradeAmount ?? 0n, selectedToken1.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Maximum Trade Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(maxTradeAmount ?? 0n, selectedToken1.decimals)}</span
-					>
+			<div class={containerStyles.cardBordered}>
+				<h4 class="mb-3 text-sm font-medium text-gray-300">Active Liquidity Order Summary</h4>
+				<div class="space-y-2">
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Trading Pair</span>
+						<span class="font-medium text-white"
+							>{selectedToken1 && selectedToken2
+								? `${selectedToken1.symbol}/${selectedToken2.symbol}`
+								: 'Select tokens'}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Initial Ratio</span>
+						<span class="font-medium text-white">{initialIo}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Cost Basis</span>
+						<span class="font-medium text-white">{costBasisMultiplier}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Spread</span>
+						<span class="font-medium text-white">{nextTradeMultiplier}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Time Per Epoch</span>
+						<span class="font-medium text-white">{timePerEpoch}s</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">{selectedToken1.symbol} Fast Exit</span>
+						<span class="font-medium text-white">{isToken1FastExit ? 'Yes' : 'No'}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">{selectedToken2.symbol} Fast Exit</span>
+						<span class="font-medium text-white">{isToken2FastExit ? 'Yes' : 'No'}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">{selectedToken1.symbol} Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(depositAmount1 ?? 0n, selectedToken1.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">{selectedToken2.symbol} Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(depositAmount2 ?? 0n, selectedToken2.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Minimum Trade Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(minTradeAmount ?? 0n, selectedToken1.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Maximum Trade Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(maxTradeAmount ?? 0n, selectedToken1.decimals)}</span
+						>
+					</div>
 				</div>
 			</div>
-		</div>
 
-		<Button
-			variant="primary"
-			size="lg"
-			fullWidth={true}
-			disabled={disableDeploy}
-			on:click={handleDsfDeploy}
-		>
-			Deploy Order
-		</Button>
-	</div>
+			<Button
+				variant="primary"
+				size="lg"
+				fullWidth={true}
+				disabled={disableDeploy}
+				on:click={handleDsfDeploy}
+			>
+				Deploy Order
+			</Button>
+		</div>
+	{/if}
 </div>

--- a/src/lib/components/orders/DcaOrder.svelte
+++ b/src/lib/components/orders/DcaOrder.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { getAllTokensByNetwork } from '$lib/config/network';
 	import Select from '$lib/components/ui/Select.svelte';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import type { CategorizedToken } from '$lib/config/network';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import type { PythToken } from '$lib/types';
 	import { validateBaseline, validatePeriod, validateSelectedAmount } from '$lib/utils/validation';
 	import Input from '$lib/components/ui/Input.svelte';
@@ -48,8 +48,8 @@
 	$: displayScale =
 		displayDenom === 'unwrapped' && Number.isFinite(wrapRatio) && wrapRatio > 0 ? wrapRatio : 1;
 
-	// Filter tokens based on current network
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
 	// Initialize tokens - accumulating token from prop, settlement token for settlement
 	let selectedInputToken: CategorizedToken;
@@ -61,15 +61,10 @@
 	$: if ($currentNetwork && ALL_TOKENS.length > 0) {
 		const settlementTokenConfig = $currentNetwork.defaultPaymentToken;
 		if (settlementTokenConfig) {
-			// eslint-disable-next-line no-restricted-syntax -- justification: lookup against the network-scoped ALL_TOKENS universe (assets + payment tokens) for a payment-token (USDC). DRIFT-01's getTokenByAnyAddress only resolves ST0x asset-token address variants and would never match USDC, so it is not a valid replacement here.
 			const match = ALL_TOKENS.find(
 				(token) => token.address.toLowerCase() === settlementTokenConfig.address.toLowerCase()
 			);
-			selectedOutputToken =
-				match ||
-				(settlementTokenConfig as unknown as CategorizedToken) ||
-				selectedOutputToken ||
-				ALL_TOKENS[0];
+			selectedOutputToken = match || selectedOutputToken;
 		} else {
 			selectedOutputToken = selectedOutputToken || ALL_TOKENS[0];
 		}

--- a/src/lib/components/orders/FolioStrategy.svelte
+++ b/src/lib/components/orders/FolioStrategy.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { getAllTokensByNetwork } from '$lib/config/network';
 	import TokenSelect from '$lib/components/TokenSelect.svelte';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import type { CategorizedToken } from '$lib/config/network';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import { validateOverrideDepositAmount } from '$lib/utils/validation';
 	import Input from '$lib/components/ui/Input.svelte';
 	import VaultIdInput from '$lib/components/VaultIdInput.svelte';
@@ -17,26 +17,33 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
 
-	// Filter tokens based on current network
-	$: ALL_TOKENS = getAllTokensByNetwork($currentNetwork.id);
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId ?? $currentNetwork?.id);
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
 	// Selected Tokens - initialize with first available tokens from current network, but preserve user selections if valid
 	$: if (ALL_TOKENS.length > 0) {
 		// Check if current selections are still valid for the new network
+		const currentToken1 = selectedToken1;
+		const currentToken2 = selectedToken2;
+		const currentToken3 = selectedToken3;
+		const currentToken4 = selectedToken4;
+		const currentToken5 = selectedToken5;
+		const currentToken6 = selectedToken6;
+		const currentToken7 = selectedToken7;
 		const token1StillValid =
-			selectedToken1 && ALL_TOKENS.some((token) => token.address === selectedToken1.address);
+			currentToken1 && ALL_TOKENS.some((token) => token.address === currentToken1.address);
 		const token2StillValid =
-			selectedToken2 && ALL_TOKENS.some((token) => token.address === selectedToken2.address);
+			currentToken2 && ALL_TOKENS.some((token) => token.address === currentToken2.address);
 		const token3StillValid =
-			selectedToken3 && ALL_TOKENS.some((token) => token.address === selectedToken3.address);
+			currentToken3 && ALL_TOKENS.some((token) => token.address === currentToken3.address);
 		const token4StillValid =
-			selectedToken4 && ALL_TOKENS.some((token) => token.address === selectedToken4.address);
+			currentToken4 && ALL_TOKENS.some((token) => token.address === currentToken4.address);
 		const token5StillValid =
-			selectedToken5 && ALL_TOKENS.some((token) => token.address === selectedToken5.address);
+			currentToken5 && ALL_TOKENS.some((token) => token.address === currentToken5.address);
 		const token6StillValid =
-			selectedToken6 && ALL_TOKENS.some((token) => token.address === selectedToken6.address);
+			currentToken6 && ALL_TOKENS.some((token) => token.address === currentToken6.address);
 		const token7StillValid =
-			selectedToken7 && ALL_TOKENS.some((token) => token.address === selectedToken7.address);
+			currentToken7 && ALL_TOKENS.some((token) => token.address === currentToken7.address);
 
 		// Only reset if current selections are not valid for the new network
 		if (!token1StillValid) {
@@ -62,19 +69,13 @@
 		}
 	}
 
-	let selectedToken1: CategorizedToken = getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken2: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[1] || getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken3: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[2] || getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken4: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[3] || getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken5: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[4] || getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken6: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[5] || getAllTokensByNetwork($currentNetwork.id)[0];
-	let selectedToken7: CategorizedToken =
-		getAllTokensByNetwork($currentNetwork.id)[6] || getAllTokensByNetwork($currentNetwork.id)[0];
+	let selectedToken1: CategorizedToken | undefined;
+	let selectedToken2: CategorizedToken | undefined;
+	let selectedToken3: CategorizedToken | undefined;
+	let selectedToken4: CategorizedToken | undefined;
+	let selectedToken5: CategorizedToken | undefined;
+	let selectedToken6: CategorizedToken | undefined;
+	let selectedToken7: CategorizedToken | undefined;
 
 	// Advanced Options
 	let showAdvancedOptions = false;
@@ -140,6 +141,13 @@
 	$: depositAmount7 = overrideDepositAmount7 ? overrideDepositAmount7 : 0n;
 
 	$: disableDeploy =
+		!selectedToken1 ||
+		!selectedToken2 ||
+		!selectedToken3 ||
+		!selectedToken4 ||
+		!selectedToken5 ||
+		!selectedToken6 ||
+		!selectedToken7 ||
 		overrideThresholdError ||
 		overrideFeeError ||
 		overrideDepositAmount1Error ||
@@ -165,15 +173,24 @@
 		outputVaultId7Error;
 
 	const handleFolioDeploy = () => {
-		if ($isAuthenticated) {
+		const tokens = [
+			selectedToken1,
+			selectedToken2,
+			selectedToken3,
+			selectedToken4,
+			selectedToken5,
+			selectedToken6,
+			selectedToken7
+		];
+		if ($isAuthenticated && tokens.every(Boolean)) {
 			transactionStore.handleFolioDeploy({
-				selectedToken1: selectedToken1,
-				selectedToken2: selectedToken2,
-				selectedToken3: selectedToken3,
-				selectedToken4: selectedToken4,
-				selectedToken5: selectedToken5,
-				selectedToken6: selectedToken6,
-				selectedToken7: selectedToken7,
+				selectedToken1: selectedToken1 as CategorizedToken,
+				selectedToken2: selectedToken2 as CategorizedToken,
+				selectedToken3: selectedToken3 as CategorizedToken,
+				selectedToken4: selectedToken4 as CategorizedToken,
+				selectedToken5: selectedToken5 as CategorizedToken,
+				selectedToken6: selectedToken6 as CategorizedToken,
+				selectedToken7: selectedToken7 as CategorizedToken,
 				overrideThreshold: overrideThreshold,
 				overrideFee: overrideFee,
 				depositAmount1: depositAmount1,
@@ -241,398 +258,402 @@
 			</div>
 		</div>
 
-		<div class="mb-6 flex items-center gap-3">
-			<button
-				on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
-				class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
-					? 'bg-blue-500'
-					: 'bg-gray-600'}"
-			>
-				<div
-					class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
-						? 'translate-x-6'
-						: 'translate-x-0.5'}"
-				/>
-			</button>
-			<span class="text-sm font-medium">Show advanced options</span>
-		</div>
-		{#if showAdvancedOptions}
-			<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
-				<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Threshold</span>
-					<Input
-						type="text"
-						placeholder="0.05"
-						bind:value={overrideThreshold}
-						bind:isError={overrideThresholdError}
+		{#if selectedToken1 && selectedToken2 && selectedToken3 && selectedToken4 && selectedToken5 && selectedToken6 && selectedToken7}
+			<div class="mb-6 flex items-center gap-3">
+				<button
+					on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
+					class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
+						? 'bg-blue-500'
+						: 'bg-gray-600'}"
+				>
+					<div
+						class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
+							? 'translate-x-6'
+							: 'translate-x-0.5'}"
 					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Fee</span>
-					<Input
-						type="text"
-						placeholder="0.003"
-						bind:value={overrideFee}
-						bind:isError={overrideFeeError}
-					/>
-				</div>
-
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 1 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken1}
-						bind:amount={overrideDepositAmount1}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount1Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 2 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken2}
-						bind:amount={overrideDepositAmount2}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount2Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 3 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken3}
-						bind:amount={overrideDepositAmount3}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount3Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 4 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken4}
-						bind:amount={overrideDepositAmount4}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount4Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 5 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken5}
-						bind:amount={overrideDepositAmount5}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount5Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 6 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken6}
-						bind:amount={overrideDepositAmount6}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount6Error}
-					/>
-				</div>
-				<div class="grid grid-cols-1 gap-3 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 7 Deposit Amount</span>
-					<TradeAmountInput
-						amountToken={selectedToken7}
-						bind:amount={overrideDepositAmount7}
-						validate={validateOverrideDepositAmount}
-						bind:isError={overrideDepositAmount7Error}
-					/>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 1 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken1.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken1.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 2 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken2.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken2.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 3 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken3.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId3} bind:isError={inputVaultId3Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken3.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId3} bind:isError={outputVaultId3Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 4 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken4.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId4} bind:isError={inputVaultId4Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken4.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId4} bind:isError={outputVaultId4Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 5 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken5.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId5} bind:isError={inputVaultId5Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken5.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId5} bind:isError={outputVaultId5Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 6 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken6.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId6} bind:isError={inputVaultId6Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken6.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId6} bind:isError={outputVaultId6Error} />
-					</div>
-				</div>
-				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-					<span class="block text-sm font-medium text-gray-300">Token 7 Vault ID</span>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Input {selectedToken7.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={inputVaultId7} bind:isError={inputVaultId7Error} />
-					</div>
-					<div class="flex flex-col gap-2">
-						<span class="text-left text-sm font-medium text-gray-400">
-							Output {selectedToken7.symbol} Vault ID
-						</span>
-						<VaultIdInput bind:vaultId={outputVaultId7} bind:isError={outputVaultId7Error} />
-					</div>
-				</div>
+				</button>
+				<span class="text-sm font-medium">Show advanced options</span>
 			</div>
+			{#if showAdvancedOptions}
+				<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
+					<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Threshold</span>
+						<Input
+							type="text"
+							placeholder="0.05"
+							bind:value={overrideThreshold}
+							bind:isError={overrideThresholdError}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Fee</span>
+						<Input
+							type="text"
+							placeholder="0.003"
+							bind:value={overrideFee}
+							bind:isError={overrideFeeError}
+						/>
+					</div>
+
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 1 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken1}
+							bind:amount={overrideDepositAmount1}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount1Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 2 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken2}
+							bind:amount={overrideDepositAmount2}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount2Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 3 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken3}
+							bind:amount={overrideDepositAmount3}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount3Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 4 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken4}
+							bind:amount={overrideDepositAmount4}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount4Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 5 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken5}
+							bind:amount={overrideDepositAmount5}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount5Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 6 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken6}
+							bind:amount={overrideDepositAmount6}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount6Error}
+						/>
+					</div>
+					<div class="grid grid-cols-1 gap-3 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 7 Deposit Amount</span>
+						<TradeAmountInput
+							amountToken={selectedToken7}
+							bind:amount={overrideDepositAmount7}
+							validate={validateOverrideDepositAmount}
+							bind:isError={overrideDepositAmount7Error}
+						/>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 1 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken1.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken1.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 2 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken2.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken2.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 3 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken3.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId3} bind:isError={inputVaultId3Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken3.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId3} bind:isError={outputVaultId3Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 4 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken4.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId4} bind:isError={inputVaultId4Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken4.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId4} bind:isError={outputVaultId4Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 5 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken5.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId5} bind:isError={inputVaultId5Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken5.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId5} bind:isError={outputVaultId5Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 6 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken6.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId6} bind:isError={inputVaultId6Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken6.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId6} bind:isError={outputVaultId6Error} />
+						</div>
+					</div>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-gray-300">Token 7 Vault ID</span>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Input {selectedToken7.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={inputVaultId7} bind:isError={inputVaultId7Error} />
+						</div>
+						<div class="flex flex-col gap-2">
+							<span class="text-left text-sm font-medium text-gray-400">
+								Output {selectedToken7.symbol} Vault ID
+							</span>
+							<VaultIdInput bind:vaultId={outputVaultId7} bind:isError={outputVaultId7Error} />
+						</div>
+					</div>
+				</div>
+			{/if}
 		{/if}
 	</div>
 
 	<!-- Order Summary and Button: always below form on mobile, side on desktop -->
-	<div class="mt-4 space-y-4 lg:mt-0">
-		<div class={containerStyles.cardBordered}>
-			<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
-			<div class="overflow-x-auto">
-				<table class="min-w-full text-sm text-gray-200">
-					<thead>
-						<tr>
-							<th class="px-2 py-1 text-left">Token</th>
-							<th class="px-2 py-1 text-right">Oracle Price</th>
-							<th class="px-2 py-1 text-right">Price Certainty</th>
-							<th class="px-2 py-1 text-right">Off-chain</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#if hasValidPriceFeedId(selectedToken1)}
-							<PythOracleRow token={selectedToken1} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
+	{#if selectedToken1 && selectedToken2 && selectedToken3 && selectedToken4 && selectedToken5 && selectedToken6 && selectedToken7}
+		<div class="mt-4 space-y-4 lg:mt-0">
+			<div class={containerStyles.cardBordered}>
+				<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
+				<div class="overflow-x-auto">
+					<table class="min-w-full text-sm text-gray-200">
+						<thead>
 							<tr>
-								<td class="px-2 py-1">{selectedToken1?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
+								<th class="px-2 py-1 text-left">Token</th>
+								<th class="px-2 py-1 text-right">Oracle Price</th>
+								<th class="px-2 py-1 text-right">Price Certainty</th>
+								<th class="px-2 py-1 text-right">Off-chain</th>
 							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken2)}
-							<PythOracleRow token={selectedToken2} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken2?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken3)}
-							<PythOracleRow token={selectedToken3} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken3?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken4)}
-							<PythOracleRow token={selectedToken4} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken4?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken5)}
-							<PythOracleRow token={selectedToken5} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken5?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken6)}
-							<PythOracleRow token={selectedToken6} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken6?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-						{#if hasValidPriceFeedId(selectedToken7)}
-							<PythOracleRow token={selectedToken7} tokenQuotes={$priceFeedsQuery?.data ?? []} />
-						{:else}
-							<tr>
-								<td class="px-2 py-1">{selectedToken7?.symbol ?? '-'}</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-								<td class="px-2 py-1 text-right">-</td>
-							</tr>
-						{/if}
-					</tbody>
-				</table>
+						</thead>
+						<tbody>
+							{#if hasValidPriceFeedId(selectedToken1)}
+								<PythOracleRow token={selectedToken1} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken1?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken2)}
+								<PythOracleRow token={selectedToken2} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken2?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken3)}
+								<PythOracleRow token={selectedToken3} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken3?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken4)}
+								<PythOracleRow token={selectedToken4} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken4?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken5)}
+								<PythOracleRow token={selectedToken5} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken5?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken6)}
+								<PythOracleRow token={selectedToken6} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken6?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+							{#if hasValidPriceFeedId(selectedToken7)}
+								<PythOracleRow token={selectedToken7} tokenQuotes={$priceFeedsQuery?.data ?? []} />
+							{:else}
+								<tr>
+									<td class="px-2 py-1">{selectedToken7?.symbol ?? '-'}</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+									<td class="px-2 py-1 text-right">-</td>
+								</tr>
+							{/if}
+						</tbody>
+					</table>
+				</div>
+				<!-- Removed mobile-only stacked cards; table above now scrolls on small screens -->
 			</div>
-			<!-- Removed mobile-only stacked cards; table above now scrolls on small screens -->
-		</div>
 
-		<div class={containerStyles.cardBordered}>
-			<h4 class="mb-3 text-sm font-medium text-gray-300">Portfolio Order Summary</h4>
-			<div class="space-y-2">
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Threshold</span>
-					<span class="font-medium text-white">{overrideThreshold || '0.05'}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Fee</span>
-					<span class="font-medium text-white">{overrideFee || '0.003'}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 1</span>
-					<span class="font-medium text-white">{selectedToken1.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 2</span>
-					<span class="font-medium text-white">{selectedToken2.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 3</span>
-					<span class="font-medium text-white">{selectedToken3.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 4</span>
-					<span class="font-medium text-white">{selectedToken4.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 5</span>
-					<span class="font-medium text-white">{selectedToken5.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 6</span>
-					<span class="font-medium text-white">{selectedToken6.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Selected Token 7</span>
-					<span class="font-medium text-white">{selectedToken7.symbol}</span>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 1 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount1 ?? 0n, selectedToken1.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 2 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount2 ?? 0n, selectedToken2.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 3 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount3 ?? 0n, selectedToken3.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 4 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount4 ?? 0n, selectedToken4.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 5 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount5 ?? 0n, selectedToken5.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 6 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount6 ?? 0n, selectedToken6.decimals)}</span
-					>
-				</div>
-				<div class="flex justify-between text-sm">
-					<span class="text-gray-400">Token 7 Deposit Amount</span>
-					<span class="font-medium text-white"
-						>{formatUnits(overrideDepositAmount7 ?? 0n, selectedToken7.decimals)}</span
-					>
+			<div class={containerStyles.cardBordered}>
+				<h4 class="mb-3 text-sm font-medium text-gray-300">Portfolio Order Summary</h4>
+				<div class="space-y-2">
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Threshold</span>
+						<span class="font-medium text-white">{overrideThreshold || '0.05'}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Fee</span>
+						<span class="font-medium text-white">{overrideFee || '0.003'}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 1</span>
+						<span class="font-medium text-white">{selectedToken1.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 2</span>
+						<span class="font-medium text-white">{selectedToken2.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 3</span>
+						<span class="font-medium text-white">{selectedToken3.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 4</span>
+						<span class="font-medium text-white">{selectedToken4.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 5</span>
+						<span class="font-medium text-white">{selectedToken5.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 6</span>
+						<span class="font-medium text-white">{selectedToken6.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Selected Token 7</span>
+						<span class="font-medium text-white">{selectedToken7.symbol}</span>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 1 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount1 ?? 0n, selectedToken1.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 2 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount2 ?? 0n, selectedToken2.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 3 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount3 ?? 0n, selectedToken3.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 4 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount4 ?? 0n, selectedToken4.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 5 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount5 ?? 0n, selectedToken5.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 6 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount6 ?? 0n, selectedToken6.decimals)}</span
+						>
+					</div>
+					<div class="flex justify-between text-sm">
+						<span class="text-gray-400">Token 7 Deposit Amount</span>
+						<span class="font-medium text-white"
+							>{formatUnits(overrideDepositAmount7 ?? 0n, selectedToken7.decimals)}</span
+						>
+					</div>
 				</div>
 			</div>
-		</div>
 
-		<Button
-			variant="primary"
-			size="lg"
-			fullWidth={true}
-			disabled={disableDeploy}
-			on:click={handleFolioDeploy}
-		>
-			Deploy Order
-		</Button>
-	</div>
+			<Button
+				variant="primary"
+				size="lg"
+				fullWidth={true}
+				disabled={disableDeploy}
+				on:click={handleFolioDeploy}
+			>
+				Deploy Order
+			</Button>
+		</div>
+	{/if}
 </div>

--- a/src/lib/components/orders/LimitOrder.svelte
+++ b/src/lib/components/orders/LimitOrder.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { getAllTokensByNetwork } from '$lib/config/network';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import type { CategorizedToken } from '$lib/config/network';
+	import { createApiTokensQuery } from '$lib/queries/tokens';
 	import { validateBaseline, validateSelectedAmount } from '$lib/utils/validation';
 	import Input from '$lib/components/ui/Input.svelte';
 	import { formatUnits, parseUnits } from 'viem';
@@ -77,8 +77,8 @@
 	$: showShareEquivalent = displayDenom === 'unwrapped' && displayScale !== 1;
 	$: wtDecimalsForSummary = showShareEquivalent ? 5 : 3;
 
-	// Filter tokens based on current network
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
 	// Initialize tokens - trading token from prop, settlement token for settlement
 	let settlementToken: CategorizedToken | undefined;
@@ -91,11 +91,10 @@
 	$: if ($currentNetwork && ALL_TOKENS.length > 0) {
 		const settlementTokenConfig = $currentNetwork.defaultPaymentToken;
 		if (settlementTokenConfig) {
-			// eslint-disable-next-line no-restricted-syntax -- justification: lookup against the network-scoped ALL_TOKENS universe (assets + payment tokens) for a payment-token (USDC). DRIFT-01's getTokenByAnyAddress only resolves ST0x asset-token address variants and would never match USDC, so it is not a valid replacement here.
 			const match = ALL_TOKENS.find(
 				(token) => token.address.toLowerCase() === settlementTokenConfig.address.toLowerCase()
 			);
-			settlementToken = match || (settlementTokenConfig as unknown as CategorizedToken);
+			settlementToken = match || settlementToken;
 		} else {
 			settlementToken = ALL_TOKENS[0];
 		}

--- a/src/lib/queries/tokens.ts
+++ b/src/lib/queries/tokens.ts
@@ -1,0 +1,120 @@
+import { browser } from '$app/environment';
+import { createQuery } from '@tanstack/svelte-query';
+import { apiGetTokens, type ApiToken } from '$lib/api/st0xApi';
+import type { CategorizedToken, TokenCategory } from '$lib/config/tokens';
+
+type ApiTokenExtensions = {
+	category?: unknown;
+	unwrappedAddress?: unknown;
+	legacyAddress?: unknown;
+	legacySymbol?: unknown;
+	tradingViewSymbol?: unknown;
+	tradingViewMarket?: unknown;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getApiChainId(token: ApiToken): number | null {
+	const network = asRecord(token.network);
+	const chainId = network?.chainId ?? network?.networkId;
+	return typeof chainId === 'number' && Number.isFinite(chainId) ? chainId : null;
+}
+
+function getApiExtensions(token: ApiToken): ApiTokenExtensions {
+	return asRecord(token.extensions) ?? {};
+}
+
+function getApiCategory(token: ApiToken): TokenCategory | null {
+	const category = asString(getApiExtensions(token).category);
+	if (category === 'ST0x' || category === 'CRYPTO') return category;
+	return 'CRYPTO';
+}
+
+function normalizeApiToken(token: ApiToken): CategorizedToken | null {
+	const chainId = getApiChainId(token);
+	const category = getApiCategory(token);
+	if (
+		!chainId ||
+		!token.address ||
+		!token.symbol ||
+		typeof token.decimals !== 'number' ||
+		!category
+	) {
+		return null;
+	}
+
+	const extensions = getApiExtensions(token);
+
+	return {
+		chainId,
+		address: token.address,
+		symbol: token.symbol,
+		decimals: token.decimals,
+		name: token.name ?? token.label ?? token.symbol,
+		logoUrl: asString(token['logo-uri']),
+		priceFeedId: '',
+		category,
+		tradingViewSymbol: asString(extensions.tradingViewSymbol),
+		tradingViewMarket: asString(extensions.tradingViewMarket),
+		unwrappedAddress: asString(extensions.unwrappedAddress),
+		legacyAddress: asString(extensions.legacyAddress),
+		legacySymbol: asString(extensions.legacySymbol),
+		limitOrders: []
+	};
+}
+
+export function normalizeApiTokensForNetwork(
+	apiTokens: ApiToken[],
+	chainId: number
+): CategorizedToken[] {
+	const seen = new Set<string>();
+	const result: CategorizedToken[] = [];
+
+	for (const apiToken of apiTokens) {
+		const normalized = normalizeApiToken(apiToken);
+		if (!normalized || normalized.chainId !== chainId) continue;
+
+		const addressKey = normalized.address.toLowerCase();
+		if (seen.has(addressKey)) continue;
+		seen.add(addressKey);
+		result.push(normalized);
+	}
+
+	return result;
+}
+
+export function getTokenAddressVariants(token: CategorizedToken): string[] {
+	return [
+		token.address,
+		...(token.unwrappedAddress ? [token.unwrappedAddress] : []),
+		...(token.legacyAddress ? [token.legacyAddress] : [])
+	].map((address) => address.toLowerCase());
+}
+
+export function findApiTokenByAnyAddress(
+	tokens: CategorizedToken[],
+	address: string | null | undefined
+): CategorizedToken | null {
+	const normalized = address?.toLowerCase();
+	if (!normalized) return null;
+
+	return tokens.find((token) => getTokenAddressVariants(token).includes(normalized)) ?? null;
+}
+
+export function createApiTokensQuery(chainId: number | null | undefined) {
+	return createQuery<CategorizedToken[]>({
+		queryKey: ['st0xApiTokens', chainId],
+		enabled: Boolean(browser && chainId),
+		staleTime: 0,
+		retry: 2,
+		refetchOnMount: 'always',
+		refetchOnWindowFocus: true,
+		queryFn: async () => normalizeApiTokensForNetwork(await apiGetTokens(), chainId as number)
+	});
+}

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -4,7 +4,7 @@
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import TokenDisplay from '$lib/components/ui/TokenDisplay.svelte';
-	import { getAllTokensByNetwork, getTokenByAnyAddress } from '$lib/config/network';
+	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
 	import { formatUnits } from 'viem';
@@ -63,8 +63,8 @@
 		}
 	}
 
-	// Filter tokens by current network
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: apiTokens = $apiTokensQuery.data ?? [];
 
 	// Price feeds query — same source the sidebar uses for symbol-based price lookup
 	let priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
@@ -145,9 +145,9 @@
 				// Resolve token info (handles wrapped/unwrapped/legacy address variants),
 				// then use symbol-based lookup against the priceFeeds query — same pattern
 				// the sidebar uses so home/sidebar stay consistent.
-				const tokenInfo = getTokenByAnyAddress(sft.address);
+				const tokenInfo = findApiTokenByAnyAddress(apiTokens, sft.address);
 				const symbolForPrice = tokenInfo?.symbol ?? sft.symbol;
-				const quote = findQuoteForSymbol(symbolForPrice, priceQuotes, ALL_TOKENS);
+				const quote = findQuoteForSymbol(symbolForPrice, priceQuotes, apiTokens);
 				const price = quote?.close ?? null;
 
 				rows.push({
@@ -421,7 +421,7 @@
 									>
 										<td class="sticky left-0 z-10 px-3 py-3 sm:px-5 sm:py-4">
 											<TokenDisplay
-												logoUrl={getTokenByAnyAddress(token.address)?.logoUrl}
+												logoUrl={findApiTokenByAnyAddress(apiTokens, token.address)?.logoUrl}
 												symbol={token.symbol}
 												name={token.name}
 											/>

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -22,8 +22,7 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { formatUnits, erc20Abi } from 'viem';
 	import { readContracts, getBalance } from '@wagmi/core';
-	import { getAllTokensByNetwork } from '$lib/config/network';
-	import { TOKENS, PAYMENT_TOKENS_BY_NETWORK, getTokenByAnyAddress } from '$lib/config/tokens';
+	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import { goto } from '$app/navigation';
 	import { transformApiTakerTradesToDisplay } from '$lib/utils/tradeTransform';
 	import Table from '$lib/components/ui/table/Table.svelte';
@@ -73,22 +72,18 @@
 	// Default vault ID (0x1 padded to 32 bytes)
 	const DEFAULT_VAULT_ID = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
-	// Filter tokens by current network
-	$: ALL_TOKENS = $currentNetwork ? getAllTokensByNetwork($currentNetwork.chainId) : [];
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
+	$: paymentTokens = ALL_TOKENS.filter((token) => token.category === 'CRYPTO');
 
 	// Set of valid token addresses (asset tokens + payment tokens) for filtering
 	$: validTokenAddresses = (() => {
 		if (!$currentNetwork) return new Set<string>();
 		const addresses = new Set<string>();
-		// Add asset tokens for current network
-		for (const token of TOKENS) {
-			if (token.chainId === $currentNetwork.chainId) {
-				addresses.add(token.address.toLowerCase());
-			}
-		}
-		// Add payment tokens for current network
-		const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork.chainId] ?? [];
 		for (const token of paymentTokens) {
+			addresses.add(token.address.toLowerCase());
+		}
+		for (const token of ALL_TOKENS.filter((token) => token.category === 'ST0x')) {
 			addresses.add(token.address.toLowerCase());
 		}
 		return addresses;
@@ -98,10 +93,8 @@
 	$: tStockAddresses = (() => {
 		if (!$currentNetwork) return new Set<string>();
 		const addresses = new Set<string>();
-		for (const token of TOKENS) {
-			if (token.chainId === $currentNetwork.chainId && token.category === 'ST0x') {
-				addresses.add(token.address.toLowerCase());
-			}
+		for (const token of ALL_TOKENS.filter((token) => token.category === 'ST0x')) {
+			addresses.add(token.address.toLowerCase());
 		}
 		return addresses;
 	})();
@@ -351,13 +344,20 @@
 	$: vaultsListQuery = createUserVaultsQuery($currentNetwork, $walletAddress);
 
 	// Query user's wallet holdings from SFTs - fetches balances via multicall (single RPC request)
-	// We query balances on WRAPPED token addresses (from TOKENS config) since that's what users trade
+	// We query balances on wrapped token addresses from the REST API token list since those are traded.
 	const walletHoldingsQuery = createQuery(
 		derived(
 			[isAuthenticated, walletAddress, sfts, currentNetwork, wagmiConfig],
 			([$isAuthenticated, $walletAddress, $sfts, $currentNetwork, $wagmiConfig]) => ({
 				queryKey: ['walletHoldings', $walletAddress, $currentNetwork?.id, $sfts?.length],
-				enabled: !!($isAuthenticated && $walletAddress && $sfts && $currentNetwork && $wagmiConfig),
+				enabled: !!(
+					$isAuthenticated &&
+					$walletAddress &&
+					$sfts &&
+					$currentNetwork &&
+					$wagmiConfig &&
+					ALL_TOKENS.length
+				),
 				refetchOnMount: 'always' as const,
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
 				staleTime: QUERY_STALE_TIME_MS,
@@ -365,13 +365,13 @@
 					if (!$sfts || !$walletAddress || !$wagmiConfig) return [];
 					const normalizedWalletAddress = $walletAddress.toLowerCase();
 
-					// Map subgraph SFTs to their wrapped token addresses from TOKENS config
+					// Map subgraph SFTs to their wrapped token addresses from the API token list.
 					// The subgraph returns unwrapped addresses, but we need to query wrapped token balances
 					const sftsWithWrappedAddresses = $sfts.map((sft) => {
-						const tokenConfig = getTokenByAnyAddress(sft.address);
+						const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
 						return {
 							...sft,
-							wrappedAddress: tokenConfig?.address ?? sft.address // Use wrapped address if found
+							wrappedAddress: tokenConfig?.address ?? sft.address
 						};
 					});
 
@@ -402,8 +402,7 @@
 								walletBalance = userHolder ? BigInt(userHolder.balance) : 0n;
 							}
 
-							// Use wrapped token info from config
-							const tokenConfig = getTokenByAnyAddress(sft.address);
+							const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
 
 							return {
 								id: sft.id,
@@ -422,7 +421,7 @@
 								(holder: { address: string }) =>
 									holder.address.toLowerCase() === normalizedWalletAddress
 							);
-							const tokenConfig = getTokenByAnyAddress(sft.address);
+							const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
 							return {
 								id: sft.id,
 								address: tokenConfig?.address ?? sft.address,
@@ -450,7 +449,6 @@
 				staleTime: QUERY_STALE_TIME_MS,
 				queryFn: async () => {
 					if (!$currentNetwork || !$walletAddress || !$wagmiConfig) return [];
-					const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork.chainId] ?? [];
 					if (paymentTokens.length === 0) return [];
 
 					const contracts = paymentTokens.map((token) => ({
@@ -797,7 +795,6 @@
 	// Split portfolio into funds (payment tokens) and holdings (asset tokens)
 	$: paymentTokenAddresses = (() => {
 		if (!$currentNetwork) return new Set<string>();
-		const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork.chainId] ?? [];
 		return new Set(paymentTokens.map((t) => t.address.toLowerCase()));
 	})();
 
@@ -809,7 +806,6 @@
 		);
 
 		// Ensure USDC is always shown (even with 0 balance)
-		const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[$currentNetwork?.chainId ?? 0] ?? [];
 		for (const token of paymentTokens) {
 			const exists = funds.some((f) => f.address.toLowerCase() === token.address.toLowerCase());
 			if (!exists) {
@@ -1343,7 +1339,7 @@
 											{@const isEth = holding.address === 'native'}
 											{@const paymentToken = isEth
 												? null
-												: (PAYMENT_TOKENS_BY_NETWORK[$currentNetwork?.chainId ?? 0] ?? []).find(
+												: paymentTokens.find(
 														(t) => t.address.toLowerCase() === holding.address.toLowerCase()
 													)}
 											{@const logoUrl = isEth ? '/images/ETH.svg' : paymentToken?.logoUrl}
@@ -1458,7 +1454,7 @@
 											<tr class="hover:bg-white/5">
 												<td class="sticky left-0 px-2 py-2 sm:px-4 sm:py-3">
 													<TokenDisplay
-														logoUrl={getTokenByAnyAddress(holding.address)?.logoUrl}
+														logoUrl={findApiTokenByAnyAddress(ALL_TOKENS, holding.address)?.logoUrl}
 														symbol={rowSymbol}
 														name={holding.name}
 														hideNameOnMobile={true}
@@ -1592,7 +1588,8 @@
 																		address: holding.address,
 																		symbol: holding.symbol,
 																		decimals: holding.decimals,
-																		image: getTokenByAnyAddress(holding.address)?.logoUrl
+																		image: findApiTokenByAnyAddress(ALL_TOKENS, holding.address)
+																			?.logoUrl
 																	})}
 																class="inline-flex items-center justify-center rounded-md border border-white/10 bg-white/5 p-1.5 text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300"
 																title="Track in Wallet"

--- a/src/routes/(main)/platform-metrics/+page.svelte
+++ b/src/routes/(main)/platform-metrics/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import Footer from '$lib/components/Footer.svelte';
 	import Section from '$lib/components/ui/Section.svelte';
-	import { getAllTokensByNetwork, networks, TOKENS, CRYPTO_TOKENS } from '$lib/config/network';
+	import { networks } from '$lib/config/network';
 	import type { CategorizedToken, Network } from '$lib/config/network';
+	import { apiGetTokens } from '$lib/api/st0xApi';
 	import type { TradingViewQuote } from '$lib/api/tradingview';
 	import PageContainer from '$lib/components/ui/PageContainer.svelte';
 	import MetricCard from '$lib/components/ui/MetricCard.svelte';
@@ -17,10 +18,13 @@
 	import type { GetVaultsFilters, RaindexVault } from '@rainlanguage/orderbook';
 	import { createOrderbookQuotesQuery } from '$lib/queries/orderbook';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
+	import { normalizeApiTokensForNetwork } from '$lib/queries/tokens';
 	import type { PublicTradeActivityResponse } from '../../api/public/trade-activity/+server';
 	import { trackPageView } from '$lib/services/analytics';
 	import { initScrollTracking } from '$lib/utils/scrollTracking';
 	import { walletAddress } from '$lib/stores/authStore';
+	import { createQuery } from '@tanstack/svelte-query';
+	import { browser } from '$app/environment';
 
 	interface TvlApiResponse {
 		success: boolean;
@@ -44,6 +48,23 @@
 
 	const priceFeedQueries = networks.map((network) => createPriceFeedsQuery(network));
 	const orderbookQueries = networks.map((network) => createOrderbookQuotesQuery(network));
+	const apiTokensQuery = createQuery<CategorizedToken[]>({
+		queryKey: ['st0xApiTokens', 'allNetworks'],
+		enabled: browser,
+		staleTime: 0,
+		refetchOnMount: 'always',
+		refetchOnWindowFocus: true,
+		queryFn: async () => {
+			const apiTokens = await apiGetTokens();
+			const tokens = networks.flatMap((network) =>
+				normalizeApiTokensForNetwork(apiTokens, network.chainId)
+			);
+			return tokens.filter(
+				(token, index, self) =>
+					index === self.findIndex((t) => t.address.toLowerCase() === token.address.toLowerCase())
+			);
+		}
+	});
 
 	const allPriceFeedQueries = derived(priceFeedQueries, (queries) => queries);
 	const allOrderbookQueries = derived(orderbookQueries, (queries) => queries);
@@ -222,26 +243,14 @@
 	}
 
 	// Token metadata helpers
-	$: ALL_TOKENS = (() => {
-		const allTokens: CategorizedToken[] = [];
-		networks.forEach((network) => {
-			const networkTokens = getAllTokensByNetwork(network.chainId);
-			allTokens.push(...networkTokens);
-		});
-		return allTokens.filter(
-			(token, index, self) =>
-				index === self.findIndex((t) => t.address.toLowerCase() === token.address.toLowerCase())
-		);
-	})();
+	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
 	let tokenLookup: TokenLookup<CategorizedToken> = createTokenLookup([]);
 	$: tokenLookup = createTokenLookup(ALL_TOKENS);
 
 	// Create canonical token set (both ST0x and Crypto tokens)
 	$: canonicalTokens = new Set<string>(
-		[...TOKENS, ...CRYPTO_TOKENS]
-			.map((token) => normalizeAddress(token.address))
-			.filter(Boolean) as string[]
+		ALL_TOKENS.map((token) => normalizeAddress(token.address)).filter(Boolean) as string[]
 	);
 
 	// Map per-network server response by chainId for quick lookup
@@ -314,7 +323,7 @@
 
 	// Build a set of tStock addresses for identification
 	$: tStockAddresses = new Set<string>(
-		TOKENS.filter((t) => t.category === 'ST0x')
+		ALL_TOKENS.filter((t) => t.category === 'ST0x')
 			.map((t) => normalizeAddress(t.address))
 			.filter(Boolean) as string[]
 	);
@@ -507,10 +516,12 @@
 		// Calculate per-network TVL from admin token TVL data
 		// Sum up TVL for tokens that belong to this network
 		let networkTvl = 0;
-		TOKENS.filter((t) => t.chainId === network.chainId).forEach((token) => {
-			const tokenTvl = adminTokenTvl[token.symbol] ?? 0;
-			networkTvl += tokenTvl;
-		});
+		ALL_TOKENS.filter((t) => t.chainId === network.chainId && t.category === 'ST0x').forEach(
+			(token) => {
+				const tokenTvl = adminTokenTvl[token.symbol] ?? 0;
+				networkTvl += tokenTvl;
+			}
+		);
 
 		return {
 			network,

--- a/src/routes/(main)/trade/[id]/+layout.ts
+++ b/src/routes/(main)/trade/[id]/+layout.ts
@@ -1,19 +1,22 @@
 import { redirect } from '@sveltejs/kit';
-import { getTokenByAnyAddress, isWrappedTokenAddress } from '$lib/config/tokens';
+import type { ApiToken } from '$lib/api/st0xApi';
+import { findApiTokenByAnyAddress, normalizeApiTokensForNetwork } from '$lib/queries/tokens';
 
 export const ssr = false;
 export const prerender = false;
 
-export function load({ params }) {
+export async function load({ params, fetch }) {
 	const tokenId = params.id;
 
-	// If not a wrapped token, try to redirect to the correct wrapped token
-	if (!isWrappedTokenAddress(tokenId)) {
-		const token = getTokenByAnyAddress(tokenId);
-		if (token) {
-			// Redirect legacy/unwrapped URLs to the wrapped token URL
-			throw redirect(301, `/trade/${token.address}`);
-		}
+	const response = await fetch('/api/st0x/v1/tokens');
+	if (!response.ok) {
+		return {};
+	}
+
+	const tokens = normalizeApiTokensForNetwork((await response.json()) as ApiToken[], 8453);
+	const token = findApiTokenByAnyAddress(tokens, tokenId);
+	if (token && token.address.toLowerCase() !== tokenId.toLowerCase()) {
+		throw redirect(301, `/trade/${token.address}`);
 	}
 
 	return {};

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import { currentNetwork, oracleQuotes, tradePanelOpen } from '$lib/stores';
 	import { formatUnits } from 'viem';
-	import { TOKENS, getTokenByAnyAddress } from '$lib/config/network';
+	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	// PERF-01: LimitOrder + DcaOrder are lazy-loaded via {#await import()} below
 	// (only fetched when their tab is selected). MarketOrder stays eager — it is
@@ -106,7 +106,9 @@
 	// Use single token query - checks global cache first, falls back to single fetch
 	$: singleTokenQuery = createSingleSftQuery(tokenId, $currentNetwork, queryClient);
 	$: currentToken = $singleTokenQuery.data;
-	const tokensLookup = createTokenLookup(TOKENS);
+	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	$: apiTokens = $apiTokensQuery.data ?? [];
+	$: tokensLookup = createTokenLookup(apiTokens);
 	let orderbookQuotesQuery = createTokenOrderbookQuotesQuery(
 		$currentNetwork,
 		currentToken?.address ?? null
@@ -354,10 +356,7 @@
 	// Note: currentToken.address from subgraph may differ from the wrapped token address
 	$: currentPythToken = (() => {
 		if (!tokenId || !$currentNetwork?.chainId) return undefined;
-		// DRIFT-01: getTokenByAnyAddress already matches wrapped/unwrapped/legacy
-		// address variants (and the wrapped-address path is a strict subset of
-		// what it covers), so the previous two-step lookup collapses to one call.
-		const match = getTokenByAnyAddress(tokenId);
+		const match = findApiTokenByAnyAddress(apiTokens, tokenId);
 		return match?.chainId === $currentNetwork.chainId ? match : undefined;
 	})();
 	$: baseSymbol = extractBaseSymbol(currentToken?.symbol);

--- a/tests/lib/queries/tokens.test.ts
+++ b/tests/lib/queries/tokens.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeApiTokensForNetwork } from '../../../src/lib/queries/tokens';
+import type { ApiToken } from '../../../src/lib/api/st0xApi';
+
+function apiToken(overrides: Partial<ApiToken>): ApiToken {
+	return {
+		address: '0x0000000000000000000000000000000000000001',
+		symbol: 'wtTEST',
+		decimals: 18,
+		name: 'Wrapped Test',
+		network: { chainId: 8453 },
+		extensions: { category: 'ST0x' },
+		...overrides
+	} as ApiToken;
+}
+
+describe('normalizeApiTokensForNetwork', () => {
+	it('uses API tokens as the returned token universe for a network', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({
+					address: '0x1111111111111111111111111111111111111111',
+					symbol: 'wtNEW',
+					name: 'Wrapped New Asset',
+					'logo-uri': 'https://st0x.io/images/NEW.png',
+					extensions: {
+						category: 'ST0x',
+						unwrappedAddress: '0x2222222222222222222222222222222222222222',
+						tradingViewSymbol: 'NASDAQ:NEW',
+						tradingViewMarket: 'america'
+					}
+				}),
+				apiToken({
+					address: '0x3333333333333333333333333333333333333333',
+					symbol: 'wtOTHER',
+					network: { chainId: 9999 }
+				})
+			],
+			8453
+		);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({
+			address: '0x1111111111111111111111111111111111111111',
+			symbol: 'wtNEW',
+			name: 'Wrapped New Asset',
+			logoUrl: 'https://st0x.io/images/NEW.png',
+			category: 'ST0x',
+			unwrappedAddress: '0x2222222222222222222222222222222222222222',
+			tradingViewSymbol: 'NASDAQ:NEW',
+			tradingViewMarket: 'america'
+		});
+	});
+
+	it('uses server-provided metadata without merging static token config', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({
+					address: '0x5cda0e1ca4ce2af96315f7f8963c85399c172204',
+					symbol: 'wtCOIN',
+					name: 'Wrapped Coinbase Global Inc ST0x',
+					'logo-uri': 'https://st0x.io/images/COIN-from-api.png',
+					extensions: {
+						category: 'ST0x',
+						unwrappedAddress: '0x626757e6f50675d17fcad312e82f989ae7a23d38'
+					}
+				})
+			],
+			8453
+		);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].symbol).toBe('wtCOIN');
+		expect(tokens[0].logoUrl).toBe('https://st0x.io/images/COIN-from-api.png');
+		expect(tokens[0].priceFeedId).toBe('');
+		expect(tokens[0].legacyAddress).toBeUndefined();
+	});
+
+	it('deduplicates API tokens by address', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({ address: '0x1111111111111111111111111111111111111111', symbol: 'wtONE' }),
+				apiToken({ address: '0x1111111111111111111111111111111111111111', symbol: 'wtTWO' })
+			],
+			8453
+		);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].symbol).toBe('wtONE');
+	});
+
+	it('keeps uncategorized API tokens as crypto tokens', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({
+					address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+					symbol: 'USDC',
+					name: 'USD Coin',
+					decimals: 6,
+					extensions: {}
+				})
+			],
+			8453
+		);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({
+			symbol: 'USDC',
+			category: 'CRYPTO',
+			decimals: 6
+		});
+	});
+});


### PR DESCRIPTION
## Linear
- Closes RAI-338: https://linear.app/makeitrain/issue/RAI-338/move-st0x-token-list-from-hardcoded-values-to-api-endpoint

## Dependencies
- Stacked on website PR: https://github.com/SARKEX/st0x/pull/199
- Upstack website PR: https://github.com/SARKEX/st0x/pull/201

## Summary
- loads the website token universe from /api/st0x/v1/tokens via a shared Svelte Query normalizer
- uses API token metadata across home, sidebar, dashboard, platform metrics, trade routing, transfer/funds UI, and order builders
- removes static token-list fallbacks from the migrated browser-facing token selection/display paths
- keeps legacy migration/wrapping/reporting utilities on local metadata where the REST token endpoint does not yet replace those specialized maps

## Local verification
- npm run test -- run tests/lib/queries/tokens.test.ts tests/lib/api/st0x-proxy.test.ts
- npm run check (fails only on existing @playwright/test type-resolution errors under tests/integration/ui)
- npm run dev -- --host 127.0.0.1 --port 5173
- curl http://127.0.0.1:5173/api/st0x/v1/tokens -> 200, 16 production tokens, includes USDC and 15 ST0x tokens
- curl http://127.0.0.1:5173/ -> 200
- curl http://127.0.0.1:5173/dashboard -> 200
- curl http://127.0.0.1:5173/platform-metrics -> 200