### PR TITLE
PR1 — Design language v2 + mobile-first navigation + animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ CLAUDE.md
 stats.html
 .svelte-kit/output/client/stats.html
 test-results/
+design-ref/

--- a/src/app.css
+++ b/src/app.css
@@ -157,16 +157,163 @@ input[type='range']::-moz-range-thumb {
 	}
 }
 
+/* ---------- micro-interactions (v2 design language) ----------
+   Small, hover-driven life for icons and cards. Pattern: put `icon-trigger`
+   on the hoverable container; inner elements opt in via `icon-slide`,
+   `icon-spin-hover`, or per-glyph rules keyed off the Icon component's
+   `icon-<name>` class. All of it is disabled under prefers-reduced-motion. */
+
+@keyframes pillar-float {
+	0%,
+	100% {
+		transform: translateY(0);
+	}
+	50% {
+		transform: translateY(-5px);
+	}
+}
+@keyframes glyph-pop {
+	0% {
+		transform: scale(0.55);
+		opacity: 0.25;
+	}
+	60% {
+		transform: scale(1.15);
+	}
+	100% {
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+@keyframes glyph-nudge-right {
+	0%,
+	100% {
+		transform: translateX(0);
+	}
+	45% {
+		transform: translateX(2.5px);
+	}
+}
+@keyframes glyph-nudge-left {
+	0%,
+	100% {
+		transform: translateX(0);
+	}
+	45% {
+		transform: translateX(-2.5px);
+	}
+}
+@keyframes glyph-draw {
+	from {
+		stroke-dashoffset: 72;
+	}
+	to {
+		stroke-dashoffset: 0;
+	}
+}
+
+/* Ambient float for the home trust pillars — stagger with animation-delay. */
+.pillar-float {
+	animation: pillar-float 7s ease-in-out infinite;
+}
+.pillar-tile {
+	transition:
+		transform 0.3s ease,
+		box-shadow 0.3s ease,
+		background-color 0.3s ease;
+}
+.icon-trigger:hover .pillar-tile {
+	transform: translateY(-3px) scale(1.05);
+	background-color: var(--accent-soft);
+	box-shadow: 0 12px 32px -10px var(--accent-glow);
+}
+
+/* Glyph choreography on hover: blocks reassemble, swap arrows flow, shield redraws. */
+.icon-trigger:hover .icon-blocks rect {
+	transform-box: fill-box;
+	transform-origin: center;
+	animation: glyph-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.icon-trigger:hover .icon-blocks rect:nth-of-type(2) {
+	animation-delay: 0.07s;
+}
+.icon-trigger:hover .icon-blocks rect:nth-of-type(3) {
+	animation-delay: 0.14s;
+}
+.icon-trigger:hover .icon-blocks rect:nth-of-type(4) {
+	animation-delay: 0.21s;
+}
+.icon-trigger:hover .icon-swap path:first-of-type {
+	animation: glyph-nudge-right 0.55s ease both;
+}
+.icon-trigger:hover .icon-swap path:last-of-type {
+	animation: glyph-nudge-left 0.55s ease both;
+}
+.icon-trigger:hover .icon-shield path {
+	stroke-dasharray: 72;
+	animation: glyph-draw 0.7s ease both;
+}
+
+/* Generic hover sprinkles. */
+.icon-slide {
+	transition: transform 0.2s ease;
+}
+.icon-trigger:hover .icon-slide {
+	transform: translateX(3px);
+}
+.icon-slide-up {
+	transition: transform 0.2s ease;
+}
+.icon-trigger:hover .icon-slide-up {
+	transform: translate(2px, -2px);
+}
+.icon-spin-hover {
+	transition: transform 0.4s ease;
+}
+.icon-trigger:hover .icon-spin-hover {
+	transform: rotate(15deg) scale(1.08);
+}
+.hover-lift {
+	transition:
+		transform 0.25s ease,
+		box-shadow 0.25s ease,
+		border-color 0.25s ease;
+}
+.hover-lift:hover {
+	transform: translateY(-3px);
+	box-shadow: 0 14px 34px -14px var(--accent-glow);
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.chart-scroll,
 	[class*='animate-'] {
 		animation: none !important;
 	}
+	.pillar-float,
+	.icon-trigger:hover .icon-blocks rect,
+	.icon-trigger:hover .icon-swap path,
+	.icon-trigger:hover .icon-shield path {
+		animation: none !important;
+	}
+	.pillar-tile,
+	.icon-slide,
+	.icon-slide-up,
+	.icon-spin-hover,
+	.hover-lift {
+		transition: none;
+	}
+	.icon-trigger:hover .pillar-tile,
+	.icon-trigger:hover .icon-slide,
+	.icon-trigger:hover .icon-slide-up,
+	.icon-trigger:hover .icon-spin-hover,
+	.hover-lift:hover {
+		transform: none;
+	}
 }
 
-/* Wallet "Connect" flow can surface from inside an in-app modal (e.g. the
-   Save & Earn modal at z-[2200]). Two different overlays can render the wallet
-   picker depending on auth path, and both default to a z-index below our modals:
+/* Wallet "Connect" flow can surface from inside an in-app modal. Two
+   different overlays can render the wallet picker depending on auth path,
+   and both default to a z-index below our modals:
    - Dynamic Labs' embedded-wallet flow renders inside a `.dynamic-shadow-dom` host.
    - WalletConnect / Web3Modal renders an `<w3m-modal>` (default z-index 999).
    Lift both above every in-app modal so the wallet flow is never hidden behind. */

--- a/src/app.css
+++ b/src/app.css
@@ -1,40 +1,180 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;200;300;400;500;600;700;800;900&display=swap');
-@import '@fontsource/ia-writer-mono';
+@import './lib/styles/tokens.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-	font-family: 'DM Sans', sans-serif;
-	color: #ffffff;
-	background-color: #030712;
+	font-family: var(--font-sans);
+	color: var(--text);
+	background-color: var(--bg);
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	transition:
+		background-color 0.5s var(--ease),
+		color 0.5s var(--ease);
+}
+
+/* Display font on real headings — the design-language signature */
+h1,
+h2,
+h3,
+h4 {
+	font-family: var(--font-display);
+	letter-spacing: -0.02em;
+}
+
+.font-display {
+	font-family: var(--font-display);
+	letter-spacing: -0.02em;
+}
+
+.font-mono {
+	font-variant-numeric: tabular-nums;
+	font-feature-settings:
+		'tnum' 1,
+		'zero' 1;
+}
+
+::selection {
+	background: var(--accent-soft);
+	color: var(--text);
 }
 
 *:focus {
 	outline: none;
 }
 
-.tab {
-	@apply flex h-full w-32 items-center justify-center gap-2 self-start border-4 border-white px-4 py-2 font-bold text-white;
-	border-style: outset;
+/* ---- range slider (mint) ---- */
+input[type='range'] {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 6px;
+	border-radius: 999px;
+	background: var(--surface-3);
+}
+input[type='range']::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 18px;
+	width: 18px;
+	border-radius: 50%;
+	background: var(--accent);
+	cursor: pointer;
+	border: 3px solid var(--accent-ink);
+	box-shadow: 0 0 0 1px var(--accent-line);
+}
+input[type='range']::-moz-range-thumb {
+	height: 18px;
+	width: 18px;
+	border-radius: 50%;
+	background: var(--accent);
+	cursor: pointer;
+	border: 3px solid var(--accent-ink);
 }
 
-.inset {
-	border-style: inset;
+/* ---- scrollbars ---- */
+.overflow-y-auto::-webkit-scrollbar,
+.overflow-x-auto::-webkit-scrollbar {
+	width: 9px;
+	height: 9px;
+}
+.overflow-y-auto::-webkit-scrollbar-thumb,
+.overflow-x-auto::-webkit-scrollbar-thumb {
+	background: var(--line-strong);
+	border-radius: 999px;
+}
+.overflow-y-auto::-webkit-scrollbar-track,
+.overflow-x-auto::-webkit-scrollbar-track {
+	background: transparent;
+}
+.no-bar::-webkit-scrollbar {
+	display: none;
+}
+.no-bar {
+	scrollbar-width: none;
 }
 
-.outset {
-	border-style: outset;
+/* ---- v2 motion keyframes (used by product screens + ambient) ---- */
+@keyframes chartscroll {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(-50%);
+	}
 }
-
-@layer utilities {
-	.border-outset {
-		border-style: outset;
+@keyframes tickertape {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(-50%);
+	}
+}
+@keyframes glowFloat1 {
+	0%,
+	100% {
+		transform: translate(-50%, 0) scale(1);
+	}
+	50% {
+		transform: translate(-42%, 6%) scale(1.12);
+	}
+}
+@keyframes glowFloat2 {
+	0%,
+	100% {
+		transform: translate(50%, 0) scale(1.05);
+	}
+	50% {
+		transform: translate(44%, -7%) scale(0.94);
+	}
+}
+@keyframes auraDrift1 {
+	0%,
+	100% {
+		transform: translate(0, 0) scale(1);
+	}
+	50% {
+		transform: translate(6vw, 5vh) scale(1.14);
+	}
+}
+@keyframes auraDrift2 {
+	0%,
+	100% {
+		transform: translate(0, 0) scale(1.05);
+	}
+	50% {
+		transform: translate(-5vw, 4vh) scale(0.92);
+	}
+}
+@keyframes auraDrift3 {
+	0%,
+	100% {
+		transform: translate(0, 0) scale(1);
+	}
+	50% {
+		transform: translate(4vw, -5vh) scale(1.1);
 	}
 }
 
-.card {
-	@apply border-outset flex  flex-col items-center gap-6 rounded-none border-4 border-white p-4 shadow-md;
-	border-style: outset;
+@media (prefers-reduced-motion: reduce) {
+	.chart-scroll,
+	[class*='animate-'] {
+		animation: none !important;
+	}
+}
+
+/* Wallet "Connect" flow can surface from inside an in-app modal (e.g. the
+   Save & Earn modal at z-[2200]). Two different overlays can render the wallet
+   picker depending on auth path, and both default to a z-index below our modals:
+   - Dynamic Labs' embedded-wallet flow renders inside a `.dynamic-shadow-dom` host.
+   - WalletConnect / Web3Modal renders an `<w3m-modal>` (default z-index 999).
+   Lift both above every in-app modal so the wallet flow is never hidden behind. */
+:root {
+	/* Official Web3Modal/AppKit override; the modal reads var(--w3m-z-index). */
+	--w3m-z-index: 2147483000;
+}
+.dynamic-shadow-dom {
+	position: relative !important;
+	z-index: 2147483646 !important;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,11 +1,22 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.ico" sizes="any" />
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/site.webmanifest" />
+		<!-- Apply the persisted theme before first paint to prevent a flash. -->
+		<script>
+			(function () {
+				try {
+					var t = localStorage.getItem('st0x-theme');
+					document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark');
+				} catch (e) {
+					/* localStorage unavailable — keep the default dark theme */
+				}
+			})();
+		</script>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<!--
@@ -15,34 +26,14 @@
 			<noscript> keeps fonts working with JS disabled.
 		-->
 		<link
-			href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap"
-			rel="stylesheet"
-			media="print"
-			onload="this.media='all'"
-		/>
-		<link
-			href="https://fonts.googleapis.com/css2?family=Handjet:wght@100..900&family=Instrument+Serif:ital@0;1&display=swap"
-			rel="stylesheet"
-			media="print"
-			onload="this.media='all'"
-		/>
-		<link
-			href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;700&display=swap"
+			href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
 			rel="stylesheet"
 			media="print"
 			onload="this.media='all'"
 		/>
 		<noscript>
 			<link
-				href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap"
-				rel="stylesheet"
-			/>
-			<link
-				href="https://fonts.googleapis.com/css2?family=Handjet:wght@100..900&family=Instrument+Serif:ital@0;1&display=swap"
-				rel="stylesheet"
-			/>
-			<link
-				href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;700&display=swap"
+				href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
 				rel="stylesheet"
 			/>
 		</noscript>

--- a/src/lib/components/AccessCodeModal.svelte
+++ b/src/lib/components/AccessCodeModal.svelte
@@ -154,23 +154,23 @@
 	<div class="space-y-4">
 		<!-- Connected wallet indicator -->
 		<div
-			class="flex items-center justify-between rounded-lg border border-green-500/30 bg-green-500/10 px-3 py-2"
+			class="flex items-center justify-between rounded-lg border border-accent-line bg-accent-soft px-3 py-2"
 		>
 			<div class="flex items-center gap-2">
-				<svg class="h-4 w-4 text-green-500" viewBox="0 0 20 20" fill="currentColor">
+				<svg class="h-4 w-4 text-up" viewBox="0 0 20 20" fill="currentColor">
 					<path
 						fill-rule="evenodd"
 						d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.172 7.707 8.879a1 1 0 10-1.414 1.414L9 13l4.707-4.707z"
 						clip-rule="evenodd"
 					/>
 				</svg>
-				<span class="text-sm text-gray-300">
+				<span class="text-sm text-text-2">
 					{truncateAddress($walletAddress || '')}
 				</span>
 			</div>
 			<button
 				on:click={handleDisconnect}
-				class="text-xs text-gray-400 transition-colors hover:text-red-400"
+				class="text-xs text-text-2 transition-colors hover:text-down"
 				disabled={submitting}
 			>
 				Disconnect
@@ -178,26 +178,26 @@
 		</div>
 
 		{#if error}
-			<div class="rounded-md border border-red-900/40 bg-red-900/20 p-3 text-sm text-red-300">
+			<div class="rounded-md border border-down bg-down-soft p-3 text-sm text-down">
 				{error}
 			</div>
 		{/if}
 
 		<!-- Access code input -->
 		<div class="space-y-2">
-			<label for="access-code-modal" class="text-sm font-medium text-gray-300">Access Code</label>
+			<label for="access-code-modal" class="text-sm font-medium text-text-2">Access Code</label>
 			<input
 				id="access-code-modal"
 				type="text"
 				bind:value={accessCode}
 				disabled={submitting}
 				placeholder="ST0X-XXXX-XXXX"
-				class="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 uppercase text-white placeholder-gray-500 focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500 disabled:cursor-not-allowed disabled:opacity-50"
+				class="w-full rounded-lg border border-line-strong bg-surface-1 px-3 py-2 uppercase text-text placeholder-text-3 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent disabled:cursor-not-allowed disabled:opacity-50"
 			/>
-			<p class="text-xs text-gray-500">
+			<p class="text-xs text-text-3">
 				Don't have an access code? Contact us at <a
 					href="mailto:toby@st0x.io"
-					class="text-yellow-500 hover:underline">toby@st0x.io</a
+					class="text-accent hover:underline">toby@st0x.io</a
 				>
 			</p>
 		</div>
@@ -205,8 +205,8 @@
 		<!-- Referral code input (collapsible) -->
 		<div class="space-y-2">
 			{#if showReferralField}
-				<label for="referral-code-modal" class="text-sm font-medium text-gray-300">
-					Referral Code <span class="text-gray-500">(optional)</span>
+				<label for="referral-code-modal" class="text-sm font-medium text-text-2">
+					Referral Code <span class="text-text-3">(optional)</span>
 				</label>
 				<input
 					id="referral-code-modal"
@@ -214,18 +214,18 @@
 					bind:value={referralCode}
 					disabled={submitting}
 					placeholder="st0x-ref-xxxxxx"
-					class="w-full rounded-lg border px-3 py-2 lowercase text-white placeholder-gray-500 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {referralCodeValid
-						? 'border-gray-700 bg-gray-800 focus:border-yellow-500 focus:ring-yellow-500'
-						: 'border-red-500 bg-gray-800 focus:border-red-500 focus:ring-red-500'}"
+					class="w-full rounded-lg border px-3 py-2 lowercase text-text placeholder-text-3 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {referralCodeValid
+						? 'border-line-strong bg-surface-1 focus:border-accent focus:ring-accent'
+						: 'border-down bg-surface-1 focus:border-down focus:ring-down'}"
 				/>
 				{#if !referralCodeValid}
-					<p class="text-xs text-red-400">Invalid referral code format</p>
+					<p class="text-xs text-down">Invalid referral code format</p>
 				{/if}
 			{:else}
 				<button
 					type="button"
 					on:click={() => (showReferralField = true)}
-					class="text-sm text-gray-400 hover:text-yellow-500"
+					class="text-sm text-text-2 hover:text-accent"
 				>
 					+ Add referral code
 				</button>
@@ -249,8 +249,6 @@
 			{/if}
 		</Button>
 
-		<p class="text-center text-xs text-gray-500">
-			You'll sign a message to verify wallet ownership
-		</p>
+		<p class="text-center text-xs text-text-3">You'll sign a message to verify wallet ownership</p>
 	</div>
 </Modal>

--- a/src/lib/components/AmbientBackground.svelte
+++ b/src/lib/components/AmbientBackground.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// Calm v2 ambient: three drifting aurora blooms + a sparse field of soft
+	// floating "bokeh" orbs on a canvas. Reads the theme tokens so it retints on
+	// light/dark switch. Respects reduced-motion.
+
+	let canvas: HTMLCanvasElement;
+
+	type Rgb = [number, number, number];
+
+	function parseRgb(value: string, fallback: Rgb): Rgb {
+		const v = value.trim();
+		const hex = v.match(/^#([0-9a-f]{6})$/i);
+		if (hex) {
+			const n = parseInt(hex[1], 16);
+			return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+		}
+		const rgb = v.match(/(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+		if (rgb) return [+rgb[1], +rgb[2], +rgb[3]];
+		return fallback;
+	}
+
+	function themeColors(): { mint: Rgb; iris: Rgb } {
+		const cs = getComputedStyle(document.documentElement);
+		return {
+			mint: parseRgb(cs.getPropertyValue('--accent'), [45, 227, 166]),
+			iris: parseRgb(cs.getPropertyValue('--iris'), [125, 139, 255])
+		};
+	}
+
+	onMount(() => {
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+
+		let palette = themeColors();
+		let width = 0;
+		let height = 0;
+		const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+		function resize() {
+			width = window.innerWidth;
+			height = window.innerHeight;
+			canvas.width = width * dpr;
+			canvas.height = height * dpr;
+			canvas.style.width = width + 'px';
+			canvas.style.height = height + 'px';
+			ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+		}
+		resize();
+		window.addEventListener('resize', resize);
+
+		const rnd = (a: number, b: number) => a + Math.random() * (b - a);
+		const count = Math.max(14, Math.min(26, Math.round((width * height) / 90000)));
+		const orbs = Array.from({ length: count }, () => {
+			const r = rnd(26, 120);
+			return {
+				x: rnd(0, width),
+				y: rnd(0, height),
+				r,
+				vy: (-rnd(2, 7) / 1000) * (140 / r),
+				vx: (rnd(-1, 1) / 1000) * (60 / r),
+				mint: Math.random() < 0.62,
+				baseA: rnd(0.05, 0.14) * (60 / r + 0.5),
+				tw: rnd(0.0004, 0.0011),
+				ph: rnd(0, Math.PI * 2)
+			};
+		});
+
+		function paint(t: number) {
+			ctx!.clearRect(0, 0, width, height);
+			ctx!.globalCompositeOperation = 'lighter';
+			for (const o of orbs) {
+				const a = Math.max(0.02, o.baseA * (0.6 + 0.4 * Math.sin(t * o.tw + o.ph)));
+				const [r, g, b] = o.mint ? palette.mint : palette.iris;
+				const grad = ctx!.createRadialGradient(o.x, o.y, 0, o.x, o.y, o.r);
+				grad.addColorStop(0, `rgba(${r},${g},${b},${a})`);
+				grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+				ctx!.fillStyle = grad;
+				ctx!.beginPath();
+				ctx!.arc(o.x, o.y, o.r, 0, Math.PI * 2);
+				ctx!.fill();
+			}
+			ctx!.globalCompositeOperation = 'source-over';
+		}
+
+		function step(dt: number) {
+			for (const o of orbs) {
+				o.x += o.vx * dt;
+				o.y += o.vy * dt;
+				const m = o.r;
+				if (o.y < -m) {
+					o.y = height + m;
+					o.x = rnd(0, width);
+				}
+				if (o.x < -m) o.x = width + m;
+				if (o.x > width + m) o.x = -m;
+			}
+		}
+
+		const retint = () => {
+			palette = themeColors();
+		};
+		window.addEventListener('st0x-retint', retint);
+
+		if (reduce) {
+			paint(0);
+			return () => {
+				window.removeEventListener('resize', resize);
+				window.removeEventListener('st0x-retint', retint);
+			};
+		}
+
+		let last = performance.now();
+		let raf = 0;
+		function loop(now: number) {
+			const dt = Math.min(50, now - last);
+			last = now;
+			step(dt);
+			paint(now);
+			raf = requestAnimationFrame(loop);
+		}
+		raf = requestAnimationFrame(loop);
+
+		const onVisibility = () => {
+			if (document.hidden) {
+				cancelAnimationFrame(raf);
+			} else {
+				last = performance.now();
+				raf = requestAnimationFrame(loop);
+			}
+		};
+		document.addEventListener('visibilitychange', onVisibility);
+
+		return () => {
+			cancelAnimationFrame(raf);
+			window.removeEventListener('resize', resize);
+			window.removeEventListener('st0x-retint', retint);
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
+	});
+</script>
+
+<div class="pointer-events-none fixed inset-0 z-0 overflow-hidden" aria-hidden="true">
+	<canvas bind:this={canvas} class="absolute inset-0"></canvas>
+	<div
+		class="absolute h-[560px] w-[620px] rounded-full opacity-[0.85] blur-[80px]"
+		style="left:6%;top:-14%;background:radial-gradient(circle at 50% 50%, var(--aura-a), transparent 70%);animation:auraDrift1 54s ease-in-out infinite;"
+	></div>
+	<div
+		class="absolute h-[520px] w-[540px] rounded-full opacity-[0.85] blur-[80px]"
+		style="left:64%;top:2%;background:radial-gradient(circle at 50% 50%, var(--aura-b), transparent 70%);animation:auraDrift2 66s ease-in-out infinite;"
+	></div>
+	<div
+		class="absolute h-[660px] w-[720px] rounded-full opacity-[0.85] blur-[80px]"
+		style="left:28%;top:42%;background:radial-gradient(circle at 50% 50%, var(--aura-c), transparent 70%);animation:auraDrift3 78s ease-in-out infinite;"
+	></div>
+</div>

--- a/src/lib/components/AuthModal.svelte
+++ b/src/lib/components/AuthModal.svelte
@@ -28,10 +28,10 @@
 
 <Modal show={$showAuthModal} title="Sign In" maxWidthClass="max-w-md" onClose={handleClose}>
 	<div class="space-y-6">
-		<p class="text-center text-gray-300">Choose how you'd like to access the platform</p>
+		<p class="text-center text-text-2">Choose how you'd like to access the platform</p>
 
 		<!-- Dynamic Login (Email or Social) -->
-		<div class="rounded-lg border border-gray-700 bg-gray-800/50 p-4">
+		<div class="rounded-lg border border-line bg-surface-2 p-4">
 			<div class="mb-3 flex items-center gap-3">
 				<div class="rounded-full bg-gradient-to-br from-indigo-500/20 to-purple-600/20 p-2">
 					<svg
@@ -49,8 +49,8 @@
 					</svg>
 				</div>
 				<div>
-					<h3 class="font-semibold text-white">Email or Social</h3>
-					<p class="text-xs text-gray-400">We'll create a wallet for you</p>
+					<h3 class="font-semibold text-text">Email or Social</h3>
+					<p class="text-xs text-text-2">We'll create a wallet for you</p>
 				</div>
 			</div>
 
@@ -85,7 +85,7 @@
 				{/if}
 			</Button>
 
-			<div class="mt-3 flex items-center justify-center gap-3 text-xs text-gray-500">
+			<div class="mt-3 flex items-center justify-center gap-3 text-xs text-text-3">
 				<!-- Email icon -->
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path
@@ -119,16 +119,21 @@
 
 		<!-- Divider -->
 		<div class="flex items-center gap-4">
-			<div class="h-px flex-1 bg-gray-700"></div>
-			<span class="text-xs text-gray-500">OR</span>
-			<div class="h-px flex-1 bg-gray-700"></div>
+			<div class="h-px flex-1 bg-surface-3"></div>
+			<span class="text-xs text-text-3">OR</span>
+			<div class="h-px flex-1 bg-surface-3"></div>
 		</div>
 
 		<!-- Direct Wallet Connect -->
-		<div class="rounded-lg border border-gray-700 bg-gray-800/50 p-4">
+		<div class="rounded-lg border border-line bg-surface-2 p-4">
 			<div class="mb-3 flex items-center gap-3">
 				<div class="rounded-full bg-gradient-to-br from-blue-500/20 to-cyan-600/20 p-2">
-					<svg class="h-5 w-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<svg
+						class="h-5 w-5 text-blue-600 dark:text-blue-400"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+					>
 						<path
 							stroke-linecap="round"
 							stroke-linejoin="round"
@@ -138,8 +143,8 @@
 					</svg>
 				</div>
 				<div>
-					<h3 class="font-semibold text-white">Connect Wallet</h3>
-					<p class="text-xs text-gray-400">Use your existing wallet</p>
+					<h3 class="font-semibold text-text">Connect Wallet</h3>
+					<p class="text-xs text-text-2">Use your existing wallet</p>
 				</div>
 			</div>
 
@@ -149,8 +154,6 @@
 		</div>
 
 		<!-- Footer note -->
-		<p class="text-center text-xs text-gray-500">
-			By continuing, you agree to our Terms of Service
-		</p>
+		<p class="text-center text-xs text-text-3">By continuing, you agree to our Terms of Service</p>
 	</div>
 </Modal>

--- a/src/lib/components/DepositModal.svelte
+++ b/src/lib/components/DepositModal.svelte
@@ -62,7 +62,7 @@
 
 <Modal show={$showDepositModal} title="Deposit" maxWidthClass="max-w-md" onClose={handleClose}>
 	<div class="space-y-5">
-		<p class="text-sm text-gray-400">
+		<p class="text-sm text-text-2">
 			Send {paymentToken} on {networkName} to this address. Funds will appear in your st0x balance once
 			confirmed.
 		</p>
@@ -74,14 +74,12 @@
 					{#if qrCodeDataUrl}
 						<img src={qrCodeDataUrl} alt="Wallet QR Code" class="h-40 w-40" />
 					{:else if qrCodeError}
-						<div
-							class="flex h-40 w-40 items-center justify-center text-center text-sm text-gray-500"
-						>
+						<div class="flex h-40 w-40 items-center justify-center text-center text-sm text-text-3">
 							{qrCodeError}
 						</div>
 					{:else}
 						<div class="flex h-40 w-40 items-center justify-center">
-							<svg class="h-6 w-6 animate-spin text-gray-400" fill="none" viewBox="0 0 24 24">
+							<svg class="h-6 w-6 animate-spin text-text-2" fill="none" viewBox="0 0 24 24">
 								<circle
 									class="opacity-25"
 									cx="12"
@@ -100,13 +98,13 @@
 					{/if}
 				</div>
 			</div>
-			<p class="text-center text-xs text-gray-500">Scan with your wallet</p>
+			<p class="text-center text-xs text-text-3">Scan with your wallet</p>
 		{/if}
 
 		<!-- Wallet Address Display -->
-		<div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
-			<span class="mb-2 block text-xs font-medium text-gray-400">Your wallet address</span>
-			<div class="break-all font-mono text-sm text-white">
+		<div class="rounded-lg border border-line bg-surface-2 p-4">
+			<span class="mb-2 block text-xs font-medium text-text-2">Your wallet address</span>
+			<div class="break-all font-mono text-sm text-text">
 				{$walletAddress || 'Not connected'}
 			</div>
 		</div>
@@ -163,8 +161,8 @@
 		</div>
 
 		<!-- Warning -->
-		<div class="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
-			<p class="text-xs text-yellow-400">
+		<div class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+			<p class="text-xs text-amber-300">
 				Only send tokens on the {networkName} network. Tokens sent on other networks may be lost.
 			</p>
 		</div>

--- a/src/lib/components/DocsSidebar.svelte
+++ b/src/lib/components/DocsSidebar.svelte
@@ -32,7 +32,7 @@
 
 <!-- Sidebar -->
 <div
-	class="fixed left-0 top-0 z-[10000] flex h-full w-64 max-w-[80vw] transform flex-col border-b border-r border-white/10 bg-gray-800/95 backdrop-blur-lg transition-transform duration-300 ease-in-out"
+	class="fixed left-0 top-0 z-[10000] flex h-full w-64 max-w-[80vw] transform flex-col border-b border-r border-line bg-surface-2 backdrop-blur-lg transition-transform duration-300 ease-in-out"
 	class:translate-x-0={visible || desktop}
 	class:-translate-x-full={!visible && !desktop}
 >
@@ -66,12 +66,12 @@
 					}}
 					class="flex items-center gap-3 rounded-lg px-4 py-3 font-medium transition-all {activePath ===
 					`/docs/${slug}`
-						? 'border border-yellow-500/30 bg-yellow-500/20 text-yellow-500'
-						: 'text-gray-400 hover:bg-white/5 hover:text-white'}"
+						? 'border border-accent-line bg-accent-soft text-accent'
+						: 'text-text-2 hover:bg-surface-2 hover:text-text'}"
 				>
 					<span>{title}</span>
 					{#if activePath === `/docs/${slug}`}
-						<div class="ml-auto h-2 w-2 rounded-full bg-yellow-500" />
+						<div class="ml-auto h-2 w-2 rounded-full bg-accent" />
 					{/if}
 				</a>
 			{/each}
@@ -79,24 +79,24 @@
 	</div>
 
 	<!-- Bottom Info -->
-	<div class="border-t border-white/10 bg-gray-800/95 p-4">
+	<div class="border-t border-line bg-surface-2 p-4">
 		<div class="flex w-full flex-col gap-3">
-			<div class="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3">
+			<div class="w-full rounded-lg border border-line bg-surface-2 px-4 py-3">
 				<div class="flex w-full flex-col sm:flex-row sm:items-center sm:justify-between">
-					<div class="text-sm font-semibold text-yellow-500">{$currentNetwork.name}</div>
+					<div class="text-sm font-semibold text-accent">{$currentNetwork.name}</div>
 					{#if $isAuthenticated && $walletAddress}
-						<div class="text-xs text-gray-400 sm:ml-2">
+						<div class="text-xs text-text-2 sm:ml-2">
 							<span class="sm:hidden">…{$walletAddress?.slice(-6)}</span>
 							<span class="hidden sm:inline">{truncateAddress($walletAddress || '')}</span>
 						</div>
 					{:else}
-						<div class="text-xs text-gray-400 sm:ml-2">Not Connected</div>
+						<div class="text-xs text-text-2 sm:ml-2">Not Connected</div>
 					{/if}
 				</div>
 			</div>
 			<a
 				href="/"
-				class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-base font-normal text-gray-300 transition-colors hover:bg-white/5 hover:text-white"
+				class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-base font-normal text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 			>
 				<ExternalLinkIcon class="h-5 w-5" />
 				<span>Back to App</span>
@@ -104,7 +104,7 @@
 			<ExternalLink
 				href="https://t.me/toby_meller"
 				label="Telegram"
-				className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-base font-normal text-gray-300 transition-colors hover:bg-white/5 hover:text-white"
+				className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-base font-normal text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 			/>
 		</div>
 	</div>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,22 +1,22 @@
 <!-- Compact Footer -->
-<footer class="border-t border-white/5 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+<footer class="border-t border-line px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
 	<div class="mx-auto max-w-5xl">
 		<!-- Links Row -->
 		<div
-			class="mb-6 flex flex-wrap items-center justify-center gap-4 text-xs text-gray-400 sm:gap-6 sm:text-sm"
+			class="mb-6 flex flex-wrap items-center justify-center gap-4 text-xs text-text-2 sm:gap-6 sm:text-sm"
 		>
-			<a href="/markets" class="transition-colors hover:text-yellow-500">Markets</a>
-			<a href="/docs" class="transition-colors hover:text-yellow-500">Docs</a>
-			<a href="/faqs" class="transition-colors hover:text-yellow-500">FAQs</a>
-			<a href="/terms" class="transition-colors hover:text-yellow-500">Terms</a>
-			<a href="/privacy-policy" class="transition-colors hover:text-yellow-500">Privacy</a>
+			<a href="/markets" class="transition-colors hover:text-accent">Markets</a>
+			<a href="/docs" class="transition-colors hover:text-accent">Docs</a>
+			<a href="/faqs" class="transition-colors hover:text-accent">FAQs</a>
+			<a href="/terms" class="transition-colors hover:text-accent">Terms</a>
+			<a href="/privacy-policy" class="transition-colors hover:text-accent">Privacy</a>
 		</div>
 
 		<!-- Social Links -->
 		<div class="mb-6 flex items-center justify-center gap-4">
 			<a
 				href="mailto:toby@st0x.io"
-				class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+				class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-3 transition-all hover:bg-accent-soft hover:text-accent"
 				aria-label="Email"
 			>
 				<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor"
@@ -29,7 +29,7 @@
 				href="https://x.com/st0x_io"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+				class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-3 transition-all hover:bg-accent-soft hover:text-accent"
 				aria-label="X"
 			>
 				<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -42,7 +42,7 @@
 				href="https://t.me/ST0xCommunity"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+				class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-3 transition-all hover:bg-accent-soft hover:text-accent"
 				aria-label="Telegram"
 			>
 				<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -55,7 +55,7 @@
 				href="https://www.linkedin.com/company/st0x"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+				class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-3 transition-all hover:bg-accent-soft hover:text-accent"
 				aria-label="LinkedIn"
 			>
 				<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -68,11 +68,11 @@
 
 		<!-- Copyright and Risk Warning -->
 		<div class="text-center">
-			<p class="mb-4 text-xs text-gray-500">
+			<p class="mb-4 text-xs text-text-3">
 				© {new Date().getFullYear()} SARK X (BVI) Ltd. All rights reserved.
 			</p>
-			<p class="text-[10px] leading-relaxed text-gray-600 sm:text-xs">
-				<span class="text-yellow-600">Risk Warning:</span> Trading tokenized assets involves substantial
+			<p class="text-[10px] leading-relaxed text-text-muted sm:text-xs">
+				<span class="text-accent">Risk Warning:</span> Trading tokenized assets involves substantial
 				risk. Past performance does not guarantee future results.
 			</p>
 		</div>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import NetworkSelector from './NetworkSelector.svelte';
 	import ReferralButton from './referrals/ReferralButton.svelte';
+	import ThemeToggle from '$lib/components/ui/ThemeToggle.svelte';
 	import { onMount } from 'svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { web3Modal } from 'svelte-wagmi';
 	import { page } from '$app/stores';
 	import { wrongNetwork, sfts, tradePanelOpen } from '$lib/stores';
@@ -10,22 +12,14 @@
 	// Unified auth
 	import { walletAddress, authMethod, isAuthenticated } from '$lib/stores/authStore';
 	import { openAuthModal, logoutDynamic, dynamicSession } from '$lib/stores/dynamicStore';
+	import { navCollapsed } from '$lib/stores/uiStore';
 
 	export let title: string;
 	export let isSidebarCollapsed = false;
 	export let isLandingPage = false;
 
-	let mobileNavOpen = false;
 	let accountMenuOpen = false;
 	let windowWidth = 0;
-
-	function toggleMobileNav() {
-		mobileNavOpen = !mobileNavOpen;
-	}
-
-	function closeMobileNav() {
-		mobileNavOpen = false;
-	}
 
 	function toggleAccountMenu() {
 		accountMenuOpen = !accountMenuOpen;
@@ -50,10 +44,13 @@
 	$: NAV_ITEMS = [
 		{ name: 'Trade', href: tradeHref, isActive: isOnTradePage, showAlpha: false },
 		{ name: 'Strategies', href: '/strategies', isActive: false, showAlpha: true },
-		{ name: 'Platform Metrics', href: '/platform-metrics', isActive: false, showAlpha: false }
+		{
+			name: 'Platform Metrics',
+			href: '/platform-metrics',
+			isActive: false,
+			showAlpha: false
+		}
 	];
-
-	const DESKTOP_NAV_WIDTH = 'w-28 xl:w-40';
 
 	// Calculate effective breakpoint based on what's taking up space
 	// Base: 1350px for the nav content itself
@@ -61,9 +58,15 @@
 	// +352px when trade panel is open
 	$: sidebarOffset = !isLandingPage && !isSidebarCollapsed ? 256 : 0;
 	$: tradePanelOffset = $tradePanelOpen ? 352 : 0;
-	$: effectiveBreakpoint = 1350 + sidebarOffset + tradePanelOffset;
+	// Base = the width the full nav cluster actually needs (~1100px of content +
+	// margin). The sidebar/trade-panel offsets account for horizontal space those
+	// take away from the header, so a full-size laptop keeps the inline nav and only
+	// collapses to the hamburger when the sidebar + order panel are both open.
+	$: effectiveBreakpoint = 1180 + sidebarOffset + tradePanelOffset;
 	$: isHamburgerMode = windowWidth < effectiveBreakpoint;
-	$: if (!isHamburgerMode) mobileNavOpen = false;
+	// Share the collapse signal so the bottom MobileTabBar shows exactly when the
+	// inline header nav hides — no width band is left without navigation.
+	$: navCollapsed.set(isHamburgerMode);
 
 	onMount(() => {
 		windowWidth = window.innerWidth;
@@ -102,12 +105,18 @@
 	}
 </script>
 
-<div class="sticky top-0 z-[100] bg-transparent transition-all duration-300">
-	<div class="px-3 py-3 sm:px-6 sm:py-5">
-		<div class="flex items-center justify-between gap-2 sm:gap-3 lg:gap-4">
-			<div class="flex items-center gap-1.5 sm:gap-2 lg:gap-4">
+<div
+	class="bg-bg/80 sticky top-0 z-[100] border-b border-line backdrop-blur-xl transition-all duration-300"
+>
+	<div class="px-4 py-3 sm:px-6">
+		<div class="flex items-center justify-between gap-3">
+			<div class="flex items-center gap-5">
 				<a href="/" aria-label="Go to home" class="shrink-0">
-					<img src="/images/logo-sidebar.svg" alt="ST0x Logo" class="h-7 w-auto sm:h-8 lg:h-10" />
+					<img
+						src="/images/logo-sidebar.svg"
+						alt="ST0x Logo"
+						class="logo-img h-7 w-auto sm:h-8 lg:h-10"
+					/>
 				</a>
 				{#if title}
 					<div class="ml-2 hidden lg:block">
@@ -116,22 +125,21 @@
 				{/if}
 			</div>
 
-			<div class="flex min-w-0 flex-nowrap items-center gap-1.5 sm:gap-2 xl:gap-3">
+			<div class="flex min-w-0 flex-nowrap items-center gap-1.5 sm:gap-2">
 				{#if !isHamburgerMode}
-					<div class="flex flex-nowrap items-center gap-2 xl:gap-3">
+					<div class="flex flex-nowrap items-center gap-1">
 						{#each NAV_ITEMS as item}
 							<a
 								href={item.href}
-								class={`flex items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-2 text-center text-sm font-medium transition-colors ${DESKTOP_NAV_WIDTH} ${
-									item.isActive || activePath === item.href
-										? 'bg-yellow-500/20 text-yellow-500'
-										: 'text-gray-300 hover:bg-white/5 hover:text-white'
-								}`}
+								class="flex items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-2 text-center text-sm font-medium transition-colors {item.isActive ||
+								activePath === item.href
+									? 'bg-white/10 text-text'
+									: 'text-text-2 hover:bg-white/5 hover:text-text'}"
 							>
 								{item.name}
 								{#if item.showAlpha}
 									<span
-										class="rounded-full bg-yellow-500/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-yellow-400"
+										class="rounded-full bg-iris-500/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-iris-300"
 										>Alpha</span
 									>
 								{/if}
@@ -140,6 +148,7 @@
 					</div>
 				{/if}
 
+				<ThemeToggle />
 				<NetworkSelector />
 
 				<!-- Hide on mobile, show in hamburger menu instead -->
@@ -151,51 +160,40 @@
 					<!-- Dynamic authenticated user -->
 					<div class="account-menu-container relative">
 						<button
-							class="flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-yellow-500 px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-yellow-400"
+							class="flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-gradient-to-b from-emerald-300 to-emerald-400 px-2.5 py-2 text-sm font-semibold text-[#053124] shadow-[0_10px_30px_-10px_rgba(45,227,166,0.45)] transition hover:brightness-105 sm:px-3.5"
 							on:click={toggleAccountMenu}
 						>
-							<span>My Dashboard</span>
-							<span class="text-[11px] font-normal text-yellow-800/70">
-								{$dynamicSession.email
-									? truncateEmail($dynamicSession.email)
-									: `...${$dynamicSession.walletAddress.slice(-4)}`}
-							</span>
-							<svg
-								class="h-4 w-4 transition-transform"
-								class:rotate-180={accountMenuOpen}
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M19 9l-7 7-7-7"
-								/>
-							</svg>
+							{#if isHamburgerMode}
+								<Icon name="wallet" className="h-4 w-4" />
+							{:else}
+								<span>My Dashboard</span>
+								<span class="font-mono text-[11px] font-medium text-emerald-900/70">
+									{$dynamicSession.email
+										? truncateEmail($dynamicSession.email)
+										: `·${$dynamicSession.walletAddress.slice(-4)}`}
+								</span>
+							{/if}
+							<Icon
+								name="chevronDown"
+								className="h-4 w-4 text-emerald-900/60 transition-transform {accountMenuOpen
+									? 'rotate-180'
+									: ''}"
+							/>
 						</button>
 						{#if accountMenuOpen}
 							<div
-								class="absolute right-0 top-full z-[110] mt-1 w-48 rounded-lg border border-white/10 bg-gray-800 py-1 shadow-xl"
+								class="absolute right-0 top-full z-[110] mt-1 w-48 rounded-lg border border-line bg-surface-1 py-1 shadow-xl"
 							>
 								<a
 									href="/dashboard"
-									class="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-200 transition-colors hover:bg-white/10"
+									class="flex items-center gap-2 px-4 py-2.5 text-sm text-text-2 transition-colors hover:bg-surface-2"
 									on:click={closeAccountMenu}
 								>
-									<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width="2"
-											d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
-										/>
-									</svg>
+									<Icon name="blocks" className="h-4 w-4" />
 									Dashboard
 								</a>
 								<button
-									class="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-red-400 transition-colors hover:bg-white/10"
+									class="hover:bg-down/10 flex w-full items-center gap-2 px-4 py-2.5 text-sm text-down transition-colors"
 									on:click={() => {
 										closeAccountMenu();
 										handleDisconnect();
@@ -218,49 +216,38 @@
 					<!-- Wallet user (fully registered) -->
 					<div class="account-menu-container relative">
 						<button
-							class="flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-yellow-500 px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-yellow-400"
+							class="flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-gradient-to-b from-emerald-300 to-emerald-400 px-2.5 py-2 text-sm font-semibold text-[#053124] shadow-[0_10px_30px_-10px_rgba(45,227,166,0.45)] transition hover:brightness-105 sm:px-3.5"
 							on:click={toggleAccountMenu}
 						>
-							<span>My Dashboard</span>
-							<span class="text-[11px] font-normal text-yellow-800/70">
-								...{$walletAddress?.slice(-4)}
-							</span>
-							<svg
-								class="h-4 w-4 transition-transform"
-								class:rotate-180={accountMenuOpen}
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M19 9l-7 7-7-7"
-								/>
-							</svg>
+							{#if isHamburgerMode}
+								<Icon name="wallet" className="h-4 w-4" />
+							{:else}
+								<span>My Dashboard</span>
+								<span class="font-mono text-[11px] font-medium text-emerald-900/70">
+									·{$walletAddress?.slice(-4)}
+								</span>
+							{/if}
+							<Icon
+								name="chevronDown"
+								className="h-4 w-4 text-emerald-900/60 transition-transform {accountMenuOpen
+									? 'rotate-180'
+									: ''}"
+							/>
 						</button>
 						{#if accountMenuOpen}
 							<div
-								class="absolute right-0 top-full z-[110] mt-1 w-48 rounded-lg border border-white/10 bg-gray-800 py-1 shadow-xl"
+								class="absolute right-0 top-full z-[110] mt-1 w-48 rounded-lg border border-line bg-surface-1 py-1 shadow-xl"
 							>
 								<a
 									href="/dashboard"
-									class="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-200 transition-colors hover:bg-white/10"
+									class="flex items-center gap-2 px-4 py-2.5 text-sm text-text-2 transition-colors hover:bg-surface-2"
 									on:click={closeAccountMenu}
 								>
-									<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width="2"
-											d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
-										/>
-									</svg>
+									<Icon name="blocks" className="h-4 w-4" />
 									Dashboard
 								</a>
 								<button
-									class="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-red-400 transition-colors hover:bg-white/10"
+									class="hover:bg-down/10 flex w-full items-center gap-2 px-4 py-2.5 text-sm text-down transition-colors"
 									on:click={() => {
 										closeAccountMenu();
 										handleDisconnect();
@@ -290,88 +277,15 @@
 						Connect or Log In
 					</Button>
 				{/if}
-
-				{#if isHamburgerMode}
-					<Button
-						variant="ghost"
-						size="sm"
-						className="p-2"
-						aria-label="Toggle navigation"
-						on:click={toggleMobileNav}
-					>
-						<svg
-							class="h-5 w-5"
-							fill="none"
-							stroke="currentColor"
-							viewBox="0 0 24 24"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							{#if mobileNavOpen}
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M6 18L18 6M6 6l12 12"
-								></path>
-							{:else}
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M4 6h16M4 12h16M4 18h16"
-								></path>
-							{/if}
-						</svg>
-					</Button>
-				{/if}
 			</div>
 		</div>
 	</div>
 </div>
 
-<!-- Mobile/Tablet Navigation Dropdown -->
-
-{#if mobileNavOpen && isHamburgerMode}
-	<div
-		class="fixed inset-0 z-[99] bg-black/50 backdrop-blur-sm"
-		role="button"
-		tabindex="0"
-		on:click={closeMobileNav}
-		on:keydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') closeMobileNav();
-		}}
-	/>
-	<div
-		class="fixed left-0 right-0 top-[60px] z-[99] border-b border-white/10 bg-gray-800/95 backdrop-blur-lg"
-	>
-		<div class="flex flex-col gap-4 p-4">
-			<!-- Referrals in mobile menu -->
-			<div class="flex flex-wrap gap-2 border-b border-white/10 pb-4">
-				<ReferralButton />
-			</div>
-
-			<nav class="flex flex-col gap-2">
-				{#each NAV_ITEMS as item}
-					<a
-						href={item.href}
-						on:click={closeMobileNav}
-						class="rounded-lg px-4 py-3 text-base font-medium transition-colors {item.isActive ||
-						activePath === item.href
-							? 'bg-yellow-500/20 text-yellow-500'
-							: 'text-gray-300 hover:bg-white/5 hover:text-white'}"
-					>
-						<span class="flex items-center gap-2">
-							{item.name}
-							{#if item.showAlpha}
-								<span
-									class="rounded-full bg-yellow-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-400"
-									>Alpha</span
-								>
-							{/if}
-						</span>
-					</a>
-				{/each}
-			</nav>
-		</div>
-	</div>
-{/if}
+<style>
+	/* The wordmark SVG is white/cream (drawn for dark backgrounds). In light mode
+	   darken it to a near-black silhouette so it stays legible on the light shell. */
+	:global([data-theme='light']) .logo-img {
+		filter: brightness(0);
+	}
+</style>

--- a/src/lib/components/LoadingSpinner.svelte
+++ b/src/lib/components/LoadingSpinner.svelte
@@ -18,13 +18,13 @@
 			container: 'flex flex-col items-center justify-center gap-3',
 			spinner:
 				'relative animate-spin rounded-full border-4 border-transparent border-b-purple-700 border-l-green-500 border-r-blue-600 border-t-yellow-500',
-			text: 'font-medium text-gray-300'
+			text: 'font-medium text-text-2'
 		},
 		fullscreen: {
-			container: 'flex flex-col h-screen items-center justify-center bg-gray-900 gap-4',
+			container: 'flex flex-col h-screen items-center justify-center bg-surface-1 gap-4',
 			spinner:
 				'relative animate-spin rounded-full border-4 border-transparent border-b-purple-700 border-l-green-500 border-r-blue-600 border-t-yellow-500',
-			text: 'text-center font-semibold text-white'
+			text: 'text-center font-semibold text-text'
 		},
 		button: {
 			container: 'flex items-center gap-2',
@@ -49,14 +49,14 @@
 	<div class={currentVariant.container}>
 		<div class="relative">
 			<div
-				class="absolute inset-0 animate-pulse rounded-full bg-gradient-to-r from-purple-700 via-blue-600 to-yellow-500 opacity-20"
+				class="absolute inset-0 animate-pulse rounded-full bg-gradient-to-r from-accent-bright via-accent to-accent-deep opacity-20"
 			></div>
 			<div class="relative {currentSize.spinner} {currentVariant.spinner}"></div>
 			<div class="absolute inset-0 flex items-center justify-center">
 				<div
 					class="h-{size === 'xl' ? '24' : '12'} w-{size === 'xl'
 						? '24'
-						: '12'} rounded-full bg-gray-{size === 'xl' ? '900' : '800'}"
+						: '12'} rounded-full bg-surface-{size === 'xl' ? '1' : '2'}"
 				></div>
 			</div>
 		</div>

--- a/src/lib/components/LowFundsBanner.svelte
+++ b/src/lib/components/LowFundsBanner.svelte
@@ -81,7 +81,7 @@
 </script>
 
 {#if showBanner}
-	<div class="relative z-50 bg-blue-600 px-4 py-2.5 text-center text-sm text-white">
+	<div class="relative z-50 bg-iris px-4 py-2.5 text-center text-sm text-text">
 		<div class="mx-auto flex max-w-4xl items-center justify-center gap-2">
 			<svg class="h-4 w-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path
@@ -95,14 +95,14 @@
 			<button
 				type="button"
 				on:click={handleDeposit}
-				class="ml-1 font-semibold underline underline-offset-2 transition hover:text-blue-100"
+				class="ml-1 font-semibold underline underline-offset-2 transition hover:text-iris"
 			>
 				Deposit to start trading
 			</button>
 			<button
 				type="button"
 				on:click={handleDismiss}
-				class="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-white/80 transition hover:bg-white/10 hover:text-white"
+				class="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-text-2 transition hover:bg-surface-3 hover:text-text"
 				aria-label="Dismiss"
 			>
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/lib/components/MobileTabBar.svelte
+++ b/src/lib/components/MobileTabBar.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { sfts } from '$lib/stores';
+	import { navCollapsed, anySheetOpen } from '$lib/stores/uiStore';
+	import Icon from '$lib/components/ui/Icon.svelte';
+	import type { IconName } from '$lib/components/ui/Icon.svelte';
+
+	$: activePath = $page.url.pathname;
+	$: firstTokenId = $sfts?.[0]?.id;
+	$: tradeHref = firstTokenId ? `/trade/${firstTokenId}` : '/';
+
+	type Tab = { href: string; label: string; icon: IconName; active: boolean };
+
+	$: tabs = [
+		{ href: '/', label: 'Home', icon: 'home', active: activePath === '/' },
+		{ href: tradeHref, label: 'Trade', icon: 'swap', active: activePath.startsWith('/trade') },
+		{ href: '/dashboard', label: 'Wallet', icon: 'wallet', active: activePath === '/dashboard' },
+		{
+			href: '/platform-metrics',
+			label: 'Metrics',
+			icon: 'chart',
+			active: activePath === '/platform-metrics'
+		}
+	] as Tab[];
+
+	// The bottom bar is the primary nav once the header collapses. Hide it whenever
+	// a bottom-sheet is up so the sheet's action button never sits behind it.
+	$: show = $navCollapsed && !$anySheetOpen;
+</script>
+
+{#if show}
+	<nav
+		class="bg-bg/95 fixed inset-x-0 bottom-0 z-[9000] flex items-stretch justify-around border-t border-line backdrop-blur-xl"
+		style="padding-bottom: env(safe-area-inset-bottom);"
+		aria-label="Primary"
+		data-sveltekit-preload-code="eager"
+		data-sveltekit-preload-data="tap"
+	>
+		{#each tabs as tab}
+			<a
+				href={tab.href}
+				aria-label={tab.label}
+				aria-current={tab.active ? 'page' : undefined}
+				class="relative flex flex-1 flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors {tab.active
+					? 'text-text'
+					: 'text-text-3'}"
+			>
+				{#if tab.active}
+					<span class="bg-text/70 absolute top-0 h-0.5 w-7 rounded-full"></span>
+				{/if}
+				<span class="relative">
+					<Icon name={tab.icon} className="h-[22px] w-[22px]" stroke={tab.active ? 2 : 1.6} />
+				</span>
+				{tab.label}
+			</a>
+		{/each}
+	</nav>
+{/if}

--- a/src/lib/components/NetworkSelector.svelte
+++ b/src/lib/components/NetworkSelector.svelte
@@ -5,6 +5,7 @@
 	import { wagmiConfig, chainId, connected } from 'svelte-wagmi';
 	import { get } from 'svelte/store';
 	import { track } from '$lib/services/analytics';
+	import Icon from '$lib/components/ui/Icon.svelte';
 
 	let isOpen = false;
 
@@ -92,18 +93,14 @@
 <div class="network-selector relative z-[10000] inline-block shrink-0">
 	<button
 		on:click={toggleDropdown}
-		class="flex min-h-10 items-center gap-2 rounded-lg bg-transparent px-2 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-white/5 active:scale-95 sm:px-3 sm:py-2 sm:text-sm"
+		class="flex items-center gap-1.5 rounded-lg border border-line bg-overlay-1 px-2.5 py-1.5 text-sm font-medium text-text-2 transition-all duration-200 hover:bg-overlay-hover active:scale-95"
 	>
-		<div class="flex items-center gap-2">
-			<img
-				src={getChainLogo($currentNetwork)}
-				alt={$currentNetwork.displayName}
-				class="h-4 w-4"
-				class:rounded-full={$currentNetwork.chainId !== 8453}
-			/>
-			<span class="hidden sm:inline">{$currentNetwork.displayName}</span>
-		</div>
-		<span class="text-xs transition-transform duration-200" class:rotate-180={isOpen}>▼</span>
+		<span class="h-2 w-2 rounded-full bg-iris-500"></span>
+		<span class="hidden capitalize sm:inline">{$currentNetwork.name}</span>
+		<Icon
+			name="chevronDown"
+			className="h-4 w-4 text-text-3 transition-transform duration-200 {isOpen ? 'rotate-180' : ''}"
+		/>
 	</button>
 
 	{#if isOpen}
@@ -118,15 +115,15 @@
 
 		<!-- Dropdown content - responsive positioning -->
 		<div
-			class="absolute left-0 right-0 top-full z-[9999] mx-2 mt-1 min-w-[200px] rounded-lg border border-white/10 bg-gray-800/95 shadow-lg backdrop-blur-lg sm:left-auto sm:right-0 sm:top-full sm:mx-0 sm:w-auto"
+			class="bg-surface-1/95 absolute left-0 right-0 top-full z-[9999] mx-2 mt-1 min-w-[200px] rounded-lg border border-line shadow-[var(--shadow-2)] backdrop-blur-lg sm:left-auto sm:right-0 sm:top-full sm:mx-0 sm:w-auto"
 		>
 			<div class="p-1">
 				{#each networks as network}
 					<button
 						on:click={() => selectNetwork(network)}
-						class="flex w-full items-center gap-3 rounded-md px-3 py-3 text-sm text-white transition-colors hover:bg-gray-700/80 active:bg-gray-600/80 {$currentNetwork.id ===
+						class="flex w-full items-center gap-3 rounded-md px-3 py-3 text-sm text-text transition-colors hover:bg-surface-2 active:bg-surface-3 {$currentNetwork.id ===
 						network.id
-							? 'bg-yellow-500/20'
+							? 'bg-accent-soft'
 							: ''}"
 					>
 						<img
@@ -137,7 +134,7 @@
 						/>
 						<div class="flex flex-col items-start">
 							<span class="font-medium">{network.displayName}</span>
-							<span class="text-xs text-gray-400">{network.currencySymbol}</span>
+							<span class="text-xs text-text-3">{network.currencySymbol}</span>
 						</div>
 					</button>
 				{/each}

--- a/src/lib/components/OldTokensBanner.svelte
+++ b/src/lib/components/OldTokensBanner.svelte
@@ -75,7 +75,7 @@
 </script>
 
 {#if showBanner}
-	<div class="relative z-40 bg-yellow-600 px-4 py-2.5 text-center text-sm text-white">
+	<div class="relative z-40 bg-amber-600 px-4 py-2.5 text-center text-sm text-white">
 		<div class="mx-auto flex max-w-4xl items-center justify-center gap-2">
 			<svg class="h-4 w-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path
@@ -94,7 +94,7 @@
 			<button
 				type="button"
 				on:click={handleSwapClick}
-				class="ml-1 font-semibold underline underline-offset-2 transition hover:text-yellow-100"
+				class="ml-1 font-semibold underline underline-offset-2 transition hover:text-amber-100"
 			>
 				Click here to swap
 			</button>

--- a/src/lib/components/PythOracleRow.svelte
+++ b/src/lib/components/PythOracleRow.svelte
@@ -100,14 +100,14 @@
 				± {priceData.confidence.toFixed(5)}
 			{/if}
 		</td>
-		<td class="px-2 py-1 text-right text-gray-400">
+		<td class="px-2 py-1 text-right text-text-2">
 			{#if quotePrice !== null}
 				${quotePrice.toFixed(5)}
 			{/if}
 		</td>
 	{:else}
 		<td class="px-2 py-1" colspan="4">
-			<div class="text-sm text-gray-400">Oracle data unavailable</div>
+			<div class="text-sm text-text-2">Oracle data unavailable</div>
 		</td>
 	{/if}
 </tr>

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -19,6 +19,9 @@
 	import Button from './ui/Button.svelte';
 	import { isOutsideMarketHours } from '$lib/utils/marketHours';
 	import { track } from '$lib/services/analytics';
+	import QuickTradeChart from './QuickTradeChart.svelte';
+	import Icon from './ui/Icon.svelte';
+	import { goto } from '$app/navigation';
 
 	type ParseFloatHex = typeof import('$lib/utils/tokenMath').parseFloatHex;
 
@@ -841,19 +844,21 @@
 <svelte:window on:click={closeDropdown} />
 
 <div
-	class="relative w-full max-w-md rounded-2xl border border-white/10 bg-gray-900/80 p-4 shadow-2xl backdrop-blur-xl sm:p-6"
+	class="bg-surface-1/80 relative w-full rounded-2xl border border-line p-4 shadow-2xl backdrop-blur-xl sm:p-6 md:grid md:grid-cols-2 md:items-stretch md:gap-6"
 >
-	<div
-		class="pointer-events-none absolute -inset-px rounded-2xl bg-gradient-to-b from-blue-500/20 via-transparent to-transparent opacity-50"
-	></div>
-
 	<div class="relative space-y-4">
+		<!-- Card header -->
+		<div class="flex items-center justify-between text-xs text-text-2">
+			<span>Quick trade</span>
+			<span>Base · {paymentToken?.symbol ?? 'USDC'}</span>
+		</div>
+
 		<!-- USDC section -->
 		<div class="space-y-1">
 			<div
-				class="flex items-center gap-3 rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3"
+				class="flex items-center gap-3 rounded-xl border border-line bg-overlay-strong px-3.5 py-3.5"
 			>
-				<div class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5">
+				<div class="flex items-center gap-2 rounded-full bg-overlay-2 px-3 py-1.5">
 					{#if paymentToken?.logoUrl}
 						<img
 							src={paymentToken.logoUrl}
@@ -861,7 +866,7 @@
 							class="h-6 w-6 rounded-full"
 						/>
 					{/if}
-					<span class="font-medium text-white">{paymentToken?.symbol ?? 'USDC'}</span>
+					<span class="font-medium text-text">{paymentToken?.symbol ?? 'USDC'}</span>
 				</div>
 				<div class="flex-1 text-right">
 					<input
@@ -871,12 +876,12 @@
 						value={topAmount}
 						on:input={handleTopInput}
 						on:blur={capAmountsIfNeeded}
-						class="w-full bg-transparent text-right text-xl font-medium text-white placeholder-gray-600 focus:outline-none sm:text-2xl"
+						class="w-full bg-transparent text-right text-xl font-medium text-text placeholder-text-3 focus:outline-none sm:text-2xl"
 					/>
 				</div>
 			</div>
 			<div class="flex items-center justify-between px-1 text-xs">
-				<span class="text-gray-500">
+				<span class="text-text-3">
 					{#if $isAuthenticated && $walletAddress}
 						Balance: {formattedUsdcBalance.toFixed(2)} {paymentToken?.symbol ?? 'USDC'}
 					{:else}
@@ -889,7 +894,7 @@
 							<button
 								type="button"
 								on:click={() => handleUsdcPercentClick(percent)}
-								class="rounded bg-gray-700/50 px-1.5 py-0.5 text-[10px] text-gray-400 transition hover:bg-gray-600 hover:text-white"
+								class="rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-text-3 transition hover:bg-surface-2 hover:text-text"
 							>
 								{percent === 100 ? 'MAX' : `${percent}%`}
 							</button>
@@ -899,7 +904,7 @@
 			</div>
 			{#if isBuying && quote && (!quote.hasLiquidity || showLiquidityWarning)}
 				<div
-					class="mt-1 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2 py-1.5 text-xs text-yellow-300"
+					class="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-300"
 				>
 					{#if showLiquidityWarning}
 						Order capped to max available liquidity.
@@ -913,41 +918,33 @@
 			{/if}
 		</div>
 
-		<!-- Direction arrow -->
-		<div class="flex justify-center">
+		<!-- Direction arrow (overlapping swap pivot) -->
+		<div class="relative z-10 -my-3 flex justify-center">
 			<button
 				type="button"
 				on:click={handleSwapDirection}
-				class="rounded-full border border-white/10 bg-gray-800 p-2 transition hover:border-white/20 hover:bg-gray-700"
+				class="flex h-9 w-9 items-center justify-center rounded-full border border-line bg-surface-1 transition hover:border-line-strong hover:bg-surface-2"
 			>
-				<svg
-					class="h-4 w-4 text-gray-400 transition-transform duration-200"
-					class:rotate-180={!isBuying}
-					fill="none"
-					stroke="currentColor"
-					viewBox="0 0 24 24"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M19 14l-7 7m0 0l-7-7m7 7V3"
-					/>
-				</svg>
+				<Icon
+					name="arrowDown"
+					className="h-4 w-4 text-text-3 transition-transform duration-200 {!isBuying
+						? 'rotate-180'
+						: ''}"
+				/>
 			</button>
 		</div>
 
 		<!-- Token section -->
 		<div class="space-y-1">
 			<div
-				class="flex items-center gap-3 rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3"
+				class="flex items-center gap-3 rounded-xl border border-line bg-overlay-strong px-3.5 py-3.5"
 			>
 				<!-- Token selector - completely independent -->
 				<div class="relative">
 					<button
 						type="button"
 						on:click={toggleDropdown}
-						class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5 transition hover:bg-gray-700"
+						class="flex items-center gap-2 rounded-full bg-overlay-2 px-3 py-1.5 transition hover:bg-overlay-hover"
 					>
 						{#if selectedToken}
 							<img
@@ -955,16 +952,11 @@
 								alt={selectedToken.symbol}
 								class="h-6 w-6 rounded-full"
 							/>
-							<span class="font-medium text-white">{selectedToken.symbol}</span>
+							<span class="font-medium text-text">{selectedToken.symbol}</span>
 						{:else}
-							<span class="text-gray-400">Select</span>
+							<span class="text-text-3">Select</span>
 						{/if}
-						<svg
-							class="h-4 w-4 text-gray-400"
-							fill="none"
-							stroke="currentColor"
-							viewBox="0 0 24 24"
-						>
+						<svg class="h-4 w-4 text-text-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -979,13 +971,13 @@
 						<!-- svelte-ignore a11y-no-static-element-interactions -->
 						<div
 							on:click|stopPropagation
-							class="absolute left-0 top-full z-[100] mt-2 w-64 overflow-hidden rounded-xl border border-white/10 bg-gray-800 shadow-xl"
+							class="absolute left-0 top-full z-[100] mt-2 w-64 overflow-hidden rounded-xl border border-line bg-surface-1 shadow-xl"
 						>
 							<!-- Scroll up indicator -->
 							{#if canScrollUp}
-								<div class="flex justify-center border-b border-white/5 py-1">
+								<div class="flex justify-center border-b border-line py-1">
 									<svg
-										class="h-4 w-4 text-gray-500"
+										class="h-4 w-4 text-text-muted"
 										fill="none"
 										stroke="currentColor"
 										viewBox="0 0 24 24"
@@ -1008,21 +1000,21 @@
 									<button
 										type="button"
 										on:click|stopPropagation={() => handleTokenSelect(token.address)}
-										class="flex w-full items-center gap-3 px-4 py-2 text-left transition hover:bg-white/5"
+										class="flex w-full items-center gap-3 px-4 py-2 text-left transition hover:bg-surface-2"
 									>
 										<img src={token.logoUrl} alt={token.symbol} class="h-6 w-6 rounded-full" />
 										<div>
-											<div class="font-medium text-white">{token.symbol}</div>
-											<div class="text-xs text-gray-500">{token.name}</div>
+											<div class="font-medium text-text">{token.symbol}</div>
+											<div class="text-xs text-text-3">{token.name}</div>
 										</div>
 									</button>
 								{/each}
 							</div>
 							<!-- Scroll down indicator -->
 							{#if canScrollDown}
-								<div class="flex justify-center border-t border-white/5 py-1">
+								<div class="flex justify-center border-t border-line py-1">
 									<svg
-										class="h-4 w-4 text-gray-500"
+										class="h-4 w-4 text-text-muted"
 										fill="none"
 										stroke="currentColor"
 										viewBox="0 0 24 24"
@@ -1048,12 +1040,12 @@
 						value={bottomAmount}
 						on:input={handleBottomInput}
 						on:blur={capAmountsIfNeeded}
-						class="w-full bg-transparent text-right text-xl font-medium text-white placeholder-gray-600 focus:outline-none sm:text-2xl"
+						class="w-full bg-transparent text-right text-xl font-medium text-text placeholder-text-3 focus:outline-none sm:text-2xl"
 					/>
 				</div>
 			</div>
 			<div class="flex items-center justify-between px-1 text-xs">
-				<span class="text-gray-500">
+				<span class="text-text-3">
 					{#if $isAuthenticated && $walletAddress}
 						Balance: {formattedTokenBalance.toFixed(4)} {selectedToken?.symbol ?? ''}
 					{:else if quote?.avgPrice}
@@ -1068,7 +1060,7 @@
 							<button
 								type="button"
 								on:click={() => handleTokenPercentClick(percent)}
-								class="rounded bg-gray-700/50 px-1.5 py-0.5 text-[10px] text-gray-400 transition hover:bg-gray-600 hover:text-white"
+								class="rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-text-3 transition hover:bg-surface-2 hover:text-text"
 							>
 								{percent === 100 ? 'MAX' : `${percent}%`}
 							</button>
@@ -1078,7 +1070,7 @@
 			</div>
 			{#if !isBuying && quote && (!quote.hasLiquidity || showLiquidityWarning)}
 				<div
-					class="mt-1 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2 py-1.5 text-xs text-yellow-300"
+					class="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-300"
 				>
 					{#if showLiquidityWarning}
 						Order capped to max available liquidity.
@@ -1093,15 +1085,15 @@
 		</div>
 
 		<!-- Network info -->
-		<div class="flex items-center justify-center gap-2 text-xs text-gray-500">
+		<div class="flex items-center justify-center gap-2 text-xs text-text-3">
 			<span>Trading on</span>
 			<img src="/images/BASE.svg" alt="Base" class="h-4 w-4" />
-			<span class="text-gray-400">{$currentNetwork?.displayName ?? 'Base'}</span>
+			<span class="text-text-2">{$currentNetwork?.displayName ?? 'Base'}</span>
 		</div>
 
 		<!-- Error display -->
 		{#if tradeError}
-			<div class="rounded-lg bg-red-500/10 px-3 py-2 text-center text-sm text-red-400">
+			<div class="rounded-lg bg-down-soft px-3 py-2 text-center text-sm text-down">
 				{tradeError}
 			</div>
 		{/if}
@@ -1182,6 +1174,29 @@
 				Connect wallet
 			</Button>
 		{/if}
+
+		<!-- or divider -->
+		<div class="flex items-center gap-3 text-[11px] uppercase tracking-wider text-text-muted">
+			<span class="h-px flex-1 bg-line"></span>
+			<span>or</span>
+			<span class="h-px flex-1 bg-line"></span>
+		</div>
+
+		<!-- Launch Trading Terminal (secondary) -->
+		<button
+			type="button"
+			class="w-full rounded-xl border border-line-strong bg-overlay-2 py-3 text-sm font-semibold text-text transition hover:bg-overlay-hover"
+			on:click={() => goto('/trade/0x2289249984f1fa2ce86c4e8867e7eb819ea7df95')}
+		>
+			Launch Trading Terminal
+		</button>
+	</div>
+
+	<!-- Right: ambient price chart for the selected token (md+ only) -->
+	<div class="relative hidden md:block">
+		<div class="h-full min-h-[320px] overflow-hidden rounded-xl border border-line bg-bg-deep">
+			<QuickTradeChart token={selectedToken} fallbackPrice={bestAskPrice ?? bestBidPrice} />
+		</div>
 	</div>
 </div>
 

--- a/src/lib/components/QuickTradeChart.svelte
+++ b/src/lib/components/QuickTradeChart.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+	// Ambient price chart for the QuickTrade card — a clean single-line area chart
+	// of real on-platform price history for the selected token, with light token /
+	// price / change overlays (mirrors the design's LivePriceChart). Falls back to a
+	// subtle decorative wave when the token has little or no recent trade history, so
+	// the panel never renders an empty or broken state.
+	import { browser } from '$app/environment';
+	import { currentNetwork } from '$lib/stores';
+	import type { CategorizedToken } from '$lib/config/network';
+	import { createTokenTradeActivityQuery } from '$lib/queries/tradeActivity';
+	import { apiTradesToHistoryPoints } from '$lib/utils/ohlc';
+
+	export let token: CategorizedToken | undefined;
+	// Best live quote price, used as the headline number when the token has no
+	// recent trades of its own (e.g. the featured wtSGOV).
+	export let fallbackPrice: number | null = null;
+
+	const W = 320;
+	const H = 240;
+	// Cap to the most recent points so the line stays smooth and reads as "recent".
+	const MAX_POINTS = 80;
+	// Floor on the y-axis range (fraction of price). Autoscaling is great for real
+	// movers, but a near-flat asset (e.g. wtSGOV, which moves well under 1% over a
+	// week) should not zoom into a microscopic, unlabelled scale that makes 1c of
+	// bid/ask bounce look volatile. We hold the axis to at least this span and centre
+	// the data in it, so anything calmer than MIN_RANGE_PCT reads as flat.
+	const MIN_RANGE_PCT = 0.06;
+
+	// Deterministic decorative wave for the no-history fallback (no Math.random, so
+	// SSR and client render identically).
+	const FALLBACK_SERIES: number[] = (() => {
+		const a: number[] = [];
+		for (let i = 0; i <= 36; i++) a.push(Math.sin(i / 2.4) * 5 + Math.sin(i / 6) * 3);
+		return a;
+	})();
+
+	$: paymentToken = $currentNetwork?.defaultPaymentToken ?? null;
+	$: tradeQuery = createTokenTradeActivityQuery($currentNetwork, token?.address ?? null);
+
+	$: assetAddresses = (() => {
+		const set = new Set<string>();
+		if (token?.address) set.add(token.address.toLowerCase());
+		if (token?.unwrappedAddress) set.add(token.unwrappedAddress.toLowerCase());
+		if (token?.legacyAddress) set.add(token.legacyAddress.toLowerCase());
+		return set;
+	})();
+
+	$: historyPoints =
+		browser && paymentToken?.address
+			? apiTradesToHistoryPoints(
+					$tradeQuery.data?.trades ?? [],
+					assetAddresses,
+					paymentToken.address
+				)
+			: [];
+
+	// Window-centred reducer used by both filters below (clamps at the edges).
+	function windowed(
+		values: number[],
+		window: number,
+		reduce: (slice: number[]) => number
+	): number[] {
+		if (values.length <= window) return values;
+		const half = Math.floor(window / 2);
+		return values.map((_, i) => {
+			const lo = Math.max(0, i - half);
+			const hi = Math.min(values.length, i + half + 1);
+			return reduce(values.slice(lo, hi));
+		});
+	}
+
+	// Median filter, then a light mean pass. Illiquid assets like wtSGOV trade in a
+	// bid/ask sawtooth (alternating high/low prints) that a mean filter only blurs but
+	// can't remove — it leaves the line looking volatile. A median collapses each pair
+	// of alternating prints to the central value, killing the sawtooth while preserving
+	// any genuine trend; the mean pass then softens the corners.
+	function denoise(values: number[]): number[] {
+		const median = windowed(values, 5, (s) => {
+			const sorted = [...s].sort((a, b) => a - b);
+			return sorted[Math.floor(sorted.length / 2)];
+		});
+		return windowed(median, 3, (s) => s.reduce((sum, v) => sum + v, 0) / s.length);
+	}
+
+	$: recentPrices = historyPoints.map((p) => p.price).slice(-MAX_POINTS);
+	$: hasRealData = recentPrices.length >= 2;
+	$: series = hasRealData ? denoise(recentPrices) : FALLBACK_SERIES;
+
+	// Headline stays the true latest trade; the change badge is read off the de-noised
+	// series so a near-flat asset doesn't report a double-digit swing from bounce alone.
+	$: latestPrice = hasRealData ? recentPrices[recentPrices.length - 1] : fallbackPrice;
+	$: changePct =
+		hasRealData && series.length >= 2
+			? ((series[series.length - 1] - series[0]) / series[0]) * 100
+			: null;
+	$: up = (changePct ?? 0) >= 0;
+
+	$: paths = (() => {
+		const min = Math.min(...series);
+		const max = Math.max(...series);
+		const mid = (min + max) / 2;
+		const dataSpan = max - min;
+		// Autoscale to the real range, but never below MIN_RANGE_PCT of price — so a
+		// flat asset stays flat instead of magnifying noise. The decorative fallback
+		// has no price scale, so it just uses its own span at full amplitude.
+		const floorSpan = mid > 0 ? mid * MIN_RANGE_PCT : dataSpan;
+		const span = hasRealData ? Math.max(dataSpan, floorSpan) : dataSpan;
+		const base = mid - span / 2;
+		const top = H * 0.22;
+		const band = H * 0.56;
+		const xy = series.map((v, i) => {
+			const x = series.length > 1 ? (i / (series.length - 1)) * W : 0;
+			const norm = span ? (v - base) / span : 0.5;
+			const y = top + (1 - norm) * band;
+			return [x, y] as const;
+		});
+		const line = xy
+			.map((q, i) => `${i ? 'L' : 'M'}${q[0].toFixed(1)},${q[1].toFixed(1)}`)
+			.join(' ');
+		return { line, area: `${line} L${W},${H} L0,${H} Z` };
+	})();
+
+	function fmtPrice(n: number): string {
+		if (n >= 1000) return n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+		if (n >= 1) return n.toFixed(2);
+		return n.toFixed(4);
+	}
+</script>
+
+<div class="relative h-full w-full overflow-hidden">
+	<svg
+		class="absolute inset-0 h-full w-full"
+		viewBox={`0 0 ${W} ${H}`}
+		preserveAspectRatio="none"
+		aria-hidden="true"
+	>
+		<defs>
+			<linearGradient id="qtchart" x1="0" y1="0" x2="0" y2="1">
+				<stop offset="0%" stop-color="#2de3a6" stop-opacity={hasRealData ? 0.22 : 0.08} />
+				<stop offset="100%" stop-color="#2de3a6" stop-opacity="0" />
+			</linearGradient>
+		</defs>
+		<path d={paths.area} fill="url(#qtchart)" />
+		<path
+			d={paths.line}
+			class:qt-draw={!hasRealData}
+			pathLength="1"
+			fill="none"
+			stroke="#2de3a6"
+			stroke-opacity={hasRealData ? 1 : 0.35}
+			stroke-width="2"
+			stroke-linejoin="round"
+			stroke-linecap="round"
+			vector-effect="non-scaling-stroke"
+		/>
+	</svg>
+
+	{#if !hasRealData}
+		<!-- Placeholder/loading affordance: a soft emerald shimmer sweep so the
+		     decorative no-history chart reads as a live placeholder, not flat data. -->
+		<div class="qt-shimmer pointer-events-none absolute inset-0" aria-hidden="true"></div>
+	{/if}
+
+	{#if token}
+		<div class="absolute left-5 top-5 flex max-w-[55%] items-center gap-2.5">
+			<img src={token.logoUrl} alt={token.symbol} class="h-7 w-7 shrink-0 rounded-full" />
+			<div class="min-w-0">
+				<div class="text-sm font-semibold leading-none text-text">{token.symbol}</div>
+				<div class="mt-1 truncate text-[11px] text-text-2">{token.name}</div>
+			</div>
+		</div>
+	{/if}
+
+	{#if latestPrice != null}
+		<div class="absolute right-5 top-5 text-right">
+			<div class="font-mono text-lg font-semibold leading-none text-text">
+				${fmtPrice(latestPrice)}
+			</div>
+			{#if changePct != null}
+				<div
+					class="mt-1.5 inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-semibold {up
+						? 'bg-emerald-400/15 text-accent'
+						: 'bg-red-400/15 text-red-300'}"
+				>
+					{up ? '▲' : '▼'}
+					{Math.abs(changePct).toFixed(2)}%
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="absolute bottom-4 left-5 flex items-center gap-1.5 text-[11px] text-text-3">
+		<span class="relative flex h-1.5 w-1.5">
+			<span
+				class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-70"
+			></span>
+			<span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
+		</span>
+		{hasRealData ? 'Live on-chain price' : 'Live market · 50+ equities'}
+	</div>
+</div>
+
+<style>
+	/* Placeholder line repeatedly "draws" itself left→right so the no-history
+	   chart obviously reads as a live placeholder rather than static flat data. */
+	.qt-draw {
+		stroke-dasharray: 1;
+		animation: qt-draw 2.8s ease-in-out infinite;
+	}
+	@keyframes qt-draw {
+		0% {
+			stroke-dashoffset: 1;
+			opacity: 0.25;
+		}
+		55% {
+			stroke-dashoffset: 0;
+			opacity: 0.65;
+		}
+		100% {
+			stroke-dashoffset: 0;
+			opacity: 0.25;
+		}
+	}
+
+	/* Soft emerald highlight sweeping across the panel — the universal "loading" cue. */
+	.qt-shimmer {
+		background: linear-gradient(
+			100deg,
+			transparent 35%,
+			rgba(45, 227, 166, 0.12) 50%,
+			transparent 65%
+		);
+		background-size: 220% 100%;
+		animation: qt-shimmer 2.4s linear infinite;
+	}
+	@keyframes qt-shimmer {
+		0% {
+			background-position: 160% 0;
+		}
+		100% {
+			background-position: -160% 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.qt-draw,
+		.qt-shimmer {
+			animation: none;
+		}
+		.qt-draw {
+			stroke-dasharray: none;
+		}
+	}
+</style>

--- a/src/lib/components/RainlangConfirmationModal.svelte
+++ b/src/lib/components/RainlangConfirmationModal.svelte
@@ -21,7 +21,7 @@
 
 <Modal {show} title="Deploy Strategy on chain" onClose={onCancel}>
 	<div class="space-y-4">
-		<div class="rounded-lg border border-white/10 bg-gray-900 p-4">
+		<div class="rounded-lg border border-line bg-surface-1 p-4">
 			<pre class="overflow-x-auto whitespace-pre-wrap font-mono text-sm">
 				<code bind:this={codeElement} class="language-javascript">{rainlangCode}</code>
 			</pre>

--- a/src/lib/components/SendFundsModal.svelte
+++ b/src/lib/components/SendFundsModal.svelte
@@ -186,19 +186,19 @@
 					</svg>
 				</div>
 				<div class="text-center">
-					<h3 class="text-lg font-semibold text-white">Transaction Submitted</h3>
-					<p class="mt-1 text-sm text-gray-400">
+					<h3 class="text-lg font-semibold text-text">Transaction Submitted</h3>
+					<p class="mt-1 text-sm text-text-2">
 						Sending {amount}
 						{selectedToken?.symbol} to
 					</p>
-					<p class="mt-1 font-mono text-xs text-gray-500">
+					<p class="mt-1 font-mono text-xs text-text-3">
 						{recipientAddress.slice(0, 10)}...{recipientAddress.slice(-8)}
 					</p>
 					<a
 						href="{$currentNetwork?.blockExplorer}/tx/{txHash}"
 						target="_blank"
 						rel="noopener noreferrer"
-						class="mt-3 inline-flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300"
+						class="mt-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 					>
 						View on BaseScan
 						<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -218,11 +218,10 @@
 			<div class="space-y-4">
 				<!-- From address (read-only) -->
 				<div>
-					<label class="mb-1.5 block text-sm font-medium text-gray-300" for="from-address"
-						>From</label
+					<label class="mb-1.5 block text-sm font-medium text-text-2" for="from-address">From</label
 					>
-					<div id="from-address" class="rounded-lg border border-gray-700 bg-gray-800 px-3 py-2.5">
-						<span class="font-mono text-sm text-gray-400">
+					<div id="from-address" class="rounded-lg border border-line bg-surface-2 px-3 py-2.5">
+						<span class="font-mono text-sm text-text-2">
 							{$dynamicSession?.walletAddress
 								? `${$dynamicSession.walletAddress.slice(
 										0,
@@ -235,7 +234,7 @@
 
 				<!-- To address -->
 				<div>
-					<label class="mb-1.5 block text-sm font-medium text-gray-300" for="recipient">
+					<label class="mb-1.5 block text-sm font-medium text-text-2" for="recipient">
 						Recipient Address
 					</label>
 					<input
@@ -244,7 +243,7 @@
 						placeholder="0x..."
 						value={recipientAddress}
 						on:input={handleAddressInput}
-						class="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2.5 font-mono text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 font-mono text-sm text-text placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 					/>
 					{#if recipientAddress && !isValidAddress}
 						<p class="mt-1 text-xs text-red-400">Invalid Ethereum address</p>
@@ -254,17 +253,17 @@
 				<!-- Token selector and amount -->
 				<div>
 					<div class="mb-1.5 flex items-center justify-between">
-						<label class="text-sm font-medium text-gray-300" for="amount">Amount</label>
+						<label class="text-sm font-medium text-text-2" for="amount">Amount</label>
 						{#if preSelectedBalance}
-							<span class="text-xs text-gray-400">
-								Balance: <span class="text-gray-300">{preSelectedBalance}</span>
+							<span class="text-xs text-text-2">
+								Balance: <span class="text-text-2">{preSelectedBalance}</span>
 							</span>
 						{/if}
 					</div>
 					<div class="flex gap-2">
 						<select
 							bind:value={selectedTokenSymbol}
-							class="rounded-lg border border-gray-700 bg-gray-800 px-3 py-2.5 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+							class="rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-sm text-text focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 						>
 							{#each availableTokens as token}
 								<option value={token.symbol}>{token.symbol}</option>
@@ -278,13 +277,13 @@
 								placeholder="0.0"
 								value={amount}
 								on:input={handleAmountInput}
-								class="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2.5 pr-14 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+								class="w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 pr-14 text-sm text-text placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 							/>
 							{#if preSelectedBalanceRaw}
 								<button
 									type="button"
 									on:click={handleMax}
-									class="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-gray-700 px-2 py-0.5 text-xs font-medium text-yellow-400 hover:bg-gray-600"
+									class="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-surface-3 px-2 py-0.5 text-xs font-medium text-accent hover:bg-gray-600"
 								>
 									MAX
 								</button>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -6,6 +6,7 @@
 	import { formatUnits } from 'viem';
 	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
+	import Icon from '$lib/components/ui/Icon.svelte';
 
 	export let visible: boolean = false; // controlled by parent
 	export let desktop: boolean = false; // is this the desktop sidebar?
@@ -55,7 +56,7 @@
 {#if desktop}
 	<button
 		on:click={toggleCollapse}
-		class="fixed top-16 z-[10001] rounded-r-lg border border-l-0 border-white/10 bg-gray-900/80 px-1 py-3 text-gray-400 backdrop-blur-xl transition-all duration-300 hover:bg-gray-800 hover:pr-2 hover:text-white"
+		class="bg-surface-1/80 fixed top-16 z-[10001] rounded-r-lg border border-l-0 border-line px-1 py-3 text-text-3 backdrop-blur-xl transition-all duration-300 hover:bg-surface-2 hover:pr-2 hover:text-text"
 		class:left-64={!collapsed}
 		class:left-0={collapsed}
 		aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
@@ -76,7 +77,7 @@
 {#if !desktop && !visible}
 	<button
 		on:click={() => dispatch('open')}
-		class="fixed left-0 top-1/3 z-[10001] flex items-center gap-1 rounded-r-lg border border-l-0 border-yellow-500/40 bg-gradient-to-r from-yellow-500/20 to-yellow-500/10 px-1.5 py-4 text-yellow-400 shadow-lg shadow-yellow-500/20 backdrop-blur-xl transition-all duration-300 hover:border-yellow-500/60 hover:bg-yellow-500/30 hover:pr-2.5 hover:text-yellow-300"
+		class="fixed left-0 top-1/3 z-[10001] flex items-center gap-1 rounded-r-lg border border-l-0 border-accent-line bg-accent-soft px-1.5 py-4 text-accent shadow-lg shadow-[var(--shadow-accent)] backdrop-blur-xl transition-all duration-300 hover:pr-2.5 hover:brightness-110"
 		aria-label="Open token list"
 	>
 		<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -87,7 +88,7 @@
 
 <!-- Sidebar -->
 <div
-	class="fixed left-0 top-0 z-[10000] flex h-full transform flex-col border-r border-white/5 bg-gray-900/70 backdrop-blur-xl transition-all duration-300 ease-in-out"
+	class="bg-surface-1/70 fixed left-0 top-0 z-[10000] flex h-full transform flex-col border-r border-line backdrop-blur-xl transition-all duration-300 ease-in-out"
 	class:w-64={desktop || (!desktop && visible)}
 	class:w-0={!desktop && !visible}
 	class:max-w-[80vw]={!desktop && visible}
@@ -96,20 +97,13 @@
 >
 	<!-- Mobile header with close button -->
 	{#if !desktop}
-		<div class="flex items-center justify-end border-b border-white/5 p-2">
+		<div class="flex items-center justify-end border-b border-line p-2">
 			<button
 				on:click={() => dispatch(visible ? 'close' : 'open')}
-				class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-white/5 hover:text-white"
+				class="rounded-lg p-2 text-text-3 transition-colors hover:bg-surface-2 hover:text-text"
 				aria-label={visible ? 'Close sidebar' : 'Open sidebar'}
 			>
-				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M6 18L18 6M6 6l12 12"
-					/>
-				</svg>
+				<Icon name="close" className="h-5 w-5" />
 			</button>
 		</div>
 	{:else}
@@ -120,7 +114,7 @@
 	{#if (desktop && !collapsed) || (!desktop && visible)}
 		<!-- Assets List (scrollable) -->
 		<div class="flex-1 overflow-y-auto p-3">
-			<div class="mb-3 px-2 text-[10px] font-medium uppercase tracking-wider text-gray-600">
+			<div class="mb-3 px-2 text-[10px] font-medium uppercase tracking-wider text-text-muted">
 				Assets
 			</div>
 			<div class="space-y-0.5">
@@ -131,9 +125,9 @@
 						on:click={() => {
 							if (!desktop) dispatch('close');
 						}}
-						class="block rounded-md px-2 py-2 transition-colors hover:bg-white/5 {activePath ===
+						class="block rounded-md px-2 py-2 transition-colors hover:bg-surface-2 {activePath ===
 						`/trade/${tokenInfo?.address ?? asset.id}`
-							? 'border-l-2 border-yellow-500 bg-yellow-500/10'
+							? 'border-l-2 border-accent bg-accent-soft'
 							: ''}"
 					>
 						<div class="flex items-center justify-between gap-2">
@@ -146,24 +140,24 @@
 									/>
 								{:else}
 									<div
-										class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-700 text-xs font-bold"
+										class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-3 text-xs font-bold"
 									>
 										{asset.symbol.charAt(0)}
 									</div>
 								{/if}
 								<div class="min-w-0 flex-1">
-									<div class="truncate text-sm font-medium text-white">{asset.symbol}</div>
-									<div class="truncate text-xs text-gray-400">{asset.name}</div>
+									<div class="truncate text-sm font-medium text-text">{asset.symbol}</div>
+									<div class="truncate text-xs text-text-3">{asset.name}</div>
 								</div>
 							</div>
-							<div class="text-sm font-medium text-white">
+							<div class="text-sm font-medium text-text">
 								${asset.price > 0 ? asset.price.toFixed(2) : 'N/A'}
 							</div>
 						</div>
 					</a>
 				{/each}
 				{#if sortedAssets.length === 0}
-					<div class="py-8 text-center text-sm text-gray-400">No assets available</div>
+					<div class="py-8 text-center text-sm text-text-3">No assets available</div>
 				{/if}
 			</div>
 		</div>

--- a/src/lib/components/TickerTape.svelte
+++ b/src/lib/components/TickerTape.svelte
@@ -48,7 +48,10 @@
 				symbols: symbols.map((s) => ({ proName: s.proName, title: s.title })),
 				showSymbolLogo: true,
 				colorTheme: 'dark',
-				isTransparent: true,
+				// isTransparent:true makes TradingView's ticker-tape paint a white
+				// canvas (the transparent flag isn't honoured for this widget), which
+				// shows as a white strip on our dark page. false => native dark bg.
+				isTransparent: false,
 				displayMode: 'adaptive',
 				locale: 'en'
 			});

--- a/src/lib/components/TokenSelect.svelte
+++ b/src/lib/components/TokenSelect.svelte
@@ -2,6 +2,8 @@
 	import { createEventDispatcher } from 'svelte';
 	import { onMount } from 'svelte';
 	import type { CategorizedToken } from '$lib/config/network';
+	import Icon from '$lib/components/ui/Icon.svelte';
+	import AssetDisc from '$lib/components/ui/AssetDisc.svelte';
 
 	export let options: CategorizedToken[] = [];
 	export let selected: CategorizedToken | undefined;
@@ -41,46 +43,46 @@
 	<!-- Selected value display -->
 	<button
 		type="button"
-		class="flex w-full items-center justify-between rounded-lg border border-white/10 bg-gray-700/50 px-4 py-3 text-white transition-colors hover:border-yellow-500/50 focus:border-yellow-500/50 focus:outline-none"
+		class="flex w-full items-center justify-between rounded-lg border border-line bg-surface-3 px-4 py-3 text-text transition-colors hover:border-accent-line focus:border-accent-line focus:outline-none"
 		on:click={toggleDropdown}
 	>
 		<div class="flex items-center gap-3">
 			{#if selected?.logoUrl}
 				<img src={selected.logoUrl} alt={selected.symbol} class="h-6 w-6 rounded-full" />
+			{:else if selected?.symbol}
+				<AssetDisc sym={selected.symbol} size={24} />
 			{/if}
 			<span class="font-medium">{selected?.symbol || placeholder}</span>
 		</div>
-		<svg
-			class="h-5 w-5 transform transition-transform {isOpen ? 'rotate-180' : ''}"
-			fill="none"
-			stroke="currentColor"
-			viewBox="0 0 24 24"
-		>
-			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-		</svg>
+		<Icon
+			name="chevronDown"
+			className="h-5 w-5 transform transition-transform {isOpen ? 'rotate-180' : ''}"
+		/>
 	</button>
 
 	<!-- Dropdown options -->
 	{#if isOpen}
 		<div
-			class="absolute left-0 z-50 mt-1 w-full rounded-lg border border-white/10 bg-gray-800/90 shadow-xl"
+			class="absolute left-0 z-50 mt-1 w-full rounded-lg border border-line bg-surface-3 shadow-xl"
 		>
 			<div class="max-h-60 overflow-y-auto py-1">
 				{#each options as token (token.address)}
 					<button
 						type="button"
-						class="flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-white transition-colors
-							hover:bg-gray-700/70 focus:outline-none {selected?.address === token.address
-							? 'bg-gradient-to-r from-blue-600/20 to-purple-700/20'
+						class="flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-text transition-colors
+							hover:bg-overlay-hover focus:outline-none {selected?.address === token.address
+							? 'bg-accent-soft text-accent'
 							: ''}"
 						on:click={() => handleSelect(token)}
 					>
 						{#if token.logoUrl}
 							<img src={token.logoUrl} alt={token.symbol} class="h-6 w-6 rounded-full" />
+						{:else}
+							<AssetDisc sym={token.symbol} size={24} />
 						{/if}
 						<span class="font-medium">{token.symbol}</span>
 						{#if token.name && token.name !== token.symbol}
-							<span class="text-sm text-gray-400">({token.name})</span>
+							<span class="text-sm text-text-2">({token.name})</span>
 						{/if}
 					</button>
 				{/each}

--- a/src/lib/components/TokenSwapModal.svelte
+++ b/src/lib/components/TokenSwapModal.svelte
@@ -472,14 +472,14 @@
 		aria-modal="true"
 		aria-labelledby="swap-modal-title"
 	>
-		<div class="relative overflow-hidden rounded-2xl border border-white/10 bg-gray-900 shadow-2xl">
+		<div class="relative overflow-hidden rounded-2xl border border-line bg-surface-1 shadow-2xl">
 			<!-- Header -->
-			<div class="flex items-center justify-between border-b border-white/10 px-6 py-4">
-				<h3 id="swap-modal-title" class="text-lg font-semibold text-white">Swap Legacy Tokens</h3>
+			<div class="flex items-center justify-between border-b border-line px-6 py-4">
+				<h3 id="swap-modal-title" class="text-lg font-semibold text-text">Swap Legacy Tokens</h3>
 				<button
 					type="button"
 					on:click={handleClose}
-					class="rounded-full p-1 text-gray-400 transition hover:bg-white/10 hover:text-white"
+					class="rounded-full p-1 text-text-2 transition hover:bg-surface-3 hover:text-text"
 					aria-label="Close"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -498,15 +498,13 @@
 				<div class="space-y-4">
 					<!-- What I Have (Old Token) -->
 					<div class="space-y-2">
-						<label for="swap-from-token" class="text-sm font-medium text-gray-400"
-							>What I have</label
-						>
-						<div class="rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3">
+						<label for="swap-from-token" class="text-sm font-medium text-text-2">What I have</label>
+						<div class="rounded-xl border border-line bg-surface-2 px-4 py-3">
 							<!-- Token Dropdown -->
 							<div class="mb-3">
 								<select
 									id="swap-from-token"
-									class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-3 py-2 text-white focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+									class="w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-text focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
 									bind:value={selectedOldTokenAddress}
 									on:change={(e) => handleTokenSelect(e.currentTarget.value)}
 								>
@@ -531,7 +529,7 @@
 							<!-- Amount Input -->
 							<div class="flex items-center gap-3">
 								{#if selectedTokenData}
-									<div class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5">
+									<div class="flex items-center gap-2 rounded-lg bg-surface-3 px-3 py-1.5">
 										{#if getTokenLogo(selectedTokenData.oldToken.address)}
 											<img
 												src={getTokenLogo(selectedTokenData.oldToken.address)}
@@ -539,11 +537,11 @@
 												class="h-6 w-6 rounded-full"
 											/>
 										{/if}
-										<span class="font-medium text-white">{selectedTokenData.oldToken.symbol}</span>
+										<span class="font-medium text-text">{selectedTokenData.oldToken.symbol}</span>
 									</div>
 								{:else}
-									<div class="rounded-lg bg-gray-700/50 px-3 py-1.5">
-										<span class="text-gray-400">Select token</span>
+									<div class="rounded-lg bg-surface-3 px-3 py-1.5">
+										<span class="text-text-2">Select token</span>
 									</div>
 								{/if}
 								<div class="flex-1 text-right">
@@ -555,7 +553,7 @@
 										on:input={handleAmountInput}
 										on:blur={capToLiquidity}
 										disabled={!selectedTokenData}
-										class="w-full bg-transparent text-right text-xl font-medium text-white placeholder-gray-600 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+										class="w-full bg-transparent text-right text-xl font-medium text-text placeholder-gray-600 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 									/>
 								</div>
 							</div>
@@ -563,7 +561,7 @@
 							<!-- Balance & Max -->
 							{#if selectedTokenData}
 								<div class="mt-2 flex items-center justify-between text-xs">
-									<span class="text-gray-500">
+									<span class="text-text-3">
 										Balance: {formatBalance(
 											selectedTokenData.balance,
 											selectedTokenData.oldToken.decimals
@@ -573,7 +571,7 @@
 									<button
 										type="button"
 										on:click={handleMaxClick}
-										class="rounded bg-gray-700/50 px-1.5 py-0.5 text-[10px] text-gray-400 transition hover:bg-gray-600 hover:text-white"
+										class="rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-text-2 transition hover:bg-gray-600 hover:text-text"
 									>
 										MAX
 									</button>
@@ -584,9 +582,9 @@
 
 					<!-- Arrow -->
 					<div class="flex justify-center">
-						<div class="rounded-full border border-white/10 bg-gray-800 p-2">
+						<div class="rounded-full border border-line bg-surface-2 p-2">
 							<svg
-								class="h-4 w-4 text-gray-400"
+								class="h-4 w-4 text-text-2"
 								fill="none"
 								stroke="currentColor"
 								viewBox="0 0 24 24"
@@ -603,11 +601,11 @@
 
 					<!-- What I Get (New Wrapped Token) -->
 					<div class="space-y-2">
-						<span class="text-sm font-medium text-gray-400">What I get</span>
-						<div class="rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3">
+						<span class="text-sm font-medium text-text-2">What I get</span>
+						<div class="rounded-xl border border-line bg-surface-2 px-4 py-3">
 							<div class="flex items-center gap-3">
 								{#if currentMapping}
-									<div class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5">
+									<div class="flex items-center gap-2 rounded-lg bg-surface-3 px-3 py-1.5">
 										{#if getTokenLogo(currentMapping.newToken.address)}
 											<img
 												src={getTokenLogo(currentMapping.newToken.address)}
@@ -615,15 +613,15 @@
 												class="h-6 w-6 rounded-full"
 											/>
 										{/if}
-										<span class="font-medium text-white">{currentMapping.newToken.symbol}</span>
+										<span class="font-medium text-text">{currentMapping.newToken.symbol}</span>
 									</div>
 								{:else}
-									<div class="rounded-lg bg-gray-700/50 px-3 py-1.5">
-										<span class="text-gray-400">—</span>
+									<div class="rounded-lg bg-surface-3 px-3 py-1.5">
+										<span class="text-text-2">—</span>
 									</div>
 								{/if}
 								<div class="flex-1 text-right">
-									<span class="text-xl font-medium text-white">
+									<span class="text-xl font-medium text-text">
 										{parsedSwapAmount > 0
 											? formatAmountDisplay(swapAmount, currentMapping?.newToken.decimals ?? 6)
 											: '0'}
@@ -632,7 +630,7 @@
 							</div>
 
 							{#if currentMapping}
-								<div class="mt-2 text-xs text-gray-500">
+								<div class="mt-2 text-xs text-text-3">
 									{currentMapping.newToken.name}
 								</div>
 							{/if}
@@ -642,7 +640,7 @@
 					<!-- Liquidity Warning -->
 					{#if liquidityWarning}
 						<div
-							class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2.5 text-xs text-blue-300"
+							class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2.5 text-xs text-blue-600 dark:text-blue-300"
 						>
 							<div class="flex items-start gap-2">
 								<svg
@@ -660,7 +658,7 @@
 								</svg>
 								<div>
 									<p class="font-medium">Not enough inventory to fully swap right now.</p>
-									<p class="mt-0.5 text-blue-300/80">
+									<p class="mt-0.5 text-blue-600/80 dark:text-blue-300/80">
 										Inventory will be periodically topped up. Please swap now and come back again
 										later.
 									</p>
@@ -670,20 +668,20 @@
 					{/if}
 
 					<!-- Swap Info -->
-					<div class="rounded-lg bg-gray-800/40 px-4 py-3 text-xs text-gray-400">
+					<div class="rounded-lg bg-surface-2 px-4 py-3 text-xs text-text-2">
 						<div class="flex justify-between">
 							<span>Rate</span>
-							<span class="text-white">1:1</span>
+							<span class="text-text">1:1</span>
 						</div>
 						{#if currentMapping}
 							<div class="mt-1 flex justify-between">
 								<span>Available liquidity</span>
 								{#if $swapLiquidityQuery.isLoading || $swapLiquidityQuery.isFetching}
-									<span class="animate-pulse text-gray-500">Checking...</span>
+									<span class="animate-pulse text-text-3">Checking...</span>
 								{:else if $swapLiquidityQuery.isError}
 									<span class="text-orange-400">Failed to check — retrying...</span>
 								{:else if availableLiquidity > 0}
-									<span class="text-white"
+									<span class="text-text"
 										>{formatNumberWithDecimals(
 											availableLiquidity,
 											currentMapping.oldToken.decimals
@@ -691,7 +689,7 @@
 										{currentMapping.oldToken.symbol}</span
 									>
 								{:else}
-									<span class="text-yellow-500">No liquidity available</span>
+									<span class="text-amber-300">No liquidity available</span>
 								{/if}
 							</div>
 						{/if}

--- a/src/lib/components/TradeAmountInput.svelte
+++ b/src/lib/components/TradeAmountInput.svelte
@@ -211,7 +211,7 @@
 		bind:isError
 	/>
 	{#if !compact}
-		<span class="text-left text-sm text-gray-400">
+		<span class="text-left text-sm text-text-2">
 			{#await balancePromise}
 				<span class="inline-flex items-center gap-2">
 					<LoadingSpinner variant="inline" size="sm" text="Loading balance..." />

--- a/src/lib/components/TransactionModal.svelte
+++ b/src/lib/components/TransactionModal.svelte
@@ -63,21 +63,21 @@
 	onClose={() => handleClose()}
 >
 	{#if $transactionStore.status !== TransactionStatus.IDLE}
-		<div class="flex flex-col items-center justify-center gap-2 p-4 text-white">
+		<div class="flex flex-col items-center justify-center gap-2 p-4 text-text">
 			{#if $transactionStore.status === TransactionStatus.ERROR}
 				{@const isUserRejection =
 					$transactionStore.error === TransactionErrorMessage.USER_REJECTED_APPROVAL}
 				{@const isTimeout = $transactionStore.error === TransactionErrorMessage.TIMEOUT}
 				<div
 					class="mb-6 flex h-20 w-20 items-center justify-center rounded-full border {isUserRejection
-						? 'border-yellow-500/30 bg-yellow-500/20'
+						? 'border-amber-500/30 bg-amber-500/20'
 						: 'border-red-500/30 bg-red-500/20'}"
 					data-testid="error-icon"
 				>
 					{#if isUserRejection}
 						<!-- Hand/stop icon for user rejection -->
 						<svg
-							class="h-10 w-10 text-yellow-500"
+							class="h-10 w-10 text-amber-400"
 							fill="none"
 							viewBox="0 0 24 24"
 							stroke="currentColor"
@@ -120,7 +120,7 @@
 						</svg>
 					{/if}
 				</div>
-				<p class="text-xl font-bold text-white" data-testid="error-status">
+				<p class="text-xl font-bold text-text" data-testid="error-status">
 					{#if isUserRejection}
 						Transaction Cancelled
 					{:else if isTimeout}
@@ -129,14 +129,14 @@
 						{$transactionStore.status}
 					{/if}
 				</p>
-				<p class="mt-2 text-center text-base text-gray-300" data-testid="error-message">
+				<p class="mt-2 text-center text-base text-text-2" data-testid="error-message">
 					{$transactionStore.error}
 				</p>
 				{#if $transactionStore.error === TransactionErrorMessage.GENERIC}
-					<p class="mt-2 text-center text-sm text-gray-400">
+					<p class="mt-2 text-center text-sm text-text-2">
 						If this issue persists, please contact support on our
 						<a
-							class="text-yellow-500 hover:text-yellow-400 hover:underline"
+							class="text-accent hover:text-accent-bright hover:underline"
 							href="https://t.me/st0xio"
 							target="_blank"
 							rel="noopener noreferrer">Telegram group</a
@@ -149,7 +149,7 @@
 						label="View transaction on block explorer"
 						head={30}
 						tail={0}
-						className="inline-flex items-center gap-1 text-sm text-yellow-500 hover:text-yellow-400 hover:underline transition-colors justify-center"
+						className="inline-flex items-center gap-1 text-sm text-accent hover:text-accent-bright hover:underline transition-colors justify-center"
 						dataTestId="view-transaction-link"
 					/>
 				{/if}
@@ -176,11 +176,11 @@
 					</svg>
 				</div>
 				<div class="flex flex-col gap-4 text-center">
-					<p class="text-xl font-bold text-white" data-testid="success-status">
+					<p class="text-xl font-bold text-text" data-testid="success-status">
 						{$transactionStore.status}
 					</p>
 					{#if $transactionStore.message}
-						<p class="text-base text-gray-300" data-testid="success-message">
+						<p class="text-base text-text-2" data-testid="success-message">
 							{$transactionStore.message}
 						</p>
 					{/if}
@@ -189,7 +189,7 @@
 							href={raindexLink.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="inline-flex items-center justify-center gap-1 text-sm text-yellow-500 transition-colors hover:text-yellow-400 hover:underline"
+							class="inline-flex items-center justify-center gap-1 text-sm text-accent transition-colors hover:text-accent-bright hover:underline"
 							data-testid="raindex-link"
 						>
 							{raindexLink.text}
@@ -207,9 +207,9 @@
 					<!-- Market order summary or no-fill message -->
 					{#if marketOrderDisplay?.isNoFill}
 						<div
-							class="w-full rounded-md border border-yellow-900/50 bg-yellow-900/20 p-4 text-left text-sm text-yellow-200"
+							class="w-full rounded-md border border-amber-900/50 bg-amber-900/20 p-4 text-left text-sm text-amber-200"
 						>
-							<div class="mb-3 text-xs uppercase tracking-wide text-yellow-600">
+							<div class="mb-3 text-xs uppercase tracking-wide text-amber-600">
 								No Tokens Available
 							</div>
 							<p class="mb-3">
@@ -220,17 +220,17 @@
 						</div>
 					{:else if marketOrderDisplay}
 						<div
-							class="w-full rounded-md border border-white/10 bg-gray-900/50 p-4 text-left text-sm text-gray-200"
+							class="w-full rounded-md border border-line bg-surface-1 p-4 text-left text-sm text-text-2"
 						>
-							<div class="mb-3 text-xs uppercase tracking-wide text-gray-500">
+							<div class="mb-3 text-xs uppercase tracking-wide text-text-3">
 								Market Order Summary
 							</div>
 							<div class="flex justify-between">
-								<span class="text-gray-400">Side</span>
+								<span class="text-text-2">Side</span>
 								<span class="font-medium">{marketOrderDisplay.direction}</span>
 							</div>
 							<div class="mt-2 flex justify-between">
-								<span class="text-gray-400">Quantity Filled</span>
+								<span class="text-text-2">Quantity Filled</span>
 								<span class="font-medium">
 									{formatQuantity(marketOrderDisplay.assetAmount, marketOrderDisplay.assetDecimals)}
 									{!isFullFill(marketOrderDisplay.assetAmount, marketOrderDisplay.requestedAmount)
@@ -243,14 +243,14 @@
 								</span>
 							</div>
 							<div class="mt-2 flex justify-between">
-								<span class="text-gray-400">Average Price</span>
+								<span class="text-text-2">Average Price</span>
 								<span class="font-medium">
 									{marketOrderDisplay.price.toFixed(6)}
 									{marketOrderDisplay.paymentSymbol}
 								</span>
 							</div>
 							{#if marketOrderDisplay.isPartialFill}
-								<div class="mt-3 rounded-md bg-yellow-900/30 p-2 text-xs text-yellow-200">
+								<div class="mt-3 rounded-md bg-amber-900/30 p-2 text-xs text-amber-200">
 									Partial fill: not all requested quantity was available within slippage tolerance.
 									We currently have a guardrail to avoid unfavourable prices. To ignore guardrails,
 									use a limit order.
@@ -267,7 +267,7 @@
 										symbol: marketOrderDisplay.assetSymbol,
 										decimals: marketOrderDisplay.assetDecimals
 									})}
-								class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300"
+								class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm font-medium text-text-2 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-700 dark:hover:text-blue-300"
 							>
 								<svg
 									class="h-4 w-4"
@@ -290,7 +290,7 @@
 								label="View transaction"
 								head={20}
 								tail={0}
-								className="inline-flex items-center gap-1 text-sm text-yellow-500 hover:text-yellow-400 hover:underline transition-colors justify-center"
+								className="inline-flex items-center gap-1 text-sm text-accent hover:text-accent-bright hover:underline transition-colors justify-center"
 								dataTestId="view-transaction-link"
 							/>
 						</div>
@@ -306,7 +306,7 @@
 									symbol: assetTokenInfo.symbol,
 									decimals: assetTokenInfo.decimals
 								})}
-							class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300"
+							class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm font-medium text-text-2 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300"
 						>
 							<svg
 								class="h-4 w-4"
@@ -328,11 +328,11 @@
 			{:else if $transactionStore.status === TransactionStatus.PENDING_MULTI_TX_ACKNOWLEDGMENT}
 				<!-- Multi-transaction acknowledgment state -->
 				<div
-					class="mb-6 flex h-20 w-20 items-center justify-center rounded-full border border-yellow-500/30 bg-yellow-500/20"
+					class="mb-6 flex h-20 w-20 items-center justify-center rounded-full border border-amber-500/30 bg-amber-500/20"
 					data-testid="multi-tx-icon"
 				>
 					<svg
-						class="h-10 w-10 text-yellow-500"
+						class="h-10 w-10 text-amber-400"
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
@@ -345,10 +345,10 @@
 						/>
 					</svg>
 				</div>
-				<p class="text-xl font-bold text-white" data-testid="multi-tx-title">
+				<p class="text-xl font-bold text-text" data-testid="multi-tx-title">
 					Multiple Transactions Required
 				</p>
-				<p class="mt-4 text-center text-base text-gray-300" data-testid="multi-tx-message">
+				<p class="mt-4 text-center text-base text-text-2" data-testid="multi-tx-message">
 					{$transactionStore.message}
 				</p>
 				<Button
@@ -360,16 +360,16 @@
 				</Button>
 			{:else if $transactionStore.status === TransactionStatus.CHECKING_ALLOWANCE || $transactionStore.status === TransactionStatus.PENDING_WALLET || $transactionStore.status === TransactionStatus.PENDING_APPROVAL}
 				<div
-					class="mb-6 flex h-20 w-20 items-center justify-center rounded-full border border-gray-600/30 bg-gray-700/30"
+					class="mb-6 flex h-20 w-20 items-center justify-center rounded-full border border-line bg-surface-3"
 					data-testid="spinner"
 				>
 					<LoadingSpinner variant="button" size="lg" text="" showText={false} />
 				</div>
-				<p class="text-lg font-medium text-gray-200" data-testid="pending-message">
+				<p class="text-lg font-medium text-text-2" data-testid="pending-message">
 					{$transactionStore.message || $transactionStore.status}
 				</p>
 				{#if multiTxProgress && multiTxProgress.totalBatches > 1}
-					<p class="mt-2 text-sm text-gray-400" data-testid="multi-tx-progress">
+					<p class="mt-2 text-sm text-text-2" data-testid="multi-tx-progress">
 						Transaction {multiTxProgress.currentBatch} of {multiTxProgress.totalBatches}
 					</p>
 				{/if}

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -277,7 +277,7 @@
 			<!-- Highlight border around each target (visual only) -->
 			{#each targetRects as rect}
 				<div
-					class="absolute rounded-lg border-2 border-yellow-500 shadow-[0_0_20px_rgba(234,179,8,0.3)]"
+					class="absolute rounded-lg border-2 border-accent shadow-[0_0_20px_rgba(234,179,8,0.3)]"
 					style="
 						left: {rect.left - 8}px;
 						top: {rect.top - 8}px;
@@ -289,45 +289,45 @@
 
 			<!-- Tooltip - needs pointer-events-auto to be clickable -->
 			<div
-				class="pointer-events-auto absolute z-[9001] w-80 rounded-xl border border-white/10 bg-gray-800 p-4 shadow-2xl"
+				class="pointer-events-auto absolute z-[9001] w-80 rounded-xl border border-line bg-surface-2 p-4 shadow-2xl"
 				style="left: {tooltipPosition.left}px; top: {tooltipPosition.top}px;"
 				transition:fly={{ y: 10, duration: 200 }}
 			>
 				<!-- Arrow -->
 				{#if tooltipPosition.arrowPosition === 'top'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-r border-t border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-r border-t border-line bg-surface-2"
 						style="top: -6px; left: 50%; transform: translateX(-50%);"
 					/>
 				{:else if tooltipPosition.arrowPosition === 'bottom'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-b border-l border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-b border-l border-line bg-surface-2"
 						style="bottom: -6px; left: 50%; transform: translateX(-50%);"
 					/>
 				{:else if tooltipPosition.arrowPosition === 'left'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-b border-r border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-b border-r border-line bg-surface-2"
 						style="left: -6px; top: 50%; transform: translateY(-50%);"
 					/>
 				{:else}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-l border-t border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-l border-t border-line bg-surface-2"
 						style="right: -6px; top: 50%; transform: translateY(-50%);"
 					/>
 				{/if}
 
-				<h3 class="mb-2 text-lg font-semibold text-white">{content.title}</h3>
-				<p class="mb-4 text-sm text-gray-300">{content.description}</p>
+				<h3 class="mb-2 text-lg font-semibold text-text">{content.title}</h3>
+				<p class="mb-4 text-sm text-text-2">{content.description}</p>
 
 				<div class="flex items-center justify-between">
 					<button
 						on:click={handleSkip}
-						class="text-sm text-gray-400 transition-colors hover:text-white"
+						class="text-sm text-text-2 transition-colors hover:text-text"
 					>
 						Skip tutorial
 					</button>
 					<div class="flex items-center gap-3">
-						<span class="text-xs text-gray-500">
+						<span class="text-xs text-text-3">
 							{$currentStepInfo.index + 1} / {$currentStepInfo.total}
 						</span>
 						<Button on:click={handleNext} variant="primary" size="sm">
@@ -347,19 +347,14 @@
 
 			<!-- Centered modal -->
 			<div
-				class="pointer-events-auto absolute left-1/2 top-1/2 z-[9001] w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-gray-800 p-6 shadow-2xl"
+				class="pointer-events-auto absolute left-1/2 top-1/2 z-[9001] w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-line bg-surface-2 p-6 shadow-2xl"
 				transition:fly={{ y: 20, duration: 300 }}
 			>
 				<div class="mb-6 text-center">
 					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-yellow-500/20"
+						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-accent-soft"
 					>
-						<svg
-							class="h-8 w-8 text-yellow-500"
-							fill="none"
-							stroke="currentColor"
-							viewBox="0 0 24 24"
-						>
+						<svg class="h-8 w-8 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -368,8 +363,8 @@
 							/>
 						</svg>
 					</div>
-					<h2 class="mb-2 text-2xl font-bold text-white">{content.title}</h2>
-					<p class="text-gray-300">{content.description}</p>
+					<h2 class="mb-2 text-2xl font-bold text-text">{content.title}</h2>
+					<p class="text-text-2">{content.description}</p>
 				</div>
 
 				<div class="flex flex-col gap-3">
@@ -378,14 +373,14 @@
 					</Button>
 					<button
 						on:click={handleSkip}
-						class="text-sm text-gray-400 transition-colors hover:text-white"
+						class="text-sm text-text-2 transition-colors hover:text-text"
 					>
 						Skip tutorial
 					</button>
 				</div>
 
 				{#if $currentStepInfo.index > 0}
-					<div class="mt-4 text-center text-xs text-gray-500">
+					<div class="mt-4 text-center text-xs text-text-3">
 						Step {$currentStepInfo.index + 1} of {$currentStepInfo.total}
 					</div>
 				{/if}

--- a/src/lib/components/VaultIdInput.svelte
+++ b/src/lib/components/VaultIdInput.svelte
@@ -25,7 +25,7 @@
 
 <div class="vault-id-input text-left">
 	<input
-		class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-4 py-3 text-white transition-colors [appearance:textfield] focus:border-yellow-500/50 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+		class="w-full rounded-lg border border-line bg-surface-3 px-4 py-3 text-text transition-colors [appearance:textfield] focus:border-accent-line focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
 		type="text"
 		bind:value={vaultId}
 		{placeholder}

--- a/src/lib/components/VaultTutorial.svelte
+++ b/src/lib/components/VaultTutorial.svelte
@@ -253,7 +253,7 @@
 
 			<!-- Highlight border around target -->
 			<div
-				class="pointer-events-none absolute rounded-lg border-2 border-yellow-500 shadow-[0_0_20px_rgba(234,179,8,0.3)]"
+				class="pointer-events-none absolute rounded-lg border-2 border-accent shadow-[0_0_20px_rgba(234,179,8,0.3)]"
 				style="
 					left: {targetRect.left - 8}px;
 					top: {targetRect.top - 8}px;
@@ -264,45 +264,45 @@
 
 			<!-- Tooltip -->
 			<div
-				class="absolute z-[9001] w-80 rounded-xl border border-white/10 bg-gray-800 p-4 shadow-2xl"
+				class="absolute z-[9001] w-80 rounded-xl border border-line bg-surface-2 p-4 shadow-2xl"
 				style="left: {tooltipPosition.left}px; top: {tooltipPosition.top}px;"
 				transition:fly={{ y: 10, duration: 200 }}
 			>
 				<!-- Arrow -->
 				{#if tooltipPosition.arrowPosition === 'top'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-r border-t border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-r border-t border-line bg-surface-2"
 						style="top: -6px; left: 50%; transform: translateX(-50%);"
 					/>
 				{:else if tooltipPosition.arrowPosition === 'bottom'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-b border-l border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-b border-l border-line bg-surface-2"
 						style="bottom: -6px; left: 50%; transform: translateX(-50%);"
 					/>
 				{:else if tooltipPosition.arrowPosition === 'left'}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-b border-r border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-b border-r border-line bg-surface-2"
 						style="left: -6px; top: 50%; transform: translateY(-50%);"
 					/>
 				{:else}
 					<div
-						class="absolute h-3 w-3 rotate-45 border-l border-t border-white/10 bg-gray-800"
+						class="absolute h-3 w-3 rotate-45 border-l border-t border-line bg-surface-2"
 						style="right: -6px; top: 50%; transform: translateY(-50%);"
 					/>
 				{/if}
 
-				<h3 class="mb-2 text-lg font-semibold text-white">{content.title}</h3>
-				<p class="mb-4 text-sm text-gray-300">{content.description}</p>
+				<h3 class="mb-2 text-lg font-semibold text-text">{content.title}</h3>
+				<p class="mb-4 text-sm text-text-2">{content.description}</p>
 
 				<div class="flex items-center justify-between">
 					<button
 						on:click={handleSkip}
-						class="text-sm text-gray-400 transition-colors hover:text-white"
+						class="text-sm text-text-2 transition-colors hover:text-text"
 					>
 						Skip
 					</button>
 					<div class="flex items-center gap-3">
-						<span class="text-xs text-gray-500">
+						<span class="text-xs text-text-3">
 							{$currentVaultStepInfo.index + 1} / {$currentVaultStepInfo.total}
 						</span>
 						<Button on:click={handleNext} variant="primary" size="sm">
@@ -322,7 +322,7 @@
 
 			<!-- Centered modal -->
 			<div
-				class="absolute left-1/2 top-1/2 z-[9001] w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-gray-800 p-6 shadow-2xl"
+				class="absolute left-1/2 top-1/2 z-[9001] w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-line bg-surface-2 p-6 shadow-2xl"
 				transition:fly={{ y: 20, duration: 300 }}
 			>
 				<div class="mb-6 text-center">
@@ -330,7 +330,7 @@
 						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-blue-500/20"
 					>
 						<svg
-							class="h-8 w-8 text-blue-500"
+							class="h-8 w-8 text-blue-600 dark:text-blue-500"
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -343,8 +343,8 @@
 							/>
 						</svg>
 					</div>
-					<h2 class="mb-2 text-2xl font-bold text-white">{content.title}</h2>
-					<p class="text-gray-300">{content.description}</p>
+					<h2 class="mb-2 text-2xl font-bold text-text">{content.title}</h2>
+					<p class="text-text-2">{content.description}</p>
 				</div>
 
 				<div class="flex flex-col gap-3">
@@ -353,13 +353,13 @@
 					</Button>
 					<button
 						on:click={handleSkip}
-						class="text-sm text-gray-400 transition-colors hover:text-white"
+						class="text-sm text-text-2 transition-colors hover:text-text"
 					>
 						Skip tutorial
 					</button>
 				</div>
 
-				<div class="mt-4 text-center text-xs text-gray-500">
+				<div class="mt-4 text-center text-xs text-text-3">
 					Step {$currentVaultStepInfo.index + 1} of {$currentVaultStepInfo.total}
 				</div>
 			</div>

--- a/src/lib/components/WalletConnect.svelte
+++ b/src/lib/components/WalletConnect.svelte
@@ -28,7 +28,7 @@
 		</div>
 	{:else}
 		<div class="flex items-center gap-1.5" data-testid="connected">
-			<svg class="h-4 w-4 text-yellow-500" viewBox="0 0 20 20" fill="currentColor">
+			<svg class="h-4 w-4 text-accent" viewBox="0 0 20 20" fill="currentColor">
 				<path
 					fill-rule="evenodd"
 					d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.172 7.707 8.879a1 1 0 10-1.414 1.414L9 13l4.707-4.707z"

--- a/src/lib/components/WalletConnectionModal.svelte
+++ b/src/lib/components/WalletConnectionModal.svelte
@@ -23,7 +23,12 @@
 	<div class="space-y-6">
 		<div class="flex flex-col items-center gap-4 py-4">
 			<div class="rounded-full bg-gradient-to-br from-blue-600/20 to-purple-700/20 p-6">
-				<svg class="h-12 w-12 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<svg
+					class="h-12 w-12 text-blue-600 dark:text-blue-400"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+				>
 					<path
 						stroke-linecap="round"
 						stroke-linejoin="round"
@@ -34,7 +39,7 @@
 			</div>
 
 			<div class="text-center">
-				<p class="text-gray-300">
+				<p class="text-text-2">
 					Connect your wallet to place orders and access all platform features.
 				</p>
 			</div>

--- a/src/lib/components/WrapUnwrapModal.svelte
+++ b/src/lib/components/WrapUnwrapModal.svelte
@@ -272,14 +272,14 @@
 		aria-modal="true"
 		aria-labelledby="wrap-unwrap-modal-title"
 	>
-		<div class="relative overflow-hidden rounded-2xl border border-white/10 bg-gray-900 shadow-2xl">
+		<div class="relative overflow-hidden rounded-2xl border border-line bg-surface-1 shadow-2xl">
 			<!-- Header -->
-			<div class="flex items-center justify-between border-b border-white/10 px-6 py-4">
-				<h3 id="wrap-unwrap-modal-title" class="text-lg font-semibold text-white">{modalTitle}</h3>
+			<div class="flex items-center justify-between border-b border-line px-6 py-4">
+				<h3 id="wrap-unwrap-modal-title" class="text-lg font-semibold text-text">{modalTitle}</h3>
 				<button
 					type="button"
 					on:click={handleClose}
-					class="rounded-full p-1 text-gray-400 transition hover:bg-white/10 hover:text-white"
+					class="rounded-full p-1 text-text-2 transition hover:bg-surface-3 hover:text-text"
 					aria-label="Close"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -298,15 +298,13 @@
 				<div class="space-y-4">
 					<!-- From Section -->
 					<div class="space-y-2">
-						<label for="wrap-from-token" class="text-sm font-medium text-gray-400"
-							>{fromLabel}</label
-						>
-						<div class="rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3">
+						<label for="wrap-from-token" class="text-sm font-medium text-text-2">{fromLabel}</label>
+						<div class="rounded-xl border border-line bg-surface-2 px-4 py-3">
 							<!-- Token Dropdown -->
 							<div class="mb-3">
 								<select
 									id="wrap-from-token"
-									class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-3 py-2 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+									class="w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-text focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 									bind:value={selectedTokenAddress}
 									on:change={(e) => handleTokenSelect(e.currentTarget.value)}
 								>
@@ -330,7 +328,7 @@
 							<!-- Amount Input -->
 							<div class="flex items-center gap-3">
 								{#if selectedTokenData}
-									<div class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5">
+									<div class="flex items-center gap-2 rounded-lg bg-surface-3 px-3 py-1.5">
 										{#if getTokenLogo(selectedTokenData.address)}
 											<img
 												src={getTokenLogo(selectedTokenData.address)}
@@ -338,11 +336,11 @@
 												class="h-6 w-6 rounded-full"
 											/>
 										{/if}
-										<span class="font-medium text-white">{selectedTokenData.symbol}</span>
+										<span class="font-medium text-text">{selectedTokenData.symbol}</span>
 									</div>
 								{:else}
-									<div class="rounded-lg bg-gray-700/50 px-3 py-1.5">
-										<span class="text-gray-400">Select token</span>
+									<div class="rounded-lg bg-surface-3 px-3 py-1.5">
+										<span class="text-text-2">Select token</span>
 									</div>
 								{/if}
 								<div class="flex-1 text-right">
@@ -353,7 +351,7 @@
 										value={amount}
 										on:input={handleAmountInput}
 										disabled={!selectedTokenData}
-										class="w-full bg-transparent text-right text-xl font-medium text-white placeholder-gray-600 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+										class="w-full bg-transparent text-right text-xl font-medium text-text placeholder-gray-600 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 									/>
 								</div>
 							</div>
@@ -361,14 +359,14 @@
 							<!-- Balance & Max -->
 							{#if selectedTokenData}
 								<div class="mt-2 flex items-center justify-between text-xs">
-									<span class="text-gray-500">
+									<span class="text-text-3">
 										Balance: {selectedTokenData.balanceFormatted.toFixed(4)}
 										{selectedTokenData.symbol}
 									</span>
 									<button
 										type="button"
 										on:click={handleMaxClick}
-										class="rounded bg-gray-700/50 px-1.5 py-0.5 text-[10px] text-gray-400 transition hover:bg-gray-600 hover:text-white"
+										class="rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-text-2 transition hover:bg-gray-600 hover:text-text"
 									>
 										MAX
 									</button>
@@ -379,9 +377,9 @@
 
 					<!-- Arrow -->
 					<div class="flex justify-center">
-						<div class="rounded-full border border-white/10 bg-gray-800 p-2">
+						<div class="rounded-full border border-line bg-surface-2 p-2">
 							<svg
-								class="h-4 w-4 text-gray-400"
+								class="h-4 w-4 text-text-2"
 								fill="none"
 								stroke="currentColor"
 								viewBox="0 0 24 24"
@@ -398,14 +396,14 @@
 
 					<!-- To Section -->
 					<div class="space-y-2">
-						<span class="text-sm font-medium text-gray-400">{toLabel}</span>
-						<div class="rounded-xl border border-white/5 bg-gray-800/60 px-4 py-3">
+						<span class="text-sm font-medium text-text-2">{toLabel}</span>
+						<div class="rounded-xl border border-line bg-surface-2 px-4 py-3">
 							<div class="flex items-center gap-3">
 								{#if currentMapping}
 									{@const targetToken = isWrapMode
 										? currentMapping.wrappedToken
 										: currentMapping.unwrappedToken}
-									<div class="flex items-center gap-2 rounded-lg bg-gray-700/50 px-3 py-1.5">
+									<div class="flex items-center gap-2 rounded-lg bg-surface-3 px-3 py-1.5">
 										{#if getTokenLogo(targetToken.address)}
 											<img
 												src={getTokenLogo(targetToken.address)}
@@ -413,15 +411,15 @@
 												class="h-6 w-6 rounded-full"
 											/>
 										{/if}
-										<span class="font-medium text-white">{targetToken.symbol}</span>
+										<span class="font-medium text-text">{targetToken.symbol}</span>
 									</div>
 								{:else}
-									<div class="rounded-lg bg-gray-700/50 px-3 py-1.5">
-										<span class="text-gray-400">-</span>
+									<div class="rounded-lg bg-surface-3 px-3 py-1.5">
+										<span class="text-text-2">-</span>
 									</div>
 								{/if}
 								<div class="flex-1 text-right">
-									<span class="text-xl font-medium text-white">
+									<span class="text-xl font-medium text-text">
 										{previewAmount
 											? parseFloat(previewAmount).toFixed(6)
 											: parsedAmount > 0
@@ -435,7 +433,7 @@
 								{@const targetToken = isWrapMode
 									? currentMapping.wrappedToken
 									: currentMapping.unwrappedToken}
-								<div class="mt-2 text-xs text-gray-500">
+								<div class="mt-2 text-xs text-text-3">
 									{targetToken.name}
 								</div>
 							{/if}
@@ -443,12 +441,12 @@
 					</div>
 
 					<!-- Info -->
-					<div class="rounded-lg bg-gray-800/40 px-4 py-3 text-xs text-gray-400">
+					<div class="rounded-lg bg-surface-2 px-4 py-3 text-xs text-text-2">
 						<div class="flex justify-between">
 							<span>Exchange Rate</span>
-							<span class="text-white">1:1</span>
+							<span class="text-text">1:1</span>
 						</div>
-						<div class="mt-1 text-gray-500">
+						<div class="mt-1 text-text-3">
 							{isWrapMode
 								? 'Wrap your underlying tokens into the ERC4626 vault for trading.'
 								: 'Unwrap your vault shares back to the underlying tokens.'}

--- a/src/lib/components/announcements/TokenSwapAnnouncementModal.svelte
+++ b/src/lib/components/announcements/TokenSwapAnnouncementModal.svelte
@@ -47,7 +47,7 @@
 	<div class="fixed inset-0 z-[201] flex items-center justify-center p-4">
 		<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 		<div
-			class="relative w-full max-w-md overflow-hidden rounded-xl border border-green-500/30 bg-gray-900 shadow-2xl"
+			class="relative w-full max-w-md overflow-hidden rounded-xl border border-green-500/30 bg-surface-1 shadow-2xl"
 			on:click|stopPropagation
 			on:keydown|stopPropagation
 			role="dialog"
@@ -60,7 +60,7 @@
 			<!-- Close button -->
 			<button
 				on:click={handleClose}
-				class="absolute right-3 top-4 rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-800 hover:text-white"
+				class="absolute right-3 top-4 rounded-lg p-2 text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 				aria-label="Close modal"
 			>
 				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -88,11 +88,11 @@
 					</svg>
 				</div>
 
-				<h2 id="modal-title" class="mb-2 text-xl font-semibold text-white">
+				<h2 id="modal-title" class="mb-2 text-xl font-semibold text-text">
 					Token Migration Complete
 				</h2>
 
-				<p class="mb-6 text-sm text-gray-400">
+				<p class="mb-6 text-sm text-text-2">
 					The token migration has been completed. If you haven't already, remember to swap your old
 					tokens to the new wrapped versions on the site.
 				</p>
@@ -100,7 +100,7 @@
 				<div class="flex gap-3">
 					<button
 						type="button"
-						class="flex-1 rounded-lg border border-gray-600 px-4 py-2.5 font-medium text-gray-300 transition-colors hover:bg-gray-800"
+						class="flex-1 rounded-lg border border-line px-4 py-2.5 font-medium text-text-2 transition-colors hover:bg-surface-2"
 						on:click={handleClose}
 					>
 						Dismiss

--- a/src/lib/components/charts/TokenMarketCharts.svelte
+++ b/src/lib/components/charts/TokenMarketCharts.svelte
@@ -730,27 +730,25 @@
 		<!-- Row 1: Trade History (2/3) -->
 		<div
 			data-testid="trade-history-chart"
-			class="flex min-h-96 flex-col lg:col-span-2 xl:col-span-2 xl:row-span-2"
+			class="flex min-h-96 flex-col rounded-2xl border border-line bg-overlay-1 p-5 backdrop-blur lg:col-span-2 xl:col-span-2 xl:row-span-2"
 		>
 			<div class="pb-3">
 				<div
 					class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
 				>
 					<div>
-						<h3 class="text-sm font-semibold uppercase tracking-wide text-gray-400">
-							Trade History
-						</h3>
-						<p class="mt-1 text-xs text-gray-500">On-chain trade executions over time</p>
+						<h3 class="text-[15px] font-semibold text-text">Trade History</h3>
+						<p class="mt-1 text-xs text-text-3">On-chain trade executions over time</p>
 					</div>
 					{#if historyRangeOptions.length > 0}
-						<div class="flex items-center gap-2 self-start">
+						<div class="flex items-center gap-1 self-start rounded-lg bg-overlay-2 p-0.5">
 							{#each historyRangeOptions as option}
 								<button
 									type="button"
-									class={`rounded-md border px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${
+									class={`rounded-md px-2 py-1 text-[11px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-1 ${
 										historyRange === option.key
-											? 'border-blue-400/60 bg-blue-500/20 text-blue-200'
-											: 'border-white/10 text-gray-400 hover:border-white/25 hover:text-white'
+											? 'bg-blue-500/80 text-white'
+											: 'text-text-2 hover:text-text'
 									}`}
 									aria-pressed={historyRange === option.key}
 									on:click={() => {
@@ -771,7 +769,7 @@
 			<div class="relative flex-1 pt-4">
 				{#if !browser}
 					<div
-						class="absolute inset-4 flex items-center justify-center rounded-lg border border-dashed border-white/10 p-4 text-center text-sm text-gray-400"
+						class="absolute inset-4 flex items-center justify-center rounded-lg border border-dashed border-line p-4 text-center text-sm text-text-2"
 					>
 						Charts are available in a browser environment.
 					</div>
@@ -779,12 +777,12 @@
 					<div class="relative h-96 lg:h-80">
 						<canvas bind:this={historyCanvas} class="absolute inset-0 h-full w-full"></canvas>
 						{#if !chartsReady}
-							<div class="absolute inset-0 flex items-center justify-center bg-gray-900">
+							<div class="absolute inset-0 flex items-center justify-center bg-surface-1">
 								<LoadingSpinner variant="inline" size="md" text="Loading chart data..." />
 							</div>
 						{:else if chartsReady && historyEmpty}
 							<div
-								class="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-gray-400"
+								class="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-text-2"
 							>
 								No on-chain trades recorded for this token during the selected period.
 							</div>
@@ -797,16 +795,16 @@
 		<!-- Orderbook Depth (spans remaining column) -->
 		<div
 			data-testid="orderbook-depth-chart"
-			class="flex min-h-96 flex-col lg:row-span-1 xl:row-span-2"
+			class="flex min-h-96 flex-col rounded-2xl border border-line bg-overlay-1 p-5 backdrop-blur lg:row-span-1 xl:row-span-2"
 		>
 			<div class="pb-3">
-				<h3 class="text-sm font-semibold uppercase tracking-wide text-gray-400">Orderbook Depth</h3>
-				<p class="mt-1 text-xs text-gray-500">Current on-chain liquidity</p>
+				<h3 class="text-[15px] font-semibold text-text">Orderbook Depth</h3>
+				<p class="mt-1 text-xs text-text-3">Current on-chain liquidity</p>
 			</div>
 			<div class="relative min-h-80 flex-1 pt-4">
 				{#if !browser}
 					<div
-						class="absolute inset-4 flex items-center justify-center rounded-lg border border-dashed border-white/10 p-4 text-center text-sm text-gray-400"
+						class="absolute inset-4 flex items-center justify-center rounded-lg border border-dashed border-line p-4 text-center text-sm text-text-2"
 					>
 						Charts are available in a browser environment.
 					</div>
@@ -818,12 +816,12 @@
 							on:mouseenter={handleDepthChartInspected}
 						></canvas>
 						{#if !chartsReady}
-							<div class="absolute inset-0 flex items-center justify-center bg-gray-900">
+							<div class="absolute inset-0 flex items-center justify-center bg-surface-1">
 								<LoadingSpinner variant="inline" size="md" text="Loading orderbook data..." />
 							</div>
 						{:else if chartsReady && depthEmpty}
 							<div
-								class="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-gray-400"
+								class="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-text-2"
 							>
 								No active on-chain quotes available for this token.
 							</div>

--- a/src/lib/components/charts/TradingViewWidget.svelte
+++ b/src/lib/components/charts/TradingViewWidget.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import TradingViewEmbed from './TradingViewEmbed.svelte';
+	import { theme as appTheme } from '$lib/stores/themeStore';
 
 	export let widgetType:
 		| 'symbol-profile'
@@ -10,10 +11,18 @@
 		| 'symbol-info';
 	export let symbol: string | undefined;
 	export let locale = 'en';
-	export let colorTheme: 'light' | 'dark' = 'dark';
+	// Follows the app theme by default so widgets aren't stuck light in dark mode.
+	// An explicit prop still wins; otherwise it tracks themeStore and re-renders on toggle.
+	export let colorTheme: 'light' | 'dark' | undefined = undefined;
+	$: effectiveColorTheme = colorTheme ?? $appTheme;
 	export let width = '100%';
 	export let height: string | number = '480';
 	export let isTransparent = false;
+	// TradingView quirk (verified empirically): isTransparent:true forces a LIGHT skin
+	// even when colorTheme is 'dark', which left every widget white in dark mode. So only
+	// keep transparency in light mode — where it renders correctly — and force an opaque
+	// (dark) background in dark mode.
+	$: effectiveTransparent = isTransparent && effectiveColorTheme === 'light';
 	export let containerClass = '';
 
 	// Widget-specific props
@@ -54,8 +63,8 @@
 			width,
 			height: normaliseHeight(height),
 			locale,
-			colorTheme,
-			isTransparent
+			colorTheme: effectiveColorTheme,
+			isTransparent: effectiveTransparent
 		};
 
 		switch (widgetType) {
@@ -113,7 +122,7 @@
 {:else}
 	<slot name="fallback">
 		{#if widgetType === 'financials'}
-			<div class="px-4 py-6 text-sm text-gray-400">
+			<div class="px-4 py-6 text-sm text-text-2">
 				TradingView fundamentals are unavailable for this token.
 			</div>
 		{/if}

--- a/src/lib/components/orders/ActiveLiquidity.svelte
+++ b/src/lib/components/orders/ActiveLiquidity.svelte
@@ -149,11 +149,11 @@
 	<div class="space-y-6 lg:col-span-2">
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
 			<div>
-				<span class="mb-2 block text-sm font-medium text-gray-300">Token 1</span>
+				<span class="mb-2 block text-sm font-medium text-text-2">Token 1</span>
 				<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken1} />
 			</div>
 			<div>
-				<span class="mb-2 block text-sm font-medium text-gray-300">Token 2</span>
+				<span class="mb-2 block text-sm font-medium text-text-2">Token 2</span>
 				<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken2} />
 			</div>
 		</div>
@@ -163,7 +163,7 @@
 				<label class="flex items-center gap-2">
 					<input
 						type="checkbox"
-						class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
+						class="h-4 w-4 rounded border-line bg-surface-3 text-accent"
 						bind:checked={isToken1FastExit}
 					/>
 					<span class="text-sm">{selectedToken1.symbol || 'Token 1'} Fast Exit</span>
@@ -171,7 +171,7 @@
 				<label class="flex items-center gap-2">
 					<input
 						type="checkbox"
-						class="h-4 w-4 rounded border-white/10 bg-gray-700 text-blue-500"
+						class="h-4 w-4 rounded border-line bg-surface-3 text-accent"
 						bind:checked={isToken2FastExit}
 					/>
 					<span class="text-sm">{selectedToken2.symbol || 'Token 2'} Fast Exit</span>
@@ -179,7 +179,7 @@
 			</div>
 
 			<div>
-				<span class="mb-2 block text-sm font-medium text-gray-300">
+				<span class="mb-2 block text-sm font-medium text-text-2">
 					Initial Ratio {selectedToken1 && selectedToken2
 						? `${selectedToken1.symbol}/${selectedToken2.symbol}`
 						: ''}
@@ -199,7 +199,7 @@
 				<div>
 					<div class="space-y-2">
 						<div class="relative">
-							<span class="text-sm font-medium text-gray-300"
+							<span class="text-sm font-medium text-text-2"
 								>{selectedToken1.symbol} Deposit Amount</span
 							>
 							<TradeAmountInput
@@ -210,7 +210,7 @@
 							/>
 						</div>
 						<div class="relative">
-							<span class="text-sm font-medium text-gray-300"
+							<span class="text-sm font-medium text-text-2"
 								>{selectedToken2.symbol} Deposit Amount</span
 							>
 							<TradeAmountInput
@@ -225,7 +225,7 @@
 				<div>
 					<div class="space-y-2">
 						<div class="relative">
-							<span class="text-sm font-medium text-gray-300">Minimum Trade Amount</span>
+							<span class="text-sm font-medium text-text-2">Minimum Trade Amount</span>
 							<TradeAmountInput
 								amountToken={selectedToken1}
 								bind:amount={minTradeAmount}
@@ -234,7 +234,7 @@
 							/>
 						</div>
 						<div class="relative">
-							<span class="text-sm font-medium text-gray-300">Maximum Trade Amount</span>
+							<span class="text-sm font-medium text-text-2">Maximum Trade Amount</span>
 							<TradeAmountInput
 								amountToken={selectedToken1}
 								bind:amount={maxTradeAmount}
@@ -250,11 +250,11 @@
 				<button
 					on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
 					class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
-						? 'bg-blue-500'
-						: 'bg-gray-600'}"
+						? 'bg-accent'
+						: 'bg-text-muted'}"
 				>
 					<div
-						class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
+						class="absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform {showAdvancedOptions
 							? 'translate-x-6'
 							: 'translate-x-0.5'}"
 					/>
@@ -263,14 +263,13 @@
 			</div>
 
 			{#if showAdvancedOptions}
-				<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
-					<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
+				<div class="space-y-4 rounded-xl border border-line bg-surface-2 p-4">
+					<h4 class="text-sm font-medium text-text-2">Advanced Options</h4>
 					<div>
-						<span class="mb-2 block text-sm font-medium text-gray-300">Strategy Parameters</span>
+						<span class="mb-2 block text-sm font-medium text-text-2">Strategy Parameters</span>
 						<div class="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
 							<div class="relative">
-								<span class="mb-1 block text-sm font-medium text-gray-300"
-									>Next Trade Multiplier</span
+								<span class="mb-1 block text-sm font-medium text-text-2">Next Trade Multiplier</span
 								>
 								<Input
 									type="number"
@@ -281,8 +280,7 @@
 								/>
 							</div>
 							<div class="relative">
-								<span class="mb-1 block text-sm font-medium text-gray-300"
-									>Cost Basis Multiplier</span
+								<span class="mb-1 block text-sm font-medium text-text-2">Cost Basis Multiplier</span
 								>
 								<Input
 									type="number"
@@ -293,7 +291,7 @@
 								/>
 							</div>
 							<div class="relative">
-								<span class="mb-1 block text-sm font-medium text-gray-300"
+								<span class="mb-1 block text-sm font-medium text-text-2"
 									>Time Per Epoch (seconds)</span
 								>
 								<Input
@@ -307,17 +305,17 @@
 						</div>
 					</div>
 					<div>
-						<span class="mb-2 block text-sm font-medium text-gray-300">Enter Vault IDs</span>
+						<span class="mb-2 block text-sm font-medium text-text-2">Enter Vault IDs</span>
 						<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
 							<div class="space-y-2">
 								<div class="relative">
-									<span class="text-sm font-medium text-gray-300"
+									<span class="text-sm font-medium text-text-2"
 										>Input {selectedToken1.symbol} Vault ID</span
 									>
 									<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
 								</div>
 								<div class="relative">
-									<span class="text-sm font-medium text-gray-300"
+									<span class="text-sm font-medium text-text-2"
 										>Input {selectedToken2.symbol} Vault ID</span
 									>
 									<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
@@ -325,13 +323,13 @@
 							</div>
 							<div class="space-y-2">
 								<div class="relative">
-									<span class="text-sm font-medium text-gray-300"
+									<span class="text-sm font-medium text-text-2"
 										>Output {selectedToken1.symbol} Vault ID</span
 									>
 									<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
 								</div>
 								<div class="relative">
-									<span class="text-sm font-medium text-gray-300"
+									<span class="text-sm font-medium text-text-2"
 										>Output {selectedToken2.symbol} Vault ID</span
 									>
 									<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
@@ -348,22 +346,34 @@
 	{#if selectedToken1 && selectedToken2}
 		<div class="mt-4 space-y-4 lg:mt-0">
 			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">Prices</h4>
 				{#if !hasValidPriceFeedId(selectedToken1) && !hasValidPriceFeedId(selectedToken2)}
-					<div class="py-6 text-center text-sm text-gray-400">No price feed data available</div>
+					<div class="py-6 text-center text-sm text-text-2">No price feed data available</div>
 				{:else if !$priceFeedsQuery?.data?.length || !$oracleQuotesQuery?.data}
 					<div class="flex justify-center py-6">
 						<LoadingSpinner size="sm" text="Loading price data..." />
 					</div>
 				{:else}
 					<div class="overflow-x-auto">
-						<table class="min-w-full text-sm text-gray-200">
+						<table class="min-w-full text-sm text-text-2">
 							<thead>
 								<tr>
-									<th class="px-2 py-1 text-left">Token</th>
-									<th class="px-2 py-1 text-right">Oracle Price</th>
-									<th class="px-2 py-1 text-right">Price Certainty</th>
-									<th class="px-2 py-1 text-right">Off-chain</th>
+									<th
+										class="px-2 py-1 text-left text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>Token</th
+									>
+									<th
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>Oracle Price</th
+									>
+									<th
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>Price Certainty</th
+									>
+									<th
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>Off-chain</th
+									>
 								</tr>
 							</thead>
 							<tbody>
@@ -386,61 +396,63 @@
 			</div>
 
 			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Active Liquidity Order Summary</h4>
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">
+					Active Liquidity Order Summary
+				</h4>
 				<div class="space-y-2">
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Trading Pair</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Trading Pair</span>
+						<span class="font-medium text-text"
 							>{selectedToken1 && selectedToken2
 								? `${selectedToken1.symbol}/${selectedToken2.symbol}`
 								: 'Select tokens'}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Initial Ratio</span>
-						<span class="font-medium text-white">{initialIo}</span>
+						<span class="text-text-2">Initial Ratio</span>
+						<span class="font-medium text-text">{initialIo}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Cost Basis</span>
-						<span class="font-medium text-white">{costBasisMultiplier}</span>
+						<span class="text-text-2">Cost Basis</span>
+						<span class="font-medium text-text">{costBasisMultiplier}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Spread</span>
-						<span class="font-medium text-white">{nextTradeMultiplier}</span>
+						<span class="text-text-2">Spread</span>
+						<span class="font-medium text-text">{nextTradeMultiplier}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Time Per Epoch</span>
-						<span class="font-medium text-white">{timePerEpoch}s</span>
+						<span class="text-text-2">Time Per Epoch</span>
+						<span class="font-medium text-text">{timePerEpoch}s</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">{selectedToken1.symbol} Fast Exit</span>
-						<span class="font-medium text-white">{isToken1FastExit ? 'Yes' : 'No'}</span>
+						<span class="text-text-2">{selectedToken1.symbol} Fast Exit</span>
+						<span class="font-medium text-text">{isToken1FastExit ? 'Yes' : 'No'}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">{selectedToken2.symbol} Fast Exit</span>
-						<span class="font-medium text-white">{isToken2FastExit ? 'Yes' : 'No'}</span>
+						<span class="text-text-2">{selectedToken2.symbol} Fast Exit</span>
+						<span class="font-medium text-text">{isToken2FastExit ? 'Yes' : 'No'}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">{selectedToken1.symbol} Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">{selectedToken1.symbol} Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(depositAmount1 ?? 0n, selectedToken1.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">{selectedToken2.symbol} Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">{selectedToken2.symbol} Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(depositAmount2 ?? 0n, selectedToken2.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Minimum Trade Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Minimum Trade Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(minTradeAmount ?? 0n, selectedToken1.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Maximum Trade Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Maximum Trade Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(maxTradeAmount ?? 0n, selectedToken1.decimals)}</span
 						>
 					</div>

--- a/src/lib/components/orders/DcaOrder.svelte
+++ b/src/lib/components/orders/DcaOrder.svelte
@@ -11,7 +11,6 @@
 	import transactionStore from '$lib/stores/transaction';
 	import { hasValidPriceFeedId, priceToIoratioString } from '$lib/utils/derivations';
 	import { currentNetwork, oracleQuotes, reviewStrategyOnDeploy } from '$lib/stores';
-	import { containerStyles } from '$lib/styles/utils';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { walletRegistered, promptWalletConnection, promptLogin } from '$lib/stores/accessStore';
 	import { DEFAULT_INPUT_VAULT_ID } from '$lib/services/orderDeployment';
@@ -34,8 +33,8 @@
 
 	$: actionButtonClass =
 		orderSide === 'Buy'
-			? 'bg-green-500 hover:bg-green-600 text-white'
-			: 'bg-red-500 hover:bg-red-600 text-white';
+			? 'bg-green-500 hover:bg-green-600 text-text'
+			: 'bg-red-500 hover:bg-red-600 text-text';
 
 	export let assetToken: PythToken | undefined; // The token we're accumulating
 	/** Share-denominated display toggle — see MarketOrder for the contract. */
@@ -310,9 +309,9 @@
 		<!-- Target Amount and Period -->
 		<div class="space-y-4">
 			<div>
-				<div class="mb-2 block text-sm font-medium text-gray-300">
+				<div class="mb-2 block text-sm font-medium text-text-2">
 					{orderSide === 'Buy' ? 'Purchase Budget' : 'Amount to Sell'}
-					<span class="ml-1 text-xs text-gray-500"
+					<span class="ml-1 text-xs text-text-3"
 						>({orderSide === 'Buy' ? settlementLabel : displayedAssetSymbol})</span
 					>
 				</div>
@@ -336,7 +335,7 @@
 						<button
 							type="button"
 							on:click={() => handlePercentageClick(percent)}
-							class="flex-1 rounded border border-white/10 bg-gray-700/50 px-2 py-1 text-xs text-gray-300 transition-colors hover:border-white/20 hover:bg-gray-600/50"
+							class="flex-1 rounded border border-line bg-surface-3 px-2 py-1 text-xs text-text-2 transition-colors hover:border-line-strong hover:bg-overlay-hover"
 						>
 							{percent === 100 ? 'Max' : `${percent}%`}
 						</button>
@@ -344,7 +343,7 @@
 				</div>
 			</div>
 			<div>
-				<div class="mb-2 block text-sm font-medium text-gray-300">{periodLabel}</div>
+				<div class="mb-2 block text-sm font-medium text-text-2">{periodLabel}</div>
 				<div class="flex gap-2">
 					<div class="flex-grow">
 						<Input
@@ -369,7 +368,7 @@
 		<!-- Price Settings -->
 		<div class="space-y-4">
 			<div>
-				<div class="mb-2 block text-sm font-medium text-gray-300">Start Price</div>
+				<div class="mb-2 block text-sm font-medium text-text-2">Start Price</div>
 				<Input
 					aria-label="Start Price"
 					type="number"
@@ -380,7 +379,7 @@
 				/>
 			</div>
 			<div>
-				<div class="mb-2 block text-sm font-medium text-gray-300">
+				<div class="mb-2 block text-sm font-medium text-text-2">
 					{orderSide === 'Buy' ? 'Ceiling Price' : 'Floor Price'}
 				</div>
 				<Input
@@ -395,11 +394,13 @@
 		</div>
 
 		<!-- Order Summary -->
-		<div class={containerStyles.cardBordered}>
-			<h4 class="mb-3 text-sm font-medium text-gray-300">Order Summary</h4>
+		<div class="rounded-xl border border-line bg-overlay-1 p-4">
+			<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">
+				Order Summary
+			</h4>
 			<div class="space-y-2 text-sm">
 				<div class="flex justify-between">
-					<span class="text-gray-400">Target Amount</span>
+					<span class="text-text-2">Target Amount</span>
 					<span class="font-medium">
 						{#if orderSide === 'Buy'}
 							{selectedAmount
@@ -415,14 +416,14 @@
 					</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">{periodLabel}</span>
+					<span class="text-text-2">{periodLabel}</span>
 					<span class="font-medium">
 						{selectedPeriod || '0'}
 						{selectedPeriodUnit.toLowerCase()}
 					</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">Average per period</span>
+					<span class="text-text-2">Average per period</span>
 					<span class="font-medium">
 						{#if orderSide === 'Buy'}
 							~{avgPricePerPeriod} {settlementLabel}
@@ -432,7 +433,7 @@
 					</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">Min trade size</span>
+					<span class="text-text-2">Min trade size</span>
 					<span class="text-xs font-medium">
 						{#if orderSide === 'Buy'}
 							{minTradeAmount ? formatUnits(minTradeAmount, selectedOutputToken.decimals) : '0'}
@@ -444,7 +445,7 @@
 					</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">Max trade size</span>
+					<span class="text-text-2">Max trade size</span>
 					<span class="text-xs font-medium">
 						{#if orderSide === 'Buy'}
 							{maxTradeAmount ? formatUnits(maxTradeAmount, selectedOutputToken.decimals) : '0'}
@@ -466,11 +467,11 @@
 		</div>
 
 		<!-- Advanced Options -->
-		<div class="border-t border-white/10 pt-4">
+		<div class="border-t border-line pt-4">
 			<button
 				type="button"
 				on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
-				class="flex w-full items-center justify-between text-sm text-gray-400 hover:text-gray-300"
+				class="flex w-full items-center justify-between text-sm text-text-2 hover:text-text-2"
 			>
 				<span>Advanced options</span>
 				<svg
@@ -493,18 +494,18 @@
 			{#if showAdvancedOptions}
 				<div class="mt-4 space-y-3">
 					<div>
-						<label for="receiving-vault-dca" class="mb-2 block text-sm font-medium text-gray-300">
+						<label for="receiving-vault-dca" class="mb-2 block text-sm font-medium text-text-2">
 							Receiving vault
 						</label>
 						<select
 							id="receiving-vault-dca"
 							bind:value={selectedVaultOption}
-							class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-4 py-3 text-white transition-colors focus:border-yellow-500/50 focus:outline-none"
+							class="w-full rounded-lg border border-line bg-surface-3 px-4 py-3 text-text transition-colors focus:border-yellow-500/50 focus:outline-none"
 						>
 							<option value="default">Default</option>
 							<option value="order-specific">Order-specific</option>
 						</select>
-						<p class="mt-1 text-xs text-gray-500">
+						<p class="mt-1 text-xs text-text-3">
 							{#if selectedVaultOption === 'default'}
 								Uses the shared default vault for receiving tokens
 							{:else}
@@ -521,9 +522,7 @@
 			on:click={handleDcaDeploy}
 			disabled={disableDeploy}
 			class={`w-full rounded-md px-4 py-3 text-sm font-semibold transition-all ${
-				disableDeploy
-					? 'cursor-not-allowed bg-gray-600 text-gray-300 opacity-50'
-					: actionButtonClass
+				disableDeploy ? 'cursor-not-allowed bg-surface-3 text-text-3 opacity-50' : actionButtonClass
 			}`}
 		>
 			{#if disableDeploy}
@@ -551,9 +550,9 @@
 				type="checkbox"
 				checked={$reviewStrategyOnDeploy}
 				on:change={(e) => reviewStrategyOnDeploy.set(e.currentTarget.checked)}
-				class="h-4 w-4 rounded border-gray-600 bg-gray-700 text-yellow-500 focus:ring-yellow-500 focus:ring-offset-gray-800"
+				class="h-4 w-4 rounded border-line bg-surface-3 text-accent focus:ring-accent-line focus:ring-offset-surface-1"
 			/>
-			<span class="text-xs text-gray-400">Review strategy source code on deploy</span>
+			<span class="text-xs text-text-2">Review strategy source code on deploy</span>
 		</label>
 	</div>
 {:else}

--- a/src/lib/components/orders/FolioStrategy.svelte
+++ b/src/lib/components/orders/FolioStrategy.svelte
@@ -223,36 +223,36 @@
 	<div class="space-y-6 lg:col-span-2">
 		<div>
 			<h3 class="mb-4 text-lg font-semibold">Select Tokens</h3>
-			<p class="mb-6 text-sm text-gray-400">
+			<p class="mb-6 text-sm text-text-2">
 				Select the tokens that you want to use in your portfolio.
 			</p>
 			<div class="grid grid-cols-1 gap-3 sm:gap-4">
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 1</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 1</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken1} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 2</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 2</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken2} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 3</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 3</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken3} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 4</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 4</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken4} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 5</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 5</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken5} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 6</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 6</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken6} />
 				</div>
 				<div>
-					<span class="mb-2 block text-sm font-medium text-gray-300">Token 7</span>
+					<span class="mb-2 block text-sm font-medium text-text-2">Token 7</span>
 					<TokenSelect options={ALL_TOKENS} bind:selected={selectedToken7} />
 				</div>
 			</div>
@@ -263,11 +263,11 @@
 				<button
 					on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
 					class="relative h-6 w-12 rounded-full transition-colors {showAdvancedOptions
-						? 'bg-blue-500'
-						: 'bg-gray-600'}"
+						? 'bg-accent'
+						: 'bg-text-muted'}"
 				>
 					<div
-						class="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform {showAdvancedOptions
+						class="absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform {showAdvancedOptions
 							? 'translate-x-6'
 							: 'translate-x-0.5'}"
 					/>
@@ -275,10 +275,10 @@
 				<span class="text-sm font-medium">Show advanced options</span>
 			</div>
 			{#if showAdvancedOptions}
-				<div class="space-y-4 rounded-lg border border-white/5 bg-gray-800/30 p-4">
-					<h4 class="text-sm font-medium text-gray-300">Advanced Options</h4>
+				<div class="space-y-4 rounded-xl border border-line bg-surface-2 p-4">
+					<h4 class="text-sm font-medium text-text-2">Advanced Options</h4>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Threshold</span>
+						<span class="block text-sm font-medium text-text-2">Threshold</span>
 						<Input
 							type="text"
 							placeholder="0.05"
@@ -287,7 +287,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Fee</span>
+						<span class="block text-sm font-medium text-text-2">Fee</span>
 						<Input
 							type="text"
 							placeholder="0.003"
@@ -297,7 +297,7 @@
 					</div>
 
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 1 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 1 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken1}
 							bind:amount={overrideDepositAmount1}
@@ -306,7 +306,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 2 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 2 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken2}
 							bind:amount={overrideDepositAmount2}
@@ -315,7 +315,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 3 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 3 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken3}
 							bind:amount={overrideDepositAmount3}
@@ -324,7 +324,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 4 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 4 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken4}
 							bind:amount={overrideDepositAmount4}
@@ -333,7 +333,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 5 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 5 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken5}
 							bind:amount={overrideDepositAmount5}
@@ -342,7 +342,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 6 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 6 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken6}
 							bind:amount={overrideDepositAmount6}
@@ -351,7 +351,7 @@
 						/>
 					</div>
 					<div class="grid grid-cols-1 gap-3 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 7 Deposit Amount</span>
+						<span class="block text-sm font-medium text-text-2">Token 7 Deposit Amount</span>
 						<TradeAmountInput
 							amountToken={selectedToken7}
 							bind:amount={overrideDepositAmount7}
@@ -359,106 +359,106 @@
 							bind:isError={overrideDepositAmount7Error}
 						/>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 1 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 1 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken1.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId1} bind:isError={inputVaultId1Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken1.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId1} bind:isError={outputVaultId1Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 2 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 2 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken2.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId2} bind:isError={inputVaultId2Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken2.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId2} bind:isError={outputVaultId2Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 3 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 3 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken3.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId3} bind:isError={inputVaultId3Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken3.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId3} bind:isError={outputVaultId3Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 4 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 4 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken4.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId4} bind:isError={inputVaultId4Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken4.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId4} bind:isError={outputVaultId4Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 5 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 5 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken5.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId5} bind:isError={inputVaultId5Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken5.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId5} bind:isError={outputVaultId5Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 6 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 6 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken6.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId6} bind:isError={inputVaultId6Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken6.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId6} bind:isError={outputVaultId6Error} />
 						</div>
 					</div>
-					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-white/10 pt-4 sm:gap-4">
-						<span class="block text-sm font-medium text-gray-300">Token 7 Vault ID</span>
+					<div class="mt-4 grid grid-cols-1 gap-3 border-t border-line pt-4 sm:gap-4">
+						<span class="block text-sm font-medium text-text-2">Token 7 Vault ID</span>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Input {selectedToken7.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={inputVaultId7} bind:isError={inputVaultId7Error} />
 						</div>
 						<div class="flex flex-col gap-2">
-							<span class="text-left text-sm font-medium text-gray-400">
+							<span class="text-left text-sm font-medium text-text-2">
 								Output {selectedToken7.symbol} Vault ID
 							</span>
 							<VaultIdInput bind:vaultId={outputVaultId7} bind:isError={outputVaultId7Error} />
@@ -473,15 +473,27 @@
 	{#if selectedToken1 && selectedToken2 && selectedToken3 && selectedToken4 && selectedToken5 && selectedToken6 && selectedToken7}
 		<div class="mt-4 space-y-4 lg:mt-0">
 			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Prices</h4>
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">Prices</h4>
 				<div class="overflow-x-auto">
-					<table class="min-w-full text-sm text-gray-200">
+					<table class="min-w-full text-sm text-text-2">
 						<thead>
 							<tr>
-								<th class="px-2 py-1 text-left">Token</th>
-								<th class="px-2 py-1 text-right">Oracle Price</th>
-								<th class="px-2 py-1 text-right">Price Certainty</th>
-								<th class="px-2 py-1 text-right">Off-chain</th>
+								<th
+									class="px-2 py-1 text-left text-[11px] font-medium uppercase tracking-wide text-text-3"
+									>Token</th
+								>
+								<th
+									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+									>Oracle Price</th
+								>
+								<th
+									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+									>Price Certainty</th
+								>
+								<th
+									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+									>Off-chain</th
+								>
 							</tr>
 						</thead>
 						<tbody>
@@ -490,9 +502,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken1?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken2)}
@@ -500,9 +521,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken2?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken3)}
@@ -510,9 +540,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken3?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken4)}
@@ -520,9 +559,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken4?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken5)}
@@ -530,9 +578,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken5?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken6)}
@@ -540,9 +597,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken6?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 							{#if hasValidPriceFeedId(selectedToken7)}
@@ -550,9 +616,18 @@
 							{:else}
 								<tr>
 									<td class="px-2 py-1">{selectedToken7?.symbol ?? '-'}</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
-									<td class="px-2 py-1 text-right">-</td>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
+									<td
+										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
+										>-</td
+									>
 								</tr>
 							{/if}
 						</tbody>
@@ -562,83 +637,85 @@
 			</div>
 
 			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Portfolio Order Summary</h4>
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">
+					Portfolio Order Summary
+				</h4>
 				<div class="space-y-2">
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Threshold</span>
-						<span class="font-medium text-white">{overrideThreshold || '0.05'}</span>
+						<span class="text-text-2">Threshold</span>
+						<span class="font-medium text-text">{overrideThreshold || '0.05'}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Fee</span>
-						<span class="font-medium text-white">{overrideFee || '0.003'}</span>
+						<span class="text-text-2">Fee</span>
+						<span class="font-medium text-text">{overrideFee || '0.003'}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 1</span>
-						<span class="font-medium text-white">{selectedToken1.symbol}</span>
+						<span class="text-text-2">Selected Token 1</span>
+						<span class="font-medium text-text">{selectedToken1.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 2</span>
-						<span class="font-medium text-white">{selectedToken2.symbol}</span>
+						<span class="text-text-2">Selected Token 2</span>
+						<span class="font-medium text-text">{selectedToken2.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 3</span>
-						<span class="font-medium text-white">{selectedToken3.symbol}</span>
+						<span class="text-text-2">Selected Token 3</span>
+						<span class="font-medium text-text">{selectedToken3.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 4</span>
-						<span class="font-medium text-white">{selectedToken4.symbol}</span>
+						<span class="text-text-2">Selected Token 4</span>
+						<span class="font-medium text-text">{selectedToken4.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 5</span>
-						<span class="font-medium text-white">{selectedToken5.symbol}</span>
+						<span class="text-text-2">Selected Token 5</span>
+						<span class="font-medium text-text">{selectedToken5.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 6</span>
-						<span class="font-medium text-white">{selectedToken6.symbol}</span>
+						<span class="text-text-2">Selected Token 6</span>
+						<span class="font-medium text-text">{selectedToken6.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Selected Token 7</span>
-						<span class="font-medium text-white">{selectedToken7.symbol}</span>
+						<span class="text-text-2">Selected Token 7</span>
+						<span class="font-medium text-text">{selectedToken7.symbol}</span>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 1 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 1 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount1 ?? 0n, selectedToken1.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 2 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 2 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount2 ?? 0n, selectedToken2.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 3 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 3 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount3 ?? 0n, selectedToken3.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 4 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 4 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount4 ?? 0n, selectedToken4.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 5 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 5 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount5 ?? 0n, selectedToken5.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 6 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 6 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount6 ?? 0n, selectedToken6.decimals)}</span
 						>
 					</div>
 					<div class="flex justify-between text-sm">
-						<span class="text-gray-400">Token 7 Deposit Amount</span>
-						<span class="font-medium text-white"
+						<span class="text-text-2">Token 7 Deposit Amount</span>
+						<span class="font-medium text-text"
 							>{formatUnits(overrideDepositAmount7 ?? 0n, selectedToken7.decimals)}</span
 						>
 					</div>

--- a/src/lib/components/orders/LimitOrder.svelte
+++ b/src/lib/components/orders/LimitOrder.svelte
@@ -10,8 +10,8 @@
 	import { currentNetwork, reviewStrategyOnDeploy } from '$lib/stores';
 	import { priceToIoratioString } from '$lib/utils/derivations';
 	import type { PythToken } from '$lib/types';
-	import { containerStyles } from '$lib/styles/utils';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { isAuthenticated } from '$lib/stores/authStore';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import { walletRegistered, promptWalletConnection, promptLogin } from '$lib/stores/accessStore';
@@ -116,8 +116,8 @@
 	$: summaryAccentClass = orderSide === 'Buy' ? 'text-green-400' : 'text-red-400';
 	$: actionButtonClass =
 		orderSide === 'Buy'
-			? 'bg-green-500 hover:bg-green-600 text-white'
-			: 'bg-red-500 hover:bg-red-600 text-white';
+			? 'bg-green-500 hover:bg-green-600 text-text'
+			: 'bg-red-500 hover:bg-red-600 text-text';
 
 	// Autofill with current price if available
 	let selectedInitialRatio: string = currentPrice || '';
@@ -456,7 +456,7 @@
 			<!-- Main inputs stacked -->
 			<div class="space-y-4">
 				<div data-testid="deposit-input">
-					<div class="mb-2 block text-sm font-medium text-gray-300">Quantity</div>
+					<div class="mb-2 block text-sm font-medium text-text-2">Quantity</div>
 					<TradeAmountInput
 						bind:this={tradeAmountInputRef}
 						aria-label="Quantity"
@@ -478,7 +478,7 @@
 							<button
 								type="button"
 								on:click={() => handlePercentageClick(percent)}
-								class="flex-1 rounded border border-white/10 bg-gray-700/50 px-2 py-1 text-xs text-gray-300 transition-colors hover:border-white/20 hover:bg-gray-600/50"
+								class="flex-1 rounded border border-line bg-surface-3 px-2 py-1 text-xs text-text-2 transition-colors hover:border-line-strong hover:bg-overlay-hover"
 							>
 								{percent === 100 ? 'Max' : `${percent}%`}
 							</button>
@@ -486,9 +486,9 @@
 					</div>
 				</div>
 				<div>
-					<div class="mb-2 block text-sm font-medium text-gray-300">
+					<div class="mb-2 block text-sm font-medium text-text-2">
 						Limit Price
-						<span class="ml-1 text-xs text-gray-500"
+						<span class="ml-1 text-xs text-text-3"
 							>({settlementLabel} per {displayedAssetSymbol})</span
 						>
 					</div>
@@ -506,13 +506,15 @@
 			</div>
 
 			<!-- Order summary -->
-			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Order Summary</h4>
+			<div class="rounded-xl border border-line bg-overlay-1 p-4">
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">
+					Order Summary
+				</h4>
 				<div class="space-y-2 text-sm">
 					<div class="flex items-start justify-between gap-3">
-						<span class="text-gray-400">{orderSide === 'Buy' ? 'Buying' : 'Selling'}</span>
+						<span class="text-text-2">{orderSide === 'Buy' ? 'Buying' : 'Selling'}</span>
 						<div class="text-right">
-							<span class="font-medium">
+							<span class="font-mono font-medium tabular-nums">
 								{(selectedAmount
 									? parseFloat(formatUnits(selectedAmount, assetToken.decimals))
 									: 0
@@ -520,7 +522,7 @@
 								{assetToken.symbol}
 							</span>
 							{#if showShareEquivalent}
-								<div class="text-[11px] text-gray-500">
+								<div class="text-[11px] text-text-3">
 									equivalent to {(
 										(selectedAmount
 											? parseFloat(formatUnits(selectedAmount, assetToken.decimals))
@@ -532,23 +534,23 @@
 						</div>
 					</div>
 					<div class="flex justify-between">
-						<span class="text-gray-400">At price</span>
-						<span class="font-medium">
+						<span class="text-text-2">At price</span>
+						<span class="font-mono font-medium tabular-nums">
 							{selectedInitialRatio || '0'}
 							{settlementLabel}
 						</span>
 					</div>
-					<div class="mt-2 border-t border-white/10 pt-2">
+					<div class="mt-2 border-t border-line pt-2">
 						<div class="flex justify-between">
-							<span class="text-gray-400">Total</span>
-							<span class={`text-lg font-semibold ${summaryAccentClass}`}>
+							<span class="text-text-2">Total</span>
+							<span class={`font-mono text-lg font-semibold tabular-nums ${summaryAccentClass}`}>
 								{totalCost}
 								{settlementLabel}
 							</span>
 						</div>
 						{#if belowMinTradeError}
 							<div
-								class="mt-2 rounded-md border border-red-500/30 bg-red-500/10 p-2 text-sm text-red-300"
+								class="mt-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-sm text-amber-700 dark:text-amber-300"
 							>
 								Minimum trade size is $1. Please increase your order amount.
 							</div>
@@ -558,45 +560,36 @@
 			</div>
 
 			<!-- Advanced Options -->
-			<div class="border-t border-white/10 pt-4">
+			<div class="border-t border-line pt-4">
 				<button
 					type="button"
 					on:click={() => (showAdvancedOptions = !showAdvancedOptions)}
-					class="flex w-full items-center justify-between text-sm text-gray-400 hover:text-gray-300"
+					class="flex w-full items-center justify-between text-sm text-text-2 hover:text-text-2"
 				>
 					<span>Advanced options</span>
-					<svg
-						class={`h-4 w-4 transform transition-transform ${
+					<Icon
+						name="chevronDown"
+						className={`h-4 w-4 transform transition-transform ${
 							showAdvancedOptions ? 'rotate-180' : ''
 						}`}
-						fill="none"
-						stroke="currentColor"
-						viewBox="0 0 24 24"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M19 9l-7 7-7-7"
-						/>
-					</svg>
+					/>
 				</button>
 
 				{#if showAdvancedOptions}
 					<div class="mt-4 space-y-3">
 						<div>
-							<label for="receiving-vault" class="mb-2 block text-sm font-medium text-gray-300">
+							<label for="receiving-vault" class="mb-2 block text-sm font-medium text-text-2">
 								Receiving vault
 							</label>
 							<select
 								id="receiving-vault"
 								bind:value={selectedVaultOption}
-								class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-4 py-3 text-white transition-colors focus:border-yellow-500/50 focus:outline-none"
+								class="w-full rounded-lg border border-line bg-surface-3 px-4 py-3 text-text transition-colors focus:border-accent-line focus:outline-none"
 							>
 								<option value="default">Default</option>
 								<option value="order-specific">Order-specific</option>
 							</select>
-							<p class="mt-1 text-xs text-gray-500">
+							<p class="mt-1 text-xs text-text-3">
 								{#if selectedVaultOption === 'default'}
 									Uses the shared default vault for receiving tokens
 								{:else}
@@ -615,9 +608,9 @@
 				data-mode="limit"
 				on:click={handleDeploy}
 				disabled={disableDeploy}
-				class={`w-full rounded-md px-4 py-3 text-sm font-semibold transition-all ${
+				class={`w-full rounded-xl px-4 py-3 text-sm font-semibold transition-all ${
 					disableDeploy
-						? 'cursor-not-allowed bg-gray-600 text-gray-300 opacity-50'
+						? 'cursor-not-allowed bg-line-strong text-text-2 opacity-50'
 						: actionButtonClass
 				}`}
 			>
@@ -679,9 +672,9 @@
 					type="checkbox"
 					checked={$reviewStrategyOnDeploy}
 					on:change={(e) => reviewStrategyOnDeploy.set(e.currentTarget.checked)}
-					class="h-4 w-4 rounded border-gray-600 bg-gray-700 text-yellow-500 focus:ring-yellow-500 focus:ring-offset-gray-800"
+					class="h-4 w-4 rounded border-line bg-surface-3 text-accent focus:ring-accent"
 				/>
-				<span class="text-xs text-gray-400">Review strategy source code on deploy</span>
+				<span class="text-xs text-text-2">Review strategy source code on deploy</span>
 			</label>
 		</div>
 	</div>
@@ -699,22 +692,16 @@
 	onClose={cancelDeploy}
 >
 	<div class="space-y-6">
-		<div class="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
+		<div class="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
 			<div class="flex gap-3">
 				<div class="flex-shrink-0">
-					<svg class="h-5 w-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-						<path
-							fill-rule="evenodd"
-							d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-							clip-rule="evenodd"
-						/>
-					</svg>
+					<Icon name="info" className="h-5 w-5 text-amber-400" />
 				</div>
 				<div>
-					<h3 class="font-semibold text-yellow-200">
+					<h3 class="font-semibold text-amber-700 dark:text-amber-200">
 						Price significantly {orderSide === 'Buy' ? 'above best offer' : 'below best bid'}
 					</h3>
-					<p class="mt-2 text-sm text-yellow-100">
+					<p class="mt-2 text-sm text-amber-800 dark:text-amber-100">
 						Your limit price is set significantly {orderSide === 'Buy' ? 'above' : 'below'} the current
 						best {orderSide === 'Buy' ? 'offer' : 'bid'}. You won't get the best possible price. We
 						recommend using a market order instead.
@@ -727,16 +714,16 @@
 			<input
 				type="checkbox"
 				bind:checked={userAcknowledgesWarning}
-				class="h-4 w-4 rounded border-gray-300 bg-gray-800 text-yellow-500 focus:ring-yellow-500"
+				class="h-4 w-4 rounded border-line bg-surface-2 text-accent focus:ring-accent"
 			/>
-			<span class="text-sm text-gray-300">I understand and wish to continue</span>
+			<span class="text-sm text-text-2">I understand and wish to continue</span>
 		</label>
 
 		<div class="flex gap-3">
 			<button
 				type="button"
 				on:click={cancelDeploy}
-				class="flex-1 rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
+				class="flex-1 rounded-xl border border-line bg-surface-2 px-4 py-2 text-sm font-medium text-text-2 transition hover:bg-surface-3 focus:outline-none focus:ring-2 focus:ring-line-strong"
 			>
 				Cancel
 			</button>
@@ -744,10 +731,10 @@
 				type="button"
 				on:click={proceedWithDeploy}
 				disabled={!userAcknowledgesWarning}
-				class={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 ${
+				class={`flex-1 rounded-xl px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 ${
 					userAcknowledgesWarning
-						? 'bg-yellow-500 text-gray-900 hover:bg-yellow-600 focus:ring-yellow-400'
-						: 'cursor-not-allowed bg-gray-600 text-gray-400 opacity-50'
+						? 'bg-emerald-500 text-[#05241a] hover:bg-emerald-400 focus:ring-accent'
+						: 'cursor-not-allowed bg-line-strong text-text-2 opacity-50'
 				}`}
 			>
 				Continue

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -9,8 +9,8 @@
 	import { normalizeAddress } from '$lib/utils/tokenMath';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import { formatUnits } from 'viem';
-	import { containerStyles } from '$lib/styles/utils';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { isAuthenticated } from '$lib/stores/authStore';
 	import { walletRegistered, promptWalletConnection, promptLogin } from '$lib/stores/accessStore';
 	import { validateSelectedAmount } from '$lib/utils/validation';
@@ -477,8 +477,8 @@
 	$: summaryAccentClass = orderSide === 'Buy' ? 'text-green-400' : 'text-red-400';
 	$: actionButtonClass =
 		orderSide === 'Buy'
-			? 'bg-green-500 hover:bg-green-600 text-white'
-			: 'bg-red-500 hover:bg-red-600 text-white';
+			? 'bg-green-500 hover:bg-green-600 text-text'
+			: 'bg-red-500 hover:bg-red-600 text-text';
 
 	$: disableDeploy =
 		!selectedAmount ||
@@ -1104,7 +1104,7 @@
 				<div>
 					<!-- Unified input with integrated toggle and token -->
 					<div
-						class="flex items-center rounded-lg border border-white/10 bg-gray-700/50 transition-colors focus-within:border-yellow-500/50"
+						class="flex items-center rounded-lg border border-line bg-surface-3 transition-colors focus-within:border-accent-line"
 					>
 						<!-- Left side: Buy/Spend or Sell toggle -->
 						{#if orderSide === 'Buy'}
@@ -1119,19 +1119,7 @@
 								class="flex items-center gap-1.5 py-3 pl-4 pr-2 text-sm font-medium text-green-400 transition-colors hover:text-green-300"
 							>
 								{inputMode === 'amount' ? 'Buy' : 'Spend'}
-								<svg
-									class="h-3 w-3 opacity-50"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
-								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="2"
-										d="M8 9l4-4 4 4m0 6l-4 4-4-4"
-									/>
-								</svg>
+								<Icon name="swap" className="h-3 w-3 opacity-50" />
 							</button>
 						{:else}
 							<span class="py-3 pl-4 pr-2 text-sm font-medium text-red-400"> Sell </span>
@@ -1163,7 +1151,7 @@
 						</div>
 
 						<!-- Right side: Token symbol -->
-						<span class="py-3 pl-2 pr-4 text-sm font-medium text-gray-300">
+						<span class="py-3 pl-2 pr-4 text-sm font-medium text-text-2">
 							{inputMode === 'spend' ? paymentTokenSymbol : displayedAssetSymbol}
 						</span>
 					</div>
@@ -1172,7 +1160,7 @@
 					     opted into the share-denominated view, scale the displayed balance
 					     by the wrap ratio and use the share symbol. Payment-token spends
 					     (USDC) are unaffected since they aren't wrapped. -->
-					<div class="mt-1.5 text-sm text-gray-400">
+					<div class="mt-1.5 text-sm text-text-2">
 						{#if spendingTokenBalanceDecimals !== null}
 							{@const balanceFormatted = parseFloat(
 								formatUnits(spendingTokenBalance, spendingTokenBalanceDecimals)
@@ -1193,7 +1181,7 @@
 								type="button"
 								on:click={() => handlePercentageClick(percent)}
 								disabled={percentageButtonsDisabled}
-								class="flex-1 rounded border border-white/10 bg-gray-700/50 px-2 py-1 text-xs text-gray-300 transition-colors hover:border-white/20 hover:bg-gray-600/50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-white/10 disabled:hover:bg-gray-700/50"
+								class="flex-1 rounded border border-line bg-surface-3 px-2 py-1 text-xs text-text-2 transition-colors hover:border-line-strong hover:bg-overlay-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-line disabled:hover:bg-surface-3"
 								title={percentageButtonsDisabled ? 'Price data unavailable' : ''}
 							>
 								{percent === 100 ? 'Max' : `${percent}%`}
@@ -1201,15 +1189,15 @@
 						{/each}
 					</div>
 					{#if percentageButtonsDisabled}
-						<p class="mt-1 text-xs text-yellow-400/80">
+						<p class="mt-1 text-xs text-amber-700 dark:text-amber-400/80">
 							Enter amount manually - price data loading
 						</p>
 					{/if}
 				</div>
 				<div>
-					<div class="mb-2 block text-sm font-medium text-gray-300">
+					<div class="mb-2 block text-sm font-medium text-text-2">
 						Market Price
-						<span class="ml-1 text-xs text-gray-500">(per {displayedAssetSymbol})</span>
+						<span class="ml-1 text-xs text-text-3">(per {displayedAssetSymbol})</span>
 					</div>
 					<div class="relative">
 						<input
@@ -1224,7 +1212,7 @@
 										? 'Price unavailable'
 										: `~${displayedMarketPrice.toFixed(2)} ${paymentTokenSymbol}`}
 							disabled
-							class="w-full rounded-md border border-white/10 bg-gray-800/50 px-3 py-2 text-gray-300 placeholder-gray-500 focus:border-yellow-400/50 focus:outline-none focus:ring-1 focus:ring-yellow-400/20 disabled:cursor-not-allowed disabled:opacity-50"
+							class="focus:ring-accent-line/20 w-full rounded-md border border-line bg-surface-2 px-3 py-2 text-text-2 placeholder-text-3 focus:border-accent-line focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50"
 						/>
 						{#if isLoadingPrice && selectedAmount > 0n}
 							<div class="absolute right-3 top-1/2 -translate-y-1/2">
@@ -1233,7 +1221,11 @@
 						{/if}
 					</div>
 					{#if selectedAmount && selectedAmount > 0n && !isLoadingPrice && !priceError}
-						<p class="mt-1 text-xs {isQuoteStale ? 'text-yellow-400' : 'text-gray-500'}">
+						<p
+							class="mt-1 text-xs {isQuoteStale
+								? 'text-amber-700 dark:text-amber-400'
+								: 'text-text-3'}"
+						>
 							{#if isQuoteStale}
 								Price may be outdated ({quoteFreshnessSeconds}s ago)
 							{:else}
@@ -1254,11 +1246,13 @@
 			</div>
 
 			<!-- Order summary -->
-			<div class={containerStyles.cardBordered}>
-				<h4 class="mb-3 text-sm font-medium text-gray-300">Order Summary</h4>
+			<div class="rounded-xl border border-line bg-overlay-1 p-4">
+				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">
+					Order Summary
+				</h4>
 				<div class="space-y-2 text-sm">
 					<div class="flex items-center justify-between">
-						<label for="market-slippage" class="text-gray-400">Slippage tolerance</label>
+						<label for="market-slippage" class="text-text-2">Slippage tolerance</label>
 						<div class="flex items-center gap-1">
 							<input
 								id="market-slippage"
@@ -1273,19 +1267,19 @@
 										e.currentTarget.blur();
 									}
 								}}
-								class="w-16 rounded border border-white/10 bg-gray-800 px-2 py-1 text-right text-sm text-gray-200 focus:border-yellow-400/50 focus:outline-none {slippageBps >
+								class="w-16 rounded border border-line bg-surface-2 px-2 py-1 text-right text-sm text-text-2 focus:border-accent-line focus:outline-none {slippageBps >
 								HIGH_SLIPPAGE_WARNING_BPS
-									? 'border-yellow-500/50 text-yellow-400'
+									? 'border-amber-500/50 text-amber-700 dark:text-amber-400'
 									: ''}"
 							/>
-							<span class="text-gray-500">%</span>
+							<span class="text-text-3">%</span>
 						</div>
 					</div>
 					{#if inputMode === 'spend'}
 						<!-- Spend mode: show spending amount first -->
 						<div class="flex justify-between">
-							<span class="text-gray-400">Spending</span>
-							<span class="font-medium">
+							<span class="text-text-2">Spending</span>
+							<span class="font-mono font-medium tabular-nums">
 								{selectedAmount
 									? parseFloat(formatUnits(selectedAmount, paymentToken?.decimals ?? 6)).toFixed(2)
 									: '0'}
@@ -1301,9 +1295,9 @@
 						     wt vs 0.01 t both round to "0.010" and the user thinks the
 						     conversion didn't happen). -->
 						<div class="flex items-start justify-between gap-3">
-							<span class="text-gray-400">{orderSide === 'Buy' ? 'Buying' : 'Selling'}</span>
+							<span class="text-text-2">{orderSide === 'Buy' ? 'Buying' : 'Selling'}</span>
 							<div class="text-right">
-								<span class="font-medium">
+								<span class="font-mono font-medium tabular-nums">
 									{(selectedAmount
 										? parseFloat(formatUnits(selectedAmount, assetToken.decimals))
 										: 0
@@ -1311,7 +1305,7 @@
 									{assetToken.symbol}
 								</span>
 								{#if showShareEquivalent}
-									<div class="text-[11px] text-gray-500">
+									<div class="text-[11px] text-text-3">
 										equivalent to {(
 											(selectedAmount
 												? parseFloat(formatUnits(selectedAmount, assetToken.decimals))
@@ -1324,7 +1318,7 @@
 						</div>
 					{/if}
 					<div class="flex items-start justify-between gap-3">
-						<span class="text-gray-400">
+						<span class="text-text-2">
 							{#if !selectedAmount || selectedAmount === 0n}
 								{orderSide === 'Buy' ? 'Best ask' : 'Best bid'}
 							{:else}
@@ -1332,7 +1326,7 @@
 							{/if}
 						</span>
 						<div class="text-right">
-							<span class="font-medium">
+							<span class="font-mono font-medium tabular-nums">
 								{#if !selectedAmount || selectedAmount === 0n}
 									{bestOrderbookPrice !== null
 										? `~${bestOrderbookPrice.toFixed(2)} ${paymentTokenSymbol}`
@@ -1351,7 +1345,7 @@
 										? displayedBestOrderbookPrice
 										: displayedMarketPrice}
 								{#if perTPrice !== null}
-									<div class="text-[11px] text-gray-500">
+									<div class="text-[11px] text-text-3">
 										equivalent to ~{perTPrice.toFixed(2)}
 										{paymentTokenSymbol} per {displayedAssetSymbol}
 									</div>
@@ -1359,10 +1353,10 @@
 							{/if}
 						</div>
 					</div>
-					<div class="mt-2 border-t border-white/10 pt-2">
+					<div class="mt-2 border-t border-line pt-2">
 						<div class="flex justify-between">
-							<span class="text-gray-400">{estimatedTradeResult.label || 'Estimated'}</span>
-							<span class={`text-lg font-semibold ${summaryAccentClass}`}>
+							<span class="text-text-2">{estimatedTradeResult.label || 'Estimated'}</span>
+							<span class={`font-mono text-lg font-semibold tabular-nums ${summaryAccentClass}`}>
 								{isLoadingPrice || priceError ? 'N/A' : estimatedTradeResult.value}
 							</span>
 						</div>
@@ -1375,7 +1369,7 @@
 						{/if}
 						{#if insufficientLiquidityWarning && !insufficientBalanceError}
 							<div
-								class="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-2 text-sm text-yellow-300"
+								class="mt-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-sm text-amber-700 dark:text-amber-300"
 							>
 								There currently isn't enough orderbook liquidity to fully fill this order. Continue
 								to fill approx. {availableLiquidityFormatted}.
@@ -1421,9 +1415,9 @@
 				data-mode="market"
 				on:click={handleMarketOrder}
 				disabled={disableDeploy}
-				class={`w-full rounded-md px-4 py-3 text-sm font-semibold transition-all ${
+				class={`w-full rounded-xl px-4 py-3 text-sm font-semibold transition-all ${
 					disableDeploy
-						? 'cursor-not-allowed bg-gray-600 text-gray-300 opacity-50'
+						? 'cursor-not-allowed bg-line-strong text-text-2 opacity-50'
 						: actionButtonClass
 				}`}
 			>
@@ -1485,26 +1479,28 @@
 		on:click={cancelHighSlippage}
 	>
 		<div
-			class="mx-4 w-full max-w-sm rounded-lg border border-yellow-500/30 bg-gray-900 p-6 shadow-xl"
+			class="mx-4 w-full max-w-sm rounded-xl border border-amber-500/30 bg-surface-1 p-6 shadow-xl"
 			on:click|stopPropagation
 		>
-			<h3 class="mb-2 text-lg font-semibold text-yellow-400">High slippage warning</h3>
-			<p class="mb-4 text-sm text-gray-300">
+			<h3 class="mb-2 text-lg font-semibold text-amber-600 dark:text-amber-400">
+				High slippage warning
+			</h3>
+			<p class="mb-4 text-sm text-text-2">
 				You are setting slippage tolerance to
-				<span class="font-semibold text-yellow-400"
+				<span class="font-mono font-semibold tabular-nums text-amber-600 dark:text-amber-400"
 					>{pendingHighSlippageBps !== null ? (pendingHighSlippageBps / 100).toFixed(2) : ''}%</span
 				>. This means your order could execute at a price significantly worse than the current
 				market price.
 			</p>
 			<div class="flex gap-3">
 				<button
-					class="flex-1 rounded-lg border border-white/10 bg-gray-800 px-4 py-2 text-sm text-gray-300 hover:bg-gray-700"
+					class="flex-1 rounded-xl border border-line bg-surface-2 px-4 py-2 text-sm text-text-2 hover:bg-surface-3"
 					on:click={cancelHighSlippage}
 				>
 					Cancel
 				</button>
 				<button
-					class="flex-1 rounded-lg bg-yellow-500/20 px-4 py-2 text-sm font-medium text-yellow-400 hover:bg-yellow-500/30"
+					class="flex-1 rounded-xl bg-amber-500/20 px-4 py-2 text-sm font-medium text-amber-700 hover:bg-amber-500/30 dark:text-amber-400"
 					on:click={confirmHighSlippage}
 				>
 					I understand, continue

--- a/src/lib/components/orders/OrdersTable.svelte
+++ b/src/lib/components/orders/OrdersTable.svelte
@@ -364,7 +364,7 @@
 			<select
 				bind:value={selectedOrdersFilter}
 				disabled={!$isAuthenticated && selectedOrdersFilter === 'my'}
-				class="rounded-md border border-white/10 bg-gray-800 px-2 py-1.5 text-xs font-medium text-gray-300 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="rounded-md border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-text-2 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 			>
 				<option value="my">My Orders</option>
 				<option value="all">All Orders</option>
@@ -374,7 +374,7 @@
 		{#if showTypeFilter}
 			<select
 				bind:value={selectedOrderTypeFilter}
-				class="rounded-md border border-white/10 bg-gray-800 px-2 py-1.5 text-xs font-medium text-gray-300 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="rounded-md border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-text-2 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 			>
 				<option value="all">All Types</option>
 				<option value="limit">Limit</option>
@@ -386,7 +386,7 @@
 
 		<select
 			bind:value={selectedDirectionFilter}
-			class="rounded-md border border-white/10 bg-gray-800 px-2 py-1.5 text-xs font-medium text-gray-300 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			class="rounded-md border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-text-2 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 		>
 			<option value="all">All Directions</option>
 			<option value="Buy">Buy</option>
@@ -398,9 +398,9 @@
 				<input
 					type="checkbox"
 					bind:checked={showClosedOrders}
-					class="h-3.5 w-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-gray-900"
+					class="h-3.5 w-3.5 rounded border-line bg-surface-3 text-blue-600 focus:ring-blue-500 focus:ring-offset-surface-1 dark:text-blue-500"
 				/>
-				<span class="text-xs text-gray-400">Closed</span>
+				<span class="text-xs text-text-2">Closed</span>
 				{#if showClosedOrders && $closedOrdersQuery.isLoading}
 					<LoadingSpinner variant="inline" size="sm" />
 				{/if}
@@ -418,15 +418,15 @@
 			Error loading orders: {errorMessage}
 		</div>
 	{:else if filteredOrders.length === 0}
-		<div class="py-8 text-center text-sm text-gray-400">
+		<div class="py-8 text-center text-sm text-text-2">
 			{selectedOrdersFilter === 'my' ? 'You have no orders' : 'No orders found'}
 		</div>
 	{:else}
 		<!-- Orders table -->
 		<div class="overflow-x-auto">
 			<table class="w-full text-sm">
-				<thead class="border-b border-white/10">
-					<tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+				<thead class="border-b border-line">
+					<tr class="text-left text-xs uppercase tracking-wide text-text-2">
 						<th class="pb-3 pr-4 font-medium">Type</th>
 						<th class="pb-3 pr-4 font-medium">Time</th>
 						{#if showTokenColumn}
@@ -437,21 +437,21 @@
 						<th class="pb-3 pr-4 font-medium">
 							Remaining
 							{#if denomination === 'unwrapped'}
-								<span class="ml-1 normal-case text-gray-500">(shares)</span>
+								<span class="ml-1 normal-case text-text-3">(shares)</span>
 							{/if}
 						</th>
 						<th class="pb-3 pr-4 font-medium">
 							Filled
 							{#if denomination === 'unwrapped'}
-								<span class="ml-1 normal-case text-gray-500">(shares)</span>
+								<span class="ml-1 normal-case text-text-3">(shares)</span>
 							{/if}
 						</th>
 						<th class="pb-3 pr-4 font-medium">
 							Price
 							{#if denomination === 'unwrapped'}
-								<span class="ml-1 normal-case text-gray-500">/ share</span>
+								<span class="ml-1 normal-case text-text-3">/ share</span>
 							{:else if wrapRatio !== 1}
-								<span class="ml-1 normal-case text-gray-500">/ token</span>
+								<span class="ml-1 normal-case text-text-3">/ token</span>
 							{/if}
 						</th>
 						<th class="pb-3 pr-4 font-medium">
@@ -471,7 +471,7 @@
 							{@const txHash = order.txHash || trade?.tradeEvent?.transaction?.id || ''}
 							<!-- For market orders: outputAmount = asset received (Buy), inputAmount = asset given (Sell) -->
 							{@const amount = order.side === 'Buy' ? order.outputAmount : order.inputAmount}
-							<tr class="border-b border-white/5 hover:bg-white/5">
+							<tr class="border-b border-line hover:bg-surface-2">
 								<td class="py-3 pr-4">
 									<span
 										class="rounded bg-purple-500/20 px-2 py-0.5 text-xs font-medium text-purple-400"
@@ -480,13 +480,13 @@
 									</span>
 								</td>
 								<td
-									class="py-3 pr-4 text-xs text-gray-400"
+									class="py-3 pr-4 text-xs text-text-2"
 									title={order.timestamp ? new Date(order.timestamp * 1000).toLocaleString() : ''}
 								>
 									{formatLocalTime(order.timestamp)}
 								</td>
 								{#if showTokenColumn}
-									<td class="py-3 pr-4 text-gray-300">{order.tokenSymbol}</td>
+									<td class="py-3 pr-4 text-text-2">{order.tokenSymbol}</td>
 								{/if}
 								<td class="py-3 pr-4">
 									<span
@@ -504,8 +504,8 @@
 										Executed
 									</span>
 								</td>
-								<td class="py-3 pr-4 text-gray-300">—</td>
-								<td class="py-3 pr-4 text-gray-300">
+								<td class="py-3 pr-4 text-text-2">—</td>
+								<td class="py-3 pr-4 text-text-2">
 									{#if amount}
 										{@const converted = displayAmount(Number(amount))}
 										{converted != null ? converted.toFixed(3) : '—'}
@@ -514,7 +514,7 @@
 									{/if}
 									{displaySymbol(order.tokenSymbol)}
 								</td>
-								<td class="py-3 pr-4 text-gray-300">
+								<td class="py-3 pr-4 text-text-2">
 									{#if order.price !== undefined && Number.isFinite(order.price)}
 										{@const px = displayPrice(order.price)}
 										{px != null ? px.toFixed(3) : '—'}
@@ -529,7 +529,7 @@
 											href={`${$currentNetwork?.blockExplorer}/tx/${txHash}`}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="hidden font-mono text-xs text-blue-400 hover:text-blue-300 hover:underline sm:inline"
+											class="hidden font-mono text-xs text-blue-600 hover:text-blue-700 hover:underline sm:inline dark:text-blue-400 dark:hover:text-blue-300"
 											title={txHash}
 										>
 											{txHash.slice(0, 8)}...{txHash.slice(-6)}
@@ -539,7 +539,7 @@
 											href={`${$currentNetwork?.blockExplorer}/tx/${txHash}`}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="inline-flex items-center justify-center text-blue-400 hover:text-blue-300 sm:hidden"
+											class="inline-flex items-center justify-center text-blue-600 hover:text-blue-700 sm:hidden dark:text-blue-400 dark:hover:text-blue-300"
 											title="View transaction"
 										>
 											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -556,7 +556,7 @@
 									{/if}
 								</td>
 								{#if selectedOrdersFilter === 'my'}
-									<td class="py-3 text-gray-500">—</td>
+									<td class="py-3 text-text-3">—</td>
 								{/if}
 							</tr>
 						{:else}
@@ -592,22 +592,22 @@
 								order.type === 'dca'
 									? 'bg-green-500/20 text-green-400'
 									: order.type === 'custom'
-										? 'bg-yellow-500/20 text-yellow-400'
-										: 'bg-blue-500/20 text-blue-400'}
-							<tr class="border-b border-white/5 hover:bg-white/5">
+										? 'bg-yellow-500/20 text-accent'
+										: 'bg-blue-500/20 text-blue-600 dark:text-blue-400'}
+							<tr class="border-b border-line hover:bg-surface-2">
 								<td class="py-3 pr-4">
 									<span class={`rounded px-2 py-0.5 text-xs font-medium ${typeClass}`}>
 										{typeLabel}
 									</span>
 								</td>
 								<td
-									class="py-3 pr-4 text-xs text-gray-400"
+									class="py-3 pr-4 text-xs text-text-2"
 									title={order.timestamp ? new Date(order.timestamp * 1000).toLocaleString() : ''}
 								>
 									{formatLocalTime(order.timestamp)}
 								</td>
 								{#if showTokenColumn}
-									<td class="py-3 pr-4 text-gray-300">{order.tokenSymbol}</td>
+									<td class="py-3 pr-4 text-text-2">{order.tokenSymbol}</td>
 								{/if}
 								<td class="py-3 pr-4">
 									<span class={`text-xs font-medium ${isBuy ? 'text-green-400' : 'text-red-400'}`}>
@@ -617,7 +617,7 @@
 								<td class="py-3 pr-4">
 									{#if isFilled && isActive}
 										<span
-											class="rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-400"
+											class="rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400"
 										>
 											Filled
 										</span>
@@ -628,14 +628,12 @@
 											Active
 										</span>
 									{:else}
-										<span
-											class="rounded bg-gray-500/20 px-2 py-0.5 text-xs font-medium text-gray-400"
-										>
+										<span class="rounded bg-overlay-2 px-2 py-0.5 text-xs font-medium text-text-2">
 											Closed
 										</span>
 									{/if}
 								</td>
-								<td class="py-3 pr-4 text-gray-300">
+								<td class="py-3 pr-4 text-text-2">
 									{#if remainingAmount === '—' || remainingAmount === 'n/a' || remainingAmount === '0'}
 										{remainingAmount}
 									{:else}
@@ -644,7 +642,7 @@
 									{/if}
 									{displaySymbol(order.tokenSymbol)}
 								</td>
-								<td class="py-3 pr-4 text-gray-300">
+								<td class="py-3 pr-4 text-text-2">
 									{#if order.filled !== undefined && order.filled > 0}
 										{@const conv = displayAmount(order.filled)}
 										{(conv ?? order.filled).toFixed(3)}
@@ -653,7 +651,7 @@
 										—
 									{/if}
 								</td>
-								<td class="py-3 pr-4 text-gray-300">
+								<td class="py-3 pr-4 text-text-2">
 									{#if order.price !== undefined && order.price !== null && Number.isFinite(order.price)}
 										{@const px = displayPrice(order.price)}
 										{px != null ? px.toFixed(3) : '—'}
@@ -673,7 +671,7 @@
 											href={raindexUrl}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="hidden font-mono text-xs text-blue-400 hover:text-blue-300 hover:underline sm:inline"
+											class="hidden font-mono text-xs text-blue-600 hover:text-blue-700 hover:underline sm:inline dark:text-blue-400 dark:hover:text-blue-300"
 											title={quote.orderHash}
 										>
 											{quote.orderHash.slice(0, 8)}...{quote.orderHash.slice(-6)}
@@ -683,7 +681,7 @@
 											href={raindexUrl}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="inline-flex items-center justify-center text-blue-400 hover:text-blue-300 sm:hidden"
+											class="inline-flex items-center justify-center text-blue-600 hover:text-blue-700 sm:hidden dark:text-blue-400 dark:hover:text-blue-300"
 											title="View on Raindex"
 										>
 											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -758,8 +756,8 @@
 						type="button"
 						class={`h-8 w-8 rounded-md text-sm font-medium transition ${
 							pageNum === currentPage
-								? 'bg-blue-500 text-white'
-								: 'bg-white/5 text-gray-400 hover:bg-white/10'
+								? 'bg-blue-500 text-text'
+								: 'bg-surface-2 text-text-2 hover:bg-surface-2'
 						}`}
 						on:click={() => {
 							currentPage = pageNum;

--- a/src/lib/components/referrals/ReferralButton.svelte
+++ b/src/lib/components/referrals/ReferralButton.svelte
@@ -82,7 +82,7 @@
 
 		<!-- Inner background -->
 		<span
-			class="pointer-events-none absolute inset-[1px] z-0 rounded-[7px] bg-gradient-to-r from-gray-900 via-purple-950/60 to-gray-900 transition-all group-hover:from-gray-800 group-hover:via-purple-900/70 group-hover:to-gray-800"
+			class="pointer-events-none absolute inset-[1px] z-0 rounded-[7px] bg-gradient-to-r from-bg via-iris-500/60 to-bg transition-all group-hover:from-surface-1 group-hover:via-iris-500/70 group-hover:to-surface-1"
 		></span>
 
 		<!-- Animated users icon -->
@@ -90,7 +90,7 @@
 			<!-- Glow behind icon -->
 			<span class="icon-glow absolute"></span>
 			<svg
-				class="relative h-4 w-4 text-purple-300 transition-all group-hover:scale-110 group-hover:text-purple-200"
+				class="relative h-4 w-4 text-iris transition-all group-hover:scale-110 group-hover:text-iris"
 				fill="none"
 				stroke="currentColor"
 				viewBox="0 0 24 24"
@@ -106,23 +106,21 @@
 
 		{#if $referralLoading}
 			<div
-				class="relative z-10 h-4 w-4 animate-spin rounded-full border-2 border-gray-500 border-t-purple-400"
+				class="relative z-10 h-4 w-4 animate-spin rounded-full border-2 border-line-strong border-t-iris"
 			></div>
-			<span class="relative z-10 text-gray-400">Loading...</span>
+			<span class="relative z-10 text-text-2">Loading...</span>
 		{:else if $referralProfile && $referralPerformance}
 			<div class="relative z-10 flex items-center gap-2">
-				<span class="font-semibold text-white">Referral</span>
-				<span class="text-xs font-medium text-yellow-300">
+				<span class="font-semibold text-text">Referral</span>
+				<span class="text-xs font-medium text-accent">
 					{formatPoints($referralPerformance.totalPoints)} pts
 				</span>
 			</div>
 		{:else}
 			<!-- Join CTA - more prominent -->
 			<div class="relative z-10 flex items-center gap-2">
-				<span class="font-semibold text-white">Referral</span>
-				<span
-					class="join-badge rounded-md bg-purple-500/30 px-2 py-0.5 text-xs font-bold text-purple-200"
-				>
+				<span class="font-semibold text-text">Referral</span>
+				<span class="join-badge rounded-md bg-iris-500/30 px-2 py-0.5 text-xs font-bold text-iris">
 					Join Now
 				</span>
 			</div>
@@ -132,26 +130,25 @@
 	<!-- Hover Tooltip -->
 	{#if showTooltip && $referralProfile && $referralPerformance}
 		<div
-			class="absolute right-0 top-full z-[200] mt-2 w-52 rounded-lg border border-gray-700 bg-gray-800 p-3 shadow-xl"
+			class="absolute right-0 top-full z-[200] mt-2 w-52 rounded-lg border border-line-strong bg-surface-1 p-3 shadow-xl"
 		>
 			<div class="space-y-2 text-sm">
 				<div class="flex justify-between">
-					<span class="text-gray-400">Wallets Referred</span>
-					<span class="font-medium text-white">{$referralPerformance.walletsReferred}</span>
+					<span class="text-text-2">Wallets Referred</span>
+					<span class="font-medium text-text">{$referralPerformance.walletsReferred}</span>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">Points</span>
-					<span class="font-medium text-yellow-300"
+					<span class="text-text-2">Points</span>
+					<span class="font-medium text-accent"
 						>{formatPoints($referralPerformance.totalPoints)}</span
 					>
 				</div>
 				<div class="flex justify-between">
-					<span class="text-gray-400">Est. Reward</span>
-					<span class="font-medium text-green-400"
-						>{formatUsd($referralPerformance.projectedRewards)}</span
+					<span class="text-text-2">Est. Reward</span>
+					<span class="font-medium text-up">{formatUsd($referralPerformance.projectedRewards)}</span
 					>
 				</div>
-				<div class="border-t border-gray-700 pt-2 text-xs text-gray-500">
+				<div class="border-t border-line-strong pt-2 text-xs text-text-3">
 					Earn rewards when your friends invest
 				</div>
 			</div>

--- a/src/lib/components/referrals/ReferralDashboardModal.svelte
+++ b/src/lib/components/referrals/ReferralDashboardModal.svelte
@@ -467,7 +467,7 @@
 
 						<!-- Info Box -->
 						<div
-							class="rounded-lg border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200"
+							class="rounded-lg border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-600 dark:text-blue-200"
 						>
 							<p>
 								Your rewards are equal to 50% of the rewards received by wallets that sign up using

--- a/src/lib/components/referrals/ReferralJoinModal.svelte
+++ b/src/lib/components/referrals/ReferralJoinModal.svelte
@@ -137,7 +137,7 @@
 	<div class="fixed inset-0 z-[201] flex items-center justify-center p-4">
 		<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 		<div
-			class="w-full max-w-md overflow-hidden rounded-xl border border-gray-700 bg-gray-800 shadow-2xl"
+			class="w-full max-w-md overflow-hidden rounded-xl border border-line-strong bg-surface-1 shadow-2xl"
 			on:click|stopPropagation
 			on:keydown|stopPropagation
 			role="dialog"
@@ -145,13 +145,13 @@
 			aria-labelledby="join-modal-title"
 		>
 			<!-- Header -->
-			<div class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
-				<h2 id="join-modal-title" class="text-lg font-semibold text-white">
+			<div class="flex items-center justify-between border-b border-line-strong px-6 py-4">
+				<h2 id="join-modal-title" class="text-lg font-semibold text-text">
 					{success ? 'Welcome to the Referral Programme!' : 'Join Referral Programme'}
 				</h2>
 				<button
 					on:click={closeModal}
-					class="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+					class="rounded-lg p-1 text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path
@@ -170,14 +170,9 @@
 					<!-- Success state -->
 					<div class="space-y-4 text-center">
 						<div
-							class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-500/20"
+							class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-accent-soft"
 						>
-							<svg
-								class="h-8 w-8 text-green-400"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
+							<svg class="h-8 w-8 text-up" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path
 									stroke-linecap="round"
 									stroke-linejoin="round"
@@ -188,14 +183,14 @@
 						</div>
 
 						<div>
-							<p class="text-gray-300">Your referral code is:</p>
+							<p class="text-text-2">Your referral code is:</p>
 							<div class="mt-2 flex items-center justify-center gap-2">
-								<code class="rounded-lg bg-gray-700 px-4 py-2 font-mono text-lg text-yellow-400">
+								<code class="rounded-lg bg-surface-2 px-4 py-2 font-mono text-lg text-accent">
 									{generatedCode}
 								</code>
 								<button
 									on:click={copyCode}
-									class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+									class="rounded-lg p-2 text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 									title="Copy code"
 								>
 									<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -210,7 +205,7 @@
 							</div>
 						</div>
 
-						<p class="text-sm text-gray-400">
+						<p class="text-sm text-text-2">
 							Share this code with friends. You'll earn 50% of the projected rewards from wallets
 							that sign up using your code.
 						</p>
@@ -220,21 +215,19 @@
 				{:else}
 					<!-- Join form -->
 					<div class="space-y-4">
-						<p class="text-sm text-gray-300">
+						<p class="text-sm text-text-2">
 							Join our referral programme to earn rewards when others sign up using your code.
 						</p>
 
 						{#if error}
-							<div
-								class="rounded-md border border-red-900/40 bg-red-900/20 p-3 text-sm text-red-300"
-							>
+							<div class="rounded-md border border-down bg-down-soft p-3 text-sm text-down">
 								{error}
 							</div>
 						{/if}
 
 						<!-- Telegram handle input -->
 						<div class="space-y-2">
-							<label for="telegram-handle" class="text-sm font-medium text-gray-300">
+							<label for="telegram-handle" class="text-sm font-medium text-text-2">
 								Telegram Handle
 							</label>
 							<input
@@ -243,20 +236,18 @@
 								bind:value={telegramHandle}
 								disabled={submitting}
 								placeholder="@username"
-								class="w-full rounded-lg border px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {telegramValid
-									? 'border-gray-700 bg-gray-800 focus:border-yellow-500 focus:ring-yellow-500'
-									: 'border-red-500 bg-gray-800 focus:border-red-500 focus:ring-red-500'}"
+								class="w-full rounded-lg border px-3 py-2 text-text placeholder-text-3 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {telegramValid
+									? 'border-line-strong bg-surface-1 focus:border-accent focus:ring-accent'
+									: 'border-down bg-surface-1 focus:border-down focus:ring-down'}"
 							/>
 							{#if !telegramValid}
-								<p class="text-xs text-red-400">
-									Invalid format. Must start with @ (e.g., @username)
-								</p>
+								<p class="text-xs text-down">Invalid format. Must start with @ (e.g., @username)</p>
 							{/if}
 						</div>
 
 						<!-- Nickname input -->
 						<div class="space-y-2">
-							<label for="nickname" class="text-sm font-medium text-gray-300">
+							<label for="nickname" class="text-sm font-medium text-text-2">
 								Leaderboard Nickname
 							</label>
 							<input
@@ -265,16 +256,16 @@
 								bind:value={nickname}
 								disabled={submitting}
 								placeholder="Your display name"
-								class="w-full rounded-lg border px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {nicknameValid
-									? 'border-gray-700 bg-gray-800 focus:border-yellow-500 focus:ring-yellow-500'
-									: 'border-red-500 bg-gray-800 focus:border-red-500 focus:ring-red-500'}"
+								class="w-full rounded-lg border px-3 py-2 text-text placeholder-text-3 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 {nicknameValid
+									? 'border-line-strong bg-surface-1 focus:border-accent focus:ring-accent'
+									: 'border-down bg-surface-1 focus:border-down focus:ring-down'}"
 							/>
 							{#if !nicknameValid}
-								<p class="text-xs text-red-400">
+								<p class="text-xs text-down">
 									3-20 characters, letters, numbers, and underscores only
 								</p>
 							{:else}
-								<p class="text-xs text-gray-500">
+								<p class="text-xs text-text-3">
 									This will be displayed publicly on the leaderboard
 								</p>
 							{/if}
@@ -298,7 +289,7 @@
 							{/if}
 						</Button>
 
-						<p class="text-center text-xs text-gray-500">
+						<p class="text-center text-xs text-text-3">
 							You'll sign a message to verify wallet ownership
 						</p>
 					</div>

--- a/src/lib/components/referrals/ReferralLeaderboardModal.svelte
+++ b/src/lib/components/referrals/ReferralLeaderboardModal.svelte
@@ -83,7 +83,7 @@
 	<div class="fixed inset-0 z-[201] flex items-center justify-center p-4">
 		<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 		<div
-			class="w-full max-w-md overflow-hidden rounded-xl border border-gray-700 bg-gray-800 shadow-2xl"
+			class="w-full max-w-md overflow-hidden rounded-xl border border-line-strong bg-surface-1 shadow-2xl"
 			on:click|stopPropagation
 			on:keydown|stopPropagation
 			role="dialog"
@@ -91,13 +91,11 @@
 			aria-labelledby="leaderboard-title"
 		>
 			<!-- Header -->
-			<div class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
-				<h2 id="leaderboard-title" class="text-lg font-semibold text-white">
-					Referral Leaderboard
-				</h2>
+			<div class="flex items-center justify-between border-b border-line-strong px-6 py-4">
+				<h2 id="leaderboard-title" class="text-lg font-semibold text-text">Referral Leaderboard</h2>
 				<button
 					on:click={closeModal}
-					class="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+					class="rounded-lg p-1 text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 					aria-label="Close"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -116,12 +114,12 @@
 				{#if $referralLeaderboardLoading}
 					<div class="flex items-center justify-center py-12">
 						<div
-							class="h-8 w-8 animate-spin rounded-full border-2 border-gray-600 border-t-yellow-400"
+							class="h-8 w-8 animate-spin rounded-full border-2 border-line-strong border-t-accent"
 						></div>
 					</div>
 				{:else if hasData}
 					<!-- Table Header -->
-					<div class="mb-2 grid grid-cols-12 gap-2 px-4 text-xs font-medium text-gray-400">
+					<div class="mb-2 grid grid-cols-12 gap-2 px-4 text-xs font-medium text-text-2">
 						<div class="col-span-1">#</div>
 						<div class="col-span-4">Nickname</div>
 						<div class="col-span-2 text-right">Refs</div>
@@ -137,8 +135,8 @@
 								: $referralProfile && entry.nickname === $referralProfile.nickname}
 							<div
 								class="grid grid-cols-12 items-center gap-2 rounded-lg px-4 py-3 {isUser
-									? 'border border-yellow-500/50 bg-yellow-500/10'
-									: 'bg-gray-700/50'}"
+									? 'border border-accent-line bg-accent-soft'
+									: 'bg-surface-2/50'}"
 							>
 								<!-- Rank -->
 								<div class="col-span-1">
@@ -146,43 +144,41 @@
 										<span
 											class="flex h-6 w-6 items-center justify-center rounded-full text-sm font-bold
 											{entry.rank === 1
-												? 'bg-yellow-500 text-gray-900'
+												? 'bg-accent text-text'
 												: entry.rank === 2
-													? 'bg-gray-300 text-gray-900'
-													: 'bg-amber-600 text-white'}"
+													? 'bg-surface-3 text-text'
+													: 'bg-accent text-text'}"
 										>
 											{getMedal(entry.rank)}
 										</span>
 									{:else}
-										<span class="text-sm text-gray-400">#{entry.rank}</span>
+										<span class="text-sm text-text-2">#{entry.rank}</span>
 									{/if}
 								</div>
 
 								<!-- Nickname -->
 								<div class="col-span-4">
-									<p
-										class="truncate text-sm font-medium {isUser ? 'text-yellow-400' : 'text-white'}"
-									>
+									<p class="truncate text-sm font-medium {isUser ? 'text-accent' : 'text-text'}">
 										{entry.nickname}
 									</p>
 									{#if isUser}
-										<p class="text-xs text-yellow-400/70">You</p>
+										<p class="text-xs text-accent">You</p>
 									{/if}
 								</div>
 
 								<!-- Wallets Referred -->
 								<div class="col-span-2 text-right">
-									<span class="text-sm text-gray-300">{entry.walletsReferred}</span>
+									<span class="text-sm text-text-2">{entry.walletsReferred}</span>
 								</div>
 
 								<!-- Points -->
 								<div class="col-span-3 text-right">
 									<span
 										class="text-sm font-medium {isUser
-											? 'text-yellow-400'
+											? 'text-accent'
 											: entry.rank <= 3
-												? 'text-yellow-400'
-												: 'text-white'}"
+												? 'text-accent'
+												: 'text-text'}"
 									>
 										{formatPoints(entry.totalPoints)}
 									</span>
@@ -190,7 +186,7 @@
 
 								<!-- Projected Rewards -->
 								<div class="col-span-2 text-right">
-									<span class="text-sm text-green-400">
+									<span class="text-sm text-up">
 										{formatUsd(entry.projectedRewards)}
 									</span>
 								</div>
@@ -200,15 +196,15 @@
 
 					<!-- Stats Summary -->
 					<div
-						class="mt-4 flex items-center justify-between rounded-lg bg-gray-700/30 px-4 py-3 text-sm"
+						class="mt-4 flex items-center justify-between rounded-lg bg-surface-2/30 px-4 py-3 text-sm"
 					>
-						<span class="text-gray-400">Total participants</span>
-						<span class="font-medium text-white">{$referralTotalParticipants}</span>
+						<span class="text-text-2">Total participants</span>
+						<span class="font-medium text-text">{$referralTotalParticipants}</span>
 					</div>
 				{:else}
 					<div class="py-12 text-center">
 						<svg
-							class="mx-auto h-12 w-12 text-gray-600"
+							class="mx-auto h-12 w-12 text-text-muted"
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -220,8 +216,8 @@
 								d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
 							/>
 						</svg>
-						<p class="mt-4 text-gray-400">No referrers yet.</p>
-						<p class="text-sm text-gray-500">Be the first to join the referral programme!</p>
+						<p class="mt-4 text-text-2">No referrers yet.</p>
+						<p class="text-sm text-text-3">Be the first to join the referral programme!</p>
 					</div>
 				{/if}
 			</div>

--- a/src/lib/components/referrals/ReferralLeaderboardModal.svelte
+++ b/src/lib/components/referrals/ReferralLeaderboardModal.svelte
@@ -196,7 +196,7 @@
 
 					<!-- Stats Summary -->
 					<div
-						class="mt-4 flex items-center justify-between rounded-lg bg-surface-2/30 px-4 py-3 text-sm"
+						class="bg-surface-2/30 mt-4 flex items-center justify-between rounded-lg px-4 py-3 text-sm"
 					>
 						<span class="text-text-2">Total participants</span>
 						<span class="font-medium text-text">{$referralTotalParticipants}</span>

--- a/src/lib/components/ui/AssetDisc.svelte
+++ b/src/lib/components/ui/AssetDisc.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" context="module">
+	// Deterministic brand-ish gradient discs for asset rows, ported from the v2
+	// handoff (`src2/atoms.jsx` → AssetDisc). USDC gets blue + "$". Everything else
+	// derives a two-stop gradient from a per-ticker table (falling back to neutral).
+	const ASSET_COLORS: Record<string, [string, string]> = {
+		tNVDA: ['#9aa6ff', '#4d3bd8'],
+		tTSLA: ['#ff8d8d', '#d83b3b'],
+		tCOIN: ['#6fa8ff', '#1a56db'],
+		tMSTR: ['#ffb877', '#f08a1d'],
+		tAAPL: ['#cfd6df', '#8a94a3'],
+		tMETA: ['#6fb3ff', '#2b6fe0'],
+		tSPYM: ['#ff9d6f', '#e0512b'],
+		tQQQM: ['#7fd1ff', '#1d8fe0'],
+		tSIVR: ['#cdd6e0', '#8a98a8'],
+		tCRCL: ['#7fffd6', '#10b981'],
+		tAMZN: ['#ffcf6f', '#e0a020'],
+		tIAU: ['#ffe08a', '#e0b820'],
+		tARKK: ['#b89dff', '#6d3bd8'],
+		tPPLT: ['#cdd6e0', '#7a8898'],
+		tVWO: ['#7fc1ff', '#2b7fe0'],
+		tBMNR: ['#ff9d8a', '#e0512b'],
+		USDC: ['#4aa0f5', '#2775CA']
+	};
+</script>
+
+<script lang="ts">
+	/** Token symbol, with or without a `w`/`t` prefix (e.g. `wtNVDA`, `tNVDA`, `USDC`). */
+	export let sym: string;
+	export let size = 32;
+	export let ring = false;
+
+	$: normalized = sym.replace(/^w/, '');
+	$: isUsdc = sym === 'USDC';
+	$: colors = ASSET_COLORS[normalized] ?? ['#9aa9bb', '#5c6a7c'];
+	$: letters = isUsdc ? '$' : normalized.replace(/^t/, '').slice(0, 2).toUpperCase();
+	$: boxShadow = ring ? '0 0 0 3px rgba(45,227,166,.18)' : 'inset 0 1px 0 rgba(255,255,255,.25)';
+</script>
+
+<div
+	class="relative flex shrink-0 items-center justify-center rounded-full font-bold text-white"
+	style="width:{size}px;height:{size}px;font-size:{size *
+		0.36}px;background:radial-gradient(circle at 30% 25%, {colors[0]}, {colors[1]});box-shadow:{boxShadow};"
+>
+	{letters}
+</div>

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	export let dataTestId: string = '';
-	export let variant: 'primary' | 'secondary' | 'danger' | 'ghost' = 'secondary';
+	export let variant: 'primary' | 'secondary' | 'danger' | 'ghost' | 'quiet' = 'secondary';
 	export let size: 'sm' | 'md' | 'lg' = 'md';
 	export let fullWidth: boolean = false;
 	export let className: string = '';
@@ -9,10 +9,12 @@
 	const dispatch = createEventDispatcher<{ click: MouseEvent }>();
 
 	const variantClass = {
-		primary: 'bg-gradient-to-r from-blue-600 to-purple-700 text-white hover:opacity-90',
-		secondary: 'bg-white/10 text-white hover:bg-white/20',
-		danger: 'bg-red-600/80 text-white hover:bg-red-600',
-		ghost: 'bg-transparent text-white border border-white/10 hover:bg-white/10'
+		primary:
+			'bg-gradient-to-b from-accent-bright to-accent text-accent-ink shadow-[0_10px_30px_-10px_var(--accent-glow)] hover:brightness-105',
+		secondary: 'bg-surface-2 text-text border border-line-strong hover:bg-surface-3',
+		danger: 'bg-down text-white hover:brightness-110',
+		ghost: 'bg-transparent text-text border border-line hover:bg-surface-2',
+		quiet: 'bg-transparent text-text-2 hover:bg-surface-2 hover:text-text'
 	}[variant];
 
 	const sizeClass = {
@@ -27,8 +29,8 @@
 	{...$$restProps}
 	on:click={(e) => dispatch('click', e)}
 	data-testid={dataTestId}
-	class={'inline-flex min-h-10 items-center justify-center gap-2 rounded-lg font-semibold transition-colors ' +
-		'focus:outline-none focus:ring-2 focus:ring-yellow-500/30 disabled:cursor-not-allowed disabled:opacity-50 ' +
+	class={'inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition ' +
+		'focus:outline-none focus:ring-2 focus:ring-accent-line disabled:cursor-not-allowed disabled:opacity-50 ' +
 		variantClass +
 		' ' +
 		sizeClass +

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	export let className: string = '';
-	export let paddingClass: string = 'p-3 sm:p-4 lg:p-5';
+	export let paddingClass: string = 'p-5';
 	export let showGradient: boolean = false;
+	// Top-hairline visibility: 'hover' (default, fades in on hover), 'static'
+	// (always shown), or 'none'. Only applies when showGradient is true.
+	export let hairline: 'hover' | 'static' | 'none' = 'hover';
 </script>
 
-<div class={'group relative overflow-hidden rounded-xl ' + className + ' ' + paddingClass}>
-	{#if showGradient}
+<div
+	class={'group relative overflow-hidden rounded-2xl border border-line bg-surface-1 shadow-[var(--shadow-2)] ' +
+		paddingClass +
+		(className ? ' ' + className : '')}
+>
+	{#if showGradient && hairline !== 'none'}
 		<div
-			class="absolute left-0 right-0 top-0 h-0.5 bg-gradient-to-r from-purple-700 via-blue-600 to-yellow-500 opacity-0 transition-opacity group-hover:opacity-100"
-		/>
+			class={'absolute left-0 right-0 top-0 h-0.5 bg-gradient-to-r from-accent-bright via-accent to-accent-deep transition-opacity ' +
+				(hairline === 'static' ? 'opacity-60' : 'opacity-0 group-hover:opacity-100')}
+		></div>
 	{/if}
 	<slot />
 </div>

--- a/src/lib/components/ui/EmptyState.svelte
+++ b/src/lib/components/ui/EmptyState.svelte
@@ -10,26 +10,26 @@
 
 <div
 	class={'text-center ' +
-		(showBorder ? 'rounded-lg border border-white/10 bg-gray-800/50 p-8' : 'py-12') +
+		(showBorder ? 'bg-surface-2/50 rounded-lg border border-line p-8' : 'py-12') +
 		' ' +
 		className}
 >
 	{#if icon}
 		<div class="mb-4 flex justify-center">
-			<div class="rounded-full bg-gray-800/50 p-4">
-				<svelte:component this={icon} class="h-8 w-8 text-gray-500" />
+			<div class="bg-surface-2/50 rounded-full p-4">
+				<svelte:component this={icon} class="h-8 w-8 text-text-3" />
 			</div>
 		</div>
 	{/if}
 
 	{#if title}
-		<h3 class="mb-2 text-lg font-semibold text-gray-400 sm:text-xl">{title}</h3>
+		<h3 class="mb-2 text-lg font-semibold text-text-2 sm:text-xl">{title}</h3>
 	{/if}
 
 	{#if description}
-		<p class="text-sm text-gray-500 sm:text-base">{description}</p>
+		<p class="text-sm text-text-3 sm:text-base">{description}</p>
 	{:else if !title}
-		<p class="text-gray-400"><slot /></p>
+		<p class="text-text-2"><slot /></p>
 	{/if}
 
 	{#if $$slots.action}

--- a/src/lib/components/ui/Icon.svelte
+++ b/src/lib/components/ui/Icon.svelte
@@ -1,0 +1,112 @@
+<script lang="ts" context="module">
+	// Canonical app-wide line-icon set, ported verbatim from the v2 design handoff
+	// (`src2/atoms.jsx` → Icon). viewBox 0 0 24 24, currentColor, round caps. Use
+	// this everywhere instead of mixed icon libraries so glyphs match the mock.
+	export type IconName =
+		| 'unlock'
+		| 'bank'
+		| 'bolt'
+		| 'shield'
+		| 'sprout'
+		| 'check'
+		| 'close'
+		| 'info'
+		| 'plus'
+		| 'minus'
+		| 'clock'
+		| 'arrowRight'
+		| 'arrowUpRight'
+		| 'arrowDown'
+		| 'chevronDown'
+		| 'trendUp'
+		| 'wallet'
+		| 'blocks'
+		| 'coins'
+		| 'chart'
+		| 'lock'
+		| 'swap'
+		| 'home';
+</script>
+
+<script lang="ts">
+	export let name: IconName;
+	export let className = 'h-5 w-5';
+	export let stroke = 1.6;
+</script>
+
+<svg
+	viewBox="0 0 24 24"
+	class={className}
+	fill="none"
+	stroke="currentColor"
+	stroke-width={stroke}
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	aria-hidden="true"
+>
+	{#if name === 'shield'}
+		<path d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
+	{:else if name === 'home'}
+		<path d="M4 11.5L12 4l8 7.5" />
+		<path d="M6 10v9.5h12V10" />
+	{:else if name === 'unlock'}
+		<rect x="4.5" y="11" width="15" height="9" rx="1.5" />
+		<path d="M8 11V8a4 4 0 017.4-2" />
+	{:else if name === 'bolt'}
+		<path d="M13 3L5 13h6l-1 8 8-10h-6l1-8z" />
+	{:else if name === 'blocks'}
+		<rect x="3.5" y="3.5" width="7" height="7" rx="1" />
+		<rect x="13.5" y="3.5" width="7" height="7" rx="1" />
+		<rect x="3.5" y="13.5" width="7" height="7" rx="1" />
+		<rect x="13.5" y="13.5" width="7" height="7" rx="1" />
+	{:else if name === 'bank'}
+		<path d="M3 9l9-5 9 5" />
+		<path d="M5 9v8M19 9v8M9 9v8M15 9v8" />
+		<path d="M3 20h18" />
+	{:else if name === 'sprout'}
+		<path d="M12 20v-8" />
+		<path d="M12 12c0-3 2.5-5 6-5 0 3-2.5 5-6 5z" />
+		<path d="M12 13c0-2.5-2-4.5-5-4.5 0 2.5 2 4.5 5 4.5z" />
+	{:else if name === 'check'}
+		<path d="M5 13l4 4L19 7" />
+	{:else if name === 'close'}
+		<path d="M6 6l12 12M6 18L18 6" />
+	{:else if name === 'info'}
+		<circle cx="12" cy="12" r="9" />
+		<path d="M12 11v5M12 8h.01" />
+	{:else if name === 'plus'}
+		<path d="M12 5v14M5 12h14" />
+	{:else if name === 'minus'}
+		<path d="M5 12h14" />
+	{:else if name === 'coins'}
+		<ellipse cx="9" cy="7" rx="5.5" ry="2.5" />
+		<path d="M3.5 7v5c0 1.4 2.5 2.5 5.5 2.5" />
+		<path d="M3.5 12v3c0 1.4 2.5 2.5 5.5 2.5" />
+		<ellipse cx="15" cy="14" rx="5.5" ry="2.5" />
+		<path d="M9.5 14.5v5c0 1.4 2.5 2.5 5.5 2.5s5.5-1.1 5.5-2.5v-5" />
+	{:else if name === 'chart'}
+		<path d="M4 4v16h16" />
+		<path d="M7 14l3-3 3 2 5-6" />
+	{:else if name === 'lock'}
+		<rect x="4.5" y="11" width="15" height="9" rx="1.5" />
+		<path d="M8 11V8a4 4 0 018 0v3" />
+	{:else if name === 'clock'}
+		<circle cx="12" cy="12" r="9" />
+		<path d="M12 7v5l3 2" />
+	{:else if name === 'wallet'}
+		<rect x="3" y="6" width="18" height="13" rx="2" />
+		<path d="M3 10h18M16 14h2" />
+	{:else if name === 'swap'}
+		<path d="M7 8h11l-3-3M17 16H6l3 3" />
+	{:else if name === 'arrowRight'}
+		<path d="M5 12h14M13 6l6 6-6 6" />
+	{:else if name === 'arrowUpRight'}
+		<path d="M7 17L17 7M9 7h8v8" />
+	{:else if name === 'arrowDown'}
+		<path d="M12 5v14M6 13l6 6 6-6" />
+	{:else if name === 'chevronDown'}
+		<path d="M6 9l6 6 6-6" />
+	{:else if name === 'trendUp'}
+		<path d="M3 17l6-6 4 4 8-8M21 7h-5m5 0v5" />
+	{/if}
+</svg>

--- a/src/lib/components/ui/Icon.svelte
+++ b/src/lib/components/ui/Icon.svelte
@@ -36,7 +36,7 @@
 
 <svg
 	viewBox="0 0 24 24"
-	class={className}
+	class="icon-{name} {className}"
 	fill="none"
 	stroke="currentColor"
 	stroke-width={stroke}
@@ -97,7 +97,9 @@
 		<rect x="3" y="6" width="18" height="13" rx="2" />
 		<path d="M3 10h18M16 14h2" />
 	{:else if name === 'swap'}
-		<path d="M7 8h11l-3-3M17 16H6l3 3" />
+		<!-- Two separate paths so the arrows can animate independently on hover. -->
+		<path d="M7 8h11l-3-3" />
+		<path d="M17 16H6l3 3" />
 	{:else if name === 'arrowRight'}
 		<path d="M5 12h14M13 6l6 6-6 6" />
 	{:else if name === 'arrowUpRight'}

--- a/src/lib/components/ui/InfoBlock.svelte
+++ b/src/lib/components/ui/InfoBlock.svelte
@@ -8,14 +8,14 @@
 		info: {
 			borderClass: 'border-blue-500/30',
 			bgClass: 'bg-blue-500/10',
-			iconClass: 'text-blue-400',
-			titleClass: 'text-blue-400'
+			iconClass: 'text-blue-600 dark:text-blue-400',
+			titleClass: 'text-blue-600 dark:text-blue-400'
 		},
 		warning: {
-			borderClass: 'border-yellow-500/30',
-			bgClass: 'bg-yellow-500/10',
-			iconClass: 'text-yellow-400',
-			titleClass: 'text-yellow-400'
+			borderClass: 'border-amber-500/30',
+			bgClass: 'bg-amber-500/10',
+			iconClass: 'text-amber-300',
+			titleClass: 'text-amber-300'
 		},
 		success: {
 			borderClass: 'border-green-500/30',
@@ -104,11 +104,11 @@
 		{/if}
 
 		{#if description}
-			<div class={'text-sm text-gray-300 ' + (title ? 'mt-1' : '')}>
+			<div class={'text-sm text-text-2 ' + (title ? 'mt-1' : '')}>
 				{description}
 			</div>
 		{:else}
-			<div class={'text-sm text-gray-300 ' + (title ? 'mt-1' : '')}>
+			<div class={'text-sm text-text-2 ' + (title ? 'mt-1' : '')}>
 				<slot />
 			</div>
 		{/if}

--- a/src/lib/components/ui/Input.svelte
+++ b/src/lib/components/ui/Input.svelte
@@ -51,12 +51,12 @@
 
 <div class="flex w-full flex-col gap-2">
 	<div
-		class="flex h-full w-full items-center justify-end text-white transition-colors focus-within:outline-none {noBorder
+		class="flex h-full w-full items-center justify-end text-text transition-colors focus-within:outline-none {noBorder
 			? 'bg-transparent'
-			: 'rounded-lg border border-white/10 bg-gray-700/50 focus-within:border-yellow-500/50'}"
+			: 'bg-surface-3/50 rounded-lg border border-line focus-within:border-accent-line'}"
 	>
 		<input
-			class="mr-2 w-full min-w-0 rounded border-none bg-transparent px-4 py-3 text-left text-base text-white outline-none [appearance:textfield] focus:ring-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+			class="mr-2 w-full min-w-0 rounded border-none bg-transparent px-4 py-3 text-left text-base text-text outline-none [appearance:textfield] focus:ring-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
 			{...$$restProps}
 			on:input={handleInput}
 			min={0}
@@ -69,7 +69,7 @@
 		{#if unit}
 			<span
 				data-testid="unit"
-				class="h-full content-center self-center bg-transparent pr-4 text-left text-base text-white sm:text-lg"
+				class="h-full content-center self-center bg-transparent pr-4 text-left text-base text-text sm:text-lg"
 			>
 				{unit}</span
 			>
@@ -79,7 +79,7 @@
 				disabled={!$walletAddress}
 				data-testid={'set-val-to-max'}
 				on:click={setValueToMax}
-				class="flex cursor-pointer items-center self-stretch border-l border-white/10 bg-transparent pl-3 pr-4 text-sm text-white transition-colors hover:bg-gray-600/50 sm:text-base"
+				class="flex cursor-pointer items-center self-stretch border-l border-line bg-transparent pl-3 pr-4 text-sm text-text transition-colors hover:bg-surface-2 sm:text-base"
 				>MAX</button
 			>
 		{/if}

--- a/src/lib/components/ui/MetricCard.svelte
+++ b/src/lib/components/ui/MetricCard.svelte
@@ -4,17 +4,17 @@
 	export let value: string;
 	export let change: string = '';
 	// New customization props with sensible defaults
-	export let valueClass: string = 'text-lg font-bold sm:text-xl lg:text-2xl';
-	export let changeClass: string = 'text-xs font-medium text-yellow-500 sm:text-sm';
+	export let valueClass: string = 'font-mono text-lg font-bold sm:text-xl lg:text-2xl';
+	export let changeClass: string = 'text-xs font-medium text-accent sm:text-sm';
 	export let icon: string | null = null; // allow custom icon character or null
-	export let cardClass: string = '';
+	export let cardClass: string = 'bg-overlay-1';
 	export let showGradient: boolean | undefined = undefined;
 	export let paddingClass: string | undefined = undefined;
 	export let subtitle: string = '';
 </script>
 
 <Card className={cardClass} {showGradient} {paddingClass}>
-	<div class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">{label}</div>
+	<div class="mb-2 text-xs font-medium uppercase tracking-wide text-text-2">{label}</div>
 	<div class="mb-2">
 		<span class={'block ' + valueClass}>{value}</span>
 	</div>
@@ -25,6 +25,6 @@
 		</div>
 	{/if}
 	{#if subtitle}
-		<div class="mt-2 text-sm text-gray-500">{subtitle}</div>
+		<div class="mt-2 text-sm text-text-3">{subtitle}</div>
 	{/if}
 </Card>

--- a/src/lib/components/ui/MetricCard.svelte
+++ b/src/lib/components/ui/MetricCard.svelte
@@ -13,7 +13,7 @@
 	export let subtitle: string = '';
 </script>
 
-<Card className={cardClass} {showGradient} {paddingClass}>
+<Card className={'hover-lift ' + cardClass} {showGradient} {paddingClass}>
 	<div class="mb-2 text-xs font-medium uppercase tracking-wide text-text-2">{label}</div>
 	<div class="mb-2">
 		<span class={'block ' + valueClass}>{value}</span>

--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -1,43 +1,59 @@
+<script lang="ts" context="module">
+	// Per-instance id so multiple open modals each register/unregister cleanly.
+	let modalSeq = 0;
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
+	import { setSheetOpen } from '$lib/stores/uiStore';
+
 	export let show: boolean = false;
 	export let title: string = '';
 	export let onClose: () => void;
 	// Allow consumers to control modal size
 	export let maxWidthClass: string = 'max-w-4xl';
 	export let maxHeightVh: number = 80; // percentage of viewport height
+
+	const sheetId = `uiModal-${modalSeq++}`;
+	// On mobile the modal is a bottom-sheet; hide the tab bar while it's open.
+	$: setSheetOpen(sheetId, show);
+	onDestroy(() => setSheetOpen(sheetId, false));
 </script>
 
 {#if show}
-	<button
-		type="button"
-		class="fixed inset-0 z-[10040] h-full w-full bg-black/20"
-		on:click={onClose}
-		aria-label="Close modal overlay"
-	/>
 	<div
-		class={`fixed left-1/2 top-1/2 z-[10050] mx-2 w-full ${maxWidthClass} -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 p-4 text-left shadow-xl transition-all duration-200 ease-in-out`}
-		role="dialog"
-		aria-modal="true"
-		aria-label="Modal"
+		class="fixed inset-0 z-[10040] flex items-end justify-center p-0 sm:items-center sm:p-4"
+		role="presentation"
 	>
+		<button
+			type="button"
+			class="absolute inset-0 h-full w-full bg-black/60 backdrop-blur-sm"
+			on:click={onClose}
+			aria-label="Close modal overlay"
+		></button>
 		<div
-			class="relative w-full overflow-y-auto rounded-lg bg-gray-900 p-6 shadow-lg"
-			style={`max-height: ${maxHeightVh}vh;`}
-			role="document"
+			class={`relative z-[10050] w-full ${maxWidthClass} overflow-y-auto rounded-t-2xl border border-line bg-surface-1 p-6 text-left shadow-[var(--shadow-pop)] transition-all duration-200 ease-in-out sm:rounded-2xl`}
+			style={`max-height: ${maxHeightVh}vh; padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));`}
+			role="dialog"
+			aria-modal="true"
+			aria-label="Modal"
 		>
-			<div class="mb-4 flex items-center justify-between border-b border-white/10 pb-2">
-				<h3 class="text-lg font-bold text-white">{title}</h3>
+			<!-- grab handle (mobile bottom-sheet affordance) -->
+			<div class="bg-text/15 mx-auto mb-3 h-1 w-10 rounded-full sm:hidden"></div>
+			<div class="mb-4 flex items-center justify-between border-b border-line pb-2">
+				<h3 class="text-lg font-bold text-text">{title}</h3>
 				<button
 					type="button"
-					class="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-primary"
+					class="rounded-full p-1 text-text-2 transition-colors hover:bg-surface-2 hover:text-text"
 					on:click={onClose}
 					on:keydown={(e) => e.key === 'Enter' && onClose()}
 					aria-label="Close modal"
 				>
-					✕
+					<Icon name="close" className="h-5 w-5" />
 				</button>
 			</div>
-			<div class="text-sm text-gray-400">
+			<div class="text-sm text-text-2">
 				<slot />
 			</div>
 		</div>

--- a/src/lib/components/ui/ModalTabs.svelte
+++ b/src/lib/components/ui/ModalTabs.svelte
@@ -7,14 +7,14 @@
 	const dispatch = createEventDispatcher<{ change: string }>();
 </script>
 
-<div class="flex border-b border-gray-700">
+<div class="flex border-b border-line">
 	{#each tabs as tab}
 		<button
 			type="button"
 			on:click={() => dispatch('change', tab.id)}
 			class="flex-1 px-4 py-3 text-sm font-medium transition-colors {activeTab === tab.id
-				? 'border-b-2 border-yellow-400 text-yellow-400'
-				: 'text-gray-400 hover:text-white'}"
+				? 'border-b-2 border-accent text-accent'
+				: 'text-text-2 hover:text-text'}"
 		>
 			{tab.label}
 		</button>

--- a/src/lib/components/ui/Select.svelte
+++ b/src/lib/components/ui/Select.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <select
-	class="w-full rounded-lg border border-white/10 bg-gray-700/50 px-4 py-3 text-white transition-colors focus:border-yellow-500/50 focus:outline-none"
+	class="bg-surface-3/50 w-full rounded-lg border border-line px-4 py-3 text-text transition-colors focus:border-accent-line focus:outline-none"
 	bind:value={selected}
 	{id}
 	aria-labelledby={ariaLabelledby}

--- a/src/lib/components/ui/TabNav.svelte
+++ b/src/lib/components/ui/TabNav.svelte
@@ -48,7 +48,7 @@
 </script>
 
 <div
-	class={'flex gap-2 overflow-x-auto border-b border-white/10 ' + className}
+	class={'flex gap-2 overflow-x-auto border-b border-line ' + className}
 	role="tablist"
 	tabindex="0"
 	on:keydown={onKeydown}
@@ -62,13 +62,13 @@
 			on:click={() => setActive(tab.id)}
 			class={'flex-shrink-0 whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors ' +
 				(activeId === tab.id
-					? 'border-yellow-500 text-yellow-500'
-					: 'border-transparent text-gray-400 hover:text-white')}
+					? 'border-accent text-accent'
+					: 'border-transparent text-text-2 hover:text-text')}
 		>
 			{tab.label}
 			{#if tab.badge != null && tab.badge !== ''}
 				<span
-					class="ml-1.5 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-white/10 px-1 text-[10px] text-gray-300"
+					class="ml-1.5 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-surface-3 px-1 text-[10px] text-text-2"
 				>
 					{tab.badge}
 				</span>

--- a/src/lib/components/ui/ThemeToggle.svelte
+++ b/src/lib/components/ui/ThemeToggle.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { theme, setTheme } from '$lib/stores/themeStore';
+</script>
+
+<div
+	class="inline-flex items-center gap-0 rounded-full border border-line bg-surface-2 p-1"
+	role="group"
+	aria-label="Theme"
+>
+	<button
+		type="button"
+		aria-label="Light theme"
+		aria-pressed={$theme === 'light'}
+		on:click={() => setTheme('light')}
+		class="flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
+		'light'
+			? 'bg-surface-1 text-accent shadow-sm'
+			: 'text-text-3 hover:text-text-2'}"
+	>
+		<svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.6">
+			<circle cx="12" cy="12" r="4.2" />
+			<path
+				stroke-linecap="round"
+				d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6L17 7M7 17l-1.4 1.4"
+			/>
+		</svg>
+	</button>
+	<button
+		type="button"
+		aria-label="Dark theme"
+		aria-pressed={$theme === 'dark'}
+		on:click={() => setTheme('dark')}
+		class="flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
+		'dark'
+			? 'bg-surface-1 text-accent shadow-sm'
+			: 'text-text-3 hover:text-text-2'}"
+	>
+		<svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.6">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M20 13.5A8 8 0 1 1 10.5 4a6.2 6.2 0 0 0 9.5 9.5z"
+			/>
+		</svg>
+	</button>
+</div>

--- a/src/lib/components/ui/ThemeToggle.svelte
+++ b/src/lib/components/ui/ThemeToggle.svelte
@@ -12,12 +12,18 @@
 		aria-label="Light theme"
 		aria-pressed={$theme === 'light'}
 		on:click={() => setTheme('light')}
-		class="flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
+		class="icon-trigger flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
 		'light'
 			? 'bg-surface-1 text-accent shadow-sm'
 			: 'text-text-3 hover:text-text-2'}"
 	>
-		<svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.6">
+		<svg
+			viewBox="0 0 24 24"
+			class="icon-spin-hover h-4 w-4"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.6"
+		>
 			<circle cx="12" cy="12" r="4.2" />
 			<path
 				stroke-linecap="round"
@@ -30,12 +36,18 @@
 		aria-label="Dark theme"
 		aria-pressed={$theme === 'dark'}
 		on:click={() => setTheme('dark')}
-		class="flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
+		class="icon-trigger flex h-7 w-[34px] items-center justify-center rounded-full transition-all duration-200 {$theme ===
 		'dark'
 			? 'bg-surface-1 text-accent shadow-sm'
 			: 'text-text-3 hover:text-text-2'}"
 	>
-		<svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.6">
+		<svg
+			viewBox="0 0 24 24"
+			class="icon-spin-hover h-4 w-4"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.6"
+		>
 			<path
 				stroke-linecap="round"
 				stroke-linejoin="round"

--- a/src/lib/components/ui/TokenDisplay.svelte
+++ b/src/lib/components/ui/TokenDisplay.svelte
@@ -39,12 +39,12 @@
 		<img
 			src={logoUrl}
 			alt={symbol}
-			class={sizeConfig.image + ' rounded-full bg-gray-700 object-cover'}
+			class={sizeConfig.image + ' rounded-full bg-surface-3 object-cover'}
 			loading="lazy"
 		/>
 	{:else}
 		<div
-			class={'flex items-center justify-center rounded-full bg-gray-700 font-bold ' +
+			class={'flex items-center justify-center rounded-full bg-surface-3 font-bold ' +
 				sizeConfig.placeholder}
 		>
 			{symbol?.charAt(0) || '?'}
@@ -57,7 +57,7 @@
 		</div>
 		{#if showName && name}
 			<div
-				class={'truncate text-gray-400 ' +
+				class={'truncate text-text-2 ' +
 					sizeConfig.nameText +
 					(hideNameOnMobile ? ' hidden sm:block' : '')}
 			>

--- a/src/lib/components/ui/TxLink.svelte
+++ b/src/lib/components/ui/TxLink.svelte
@@ -8,7 +8,7 @@
 	export let head: number = 6;
 	export let tail: number = 4;
 	export let className: string =
-		'flex items-center gap-1 font-mono text-xs text-blue-400 hover:text-blue-300';
+		'flex items-center gap-1 font-mono text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300';
 	export let dataTestId: string | undefined = undefined;
 
 	function truncate(value: string, h = head, t = tail) {

--- a/src/lib/components/ui/WalletConnectionPrompt.svelte
+++ b/src/lib/components/ui/WalletConnectionPrompt.svelte
@@ -22,9 +22,9 @@
 	{#if showSection}
 		<Section>
 			<div class="flex flex-col items-center justify-center gap-6 px-6 {containerClasses}">
-				<div class="rounded-full bg-gradient-to-br from-blue-600/20 to-purple-700/20 p-6">
+				<div class="rounded-full bg-gradient-to-br from-emerald-500/20 to-emerald-700/20 p-6">
 					<svg
-						class="h-10 w-10 text-blue-400 sm:h-12 sm:w-12"
+						class="h-10 w-10 text-blue-600 sm:h-12 sm:w-12 dark:text-blue-400"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"
@@ -40,7 +40,7 @@
 
 				<div class="text-center">
 					<h2 class="mb-2 text-xl font-bold sm:text-2xl">{title}</h2>
-					<p class="max-w-md text-sm text-gray-400 sm:text-base">
+					<p class="max-w-md text-sm text-text-2 sm:text-base">
 						{defaultDescription}
 					</p>
 				</div>
@@ -56,7 +56,7 @@
 		<div class="flex flex-col items-center justify-center gap-6 px-6 {containerClasses}">
 			<div class="rounded-full bg-gradient-to-br from-blue-600/20 to-purple-700/20 p-6">
 				<svg
-					class="h-10 w-10 text-blue-400 sm:h-12 sm:w-12"
+					class="h-10 w-10 text-blue-600 sm:h-12 sm:w-12 dark:text-blue-400"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"
@@ -72,7 +72,7 @@
 
 			<div class="text-center">
 				<h2 class="mb-2 text-xl font-bold sm:text-2xl">{title}</h2>
-				<p class="max-w-md text-sm text-gray-400 sm:text-base">
+				<p class="max-w-md text-sm text-text-2 sm:text-base">
 					{defaultDescription}
 				</p>
 			</div>

--- a/src/lib/components/wrap/DenomToggle.svelte
+++ b/src/lib/components/wrap/DenomToggle.svelte
@@ -31,12 +31,12 @@
 
 <div class="inline-flex items-center gap-2">
 	{#if showPrefix}
-		<span class="hidden text-[11px] uppercase tracking-wide text-gray-500 sm:inline">Show as</span>
+		<span class="hidden text-[11px] uppercase tracking-wide text-text-3 sm:inline">Show as</span>
 	{/if}
 	<div
 		role="tablist"
 		aria-label={ariaLabel}
-		class="inline-flex items-center rounded-lg border border-white/10 bg-white/5 p-0.5 text-xs"
+		class="inline-flex items-center rounded-lg border border-line bg-surface-2 p-0.5 text-xs"
 	>
 		<button
 			type="button"
@@ -45,8 +45,8 @@
 			on:click={() => set('unwrapped')}
 			class={'rounded-md px-2.5 py-1 font-medium transition ' +
 				(value === 'unwrapped'
-					? 'bg-yellow-400/15 text-yellow-200 ring-1 ring-yellow-400/30'
-					: 'text-gray-400 hover:text-gray-200')}
+					? 'bg-yellow-400/15 text-accent ring-1 ring-yellow-400/30'
+					: 'text-text-2 hover:text-text-2')}
 		>
 			Shares ({assetSymbol})
 		</button>
@@ -57,8 +57,8 @@
 			on:click={() => set('wrapped')}
 			class={'rounded-md px-2.5 py-1 font-medium transition ' +
 				(value === 'wrapped'
-					? 'bg-yellow-400/15 text-yellow-200 ring-1 ring-yellow-400/30'
-					: 'text-gray-400 hover:text-gray-200')}
+					? 'bg-yellow-400/15 text-accent ring-1 ring-yellow-400/30'
+					: 'text-text-2 hover:text-text-2')}
 		>
 			Tokens ({wrappedSymbol})
 		</button>

--- a/src/lib/components/wrap/RatioHistoryTab.svelte
+++ b/src/lib/components/wrap/RatioHistoryTab.svelte
@@ -53,8 +53,8 @@
 <div>
 	<div class="mb-3 flex flex-wrap items-end justify-between gap-2">
 		<div>
-			<h3 class="font-semibold text-white">Wrap Ratio History</h3>
-			<p class="mt-0.5 text-xs text-gray-400 sm:text-sm">
+			<h3 class="font-semibold text-text">Wrap Ratio History</h3>
+			<p class="mt-0.5 text-xs text-text-2 sm:text-sm">
 				Starts at <span class="font-mono">1 : 1</span>. Each snapshot records how much
 				{assetSymbol} backs 1 {wrappedSymbol} when the API samples the vault.
 				{#if onLearnMore}
@@ -85,15 +85,13 @@
 		</div>
 	{:else if events.length === 0}
 		<RatioStepChart events={[]} {wrappedSymbol} {assetSymbol} />
-		<div
-			class="mt-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-4 text-sm text-gray-400"
-		>
+		<div class="mt-3 rounded-lg border border-line bg-surface-2 px-3 py-4 text-sm text-text-2">
 			No historical snapshots yet. The current sampled ratio is shown above.
 		</div>
 	{:else}
 		<RatioStepChart {events} {wrappedSymbol} {assetSymbol} />
 
-		<h4 class="mb-2 mt-4 text-xs font-semibold uppercase tracking-wide text-gray-400">Snapshots</h4>
+		<h4 class="mb-2 mt-4 text-xs font-semibold uppercase tracking-wide text-text-2">Snapshots</h4>
 		<ol class="relative space-y-0">
 			{#each eventsDesc as ev, idx (`${ev.blockNumber}-${ev.capturedAt}`)}
 				{@const isLatest = idx === 0}
@@ -101,12 +99,14 @@
 				{@const prev = eventsDesc[idx + 1] != null ? ratioOfEvent(eventsDesc[idx + 1]) : 1}
 				<li class="relative pl-6 pr-1">
 					<span
-						class="absolute bottom-[-4px] left-[7px] top-5 w-px bg-white/10"
+						class="absolute bottom-[-4px] left-[7px] top-5 w-px bg-surface-3"
 						aria-hidden="true"
 					/>
 					<span
 						class={'absolute left-0 top-2 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border ' +
-							(isLatest ? 'border-yellow-400/60 bg-yellow-400/20' : 'border-white/15 bg-white/5')}
+							(isLatest
+								? 'border-yellow-400/60 bg-yellow-400/20'
+								: 'border-line-strong bg-surface-2')}
 						aria-hidden="true"
 					>
 						<span
@@ -114,10 +114,10 @@
 						/>
 					</span>
 
-					<div class="border-b border-white/5 py-3">
+					<div class="border-b border-line py-3">
 						<div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
 							<div class="flex items-baseline gap-2">
-								<span class="text-sm font-medium text-gray-100">Snapshot</span>
+								<span class="text-sm font-medium text-text-2">Snapshot</span>
 								{#if isLatest}
 									<span
 										class="inline-flex items-center rounded-full border border-yellow-400/35 bg-yellow-400/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-yellow-200"
@@ -126,16 +126,16 @@
 									</span>
 								{/if}
 							</div>
-							<div class="flex items-baseline gap-2 text-[11px] text-gray-500">
+							<div class="flex items-baseline gap-2 text-[11px] text-text-3">
 								<span>{fmtFullDate(ev.blockTimestamp)}</span>
-								<span class="text-gray-600">·</span>
+								<span class="text-text-muted">·</span>
 								<span>{relativeFromSec(ev.blockTimestamp)}</span>
 							</div>
 						</div>
 
 						<div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-							<span class="font-mono tabular-nums text-gray-300">
-								1 : <b class="text-gray-100">{fmtRatio(newRate)}</b>
+							<span class="font-mono tabular-nums text-text-2">
+								1 : <b class="text-text-2">{fmtRatio(newRate)}</b>
 							</span>
 							{#if prev != null && newRate != null && prev !== newRate}
 								{@const pct = ((newRate - prev) / prev) * 100}
@@ -150,8 +150,8 @@
 								</span>
 							{/if}
 						</div>
-						<p class="mt-1.5 text-xs leading-relaxed text-gray-400">
-							Captured at block <span class="font-mono tabular-nums text-gray-300"
+						<p class="mt-1.5 text-xs leading-relaxed text-text-2">
+							Captured at block <span class="font-mono tabular-nums text-text-2"
 								>{ev.blockNumber}</span
 							>.
 						</p>
@@ -161,14 +161,14 @@
 
 			<li class="relative pl-6 pr-1">
 				<span
-					class="absolute left-0 top-2 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-white/15 bg-white/5"
+					class="absolute left-0 top-2 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-line-strong bg-surface-2"
 					aria-hidden="true"
 				>
 					<span class="h-1.5 w-1.5 rounded-full bg-gray-500" />
 				</span>
-				<div class="border-b border-white/5 py-3">
-					<span class="text-sm font-medium text-gray-100">Deployed</span>
-					<div class="mt-1 font-mono text-xs tabular-nums text-gray-300">1 : <b>1</b></div>
+				<div class="border-b border-line py-3">
+					<span class="text-sm font-medium text-text-2">Deployed</span>
+					<div class="mt-1 font-mono text-xs tabular-nums text-text-2">1 : <b>1</b></div>
 				</div>
 			</li>
 		</ol>

--- a/src/lib/components/wrap/RatioStepChart.svelte
+++ b/src/lib/components/wrap/RatioStepChart.svelte
@@ -120,10 +120,9 @@
 </script>
 
 <div
-	class="rounded-lg border border-white/10 p-2 sm:p-3"
-	style="background: radial-gradient(60% 80% at 30% 30%, rgba(250,204,21,0.06), transparent 60%), linear-gradient(180deg, #0e1422 0%, #0a0f1c 100%);"
+	class="rounded-lg border border-line bg-surface-1 p-2 sm:p-3 dark:bg-[linear-gradient(180deg,#0e1422_0%,#0a0f1c_100%)]"
 >
-	<div class="mb-1 flex items-center justify-between px-1 text-[11px] text-gray-500">
+	<div class="mb-1 flex items-center justify-between px-1 text-[11px] text-text-3">
 		<span>Wrap ratio over time</span>
 		<span class="font-mono tabular-nums">1 {wrappedSymbol} : N {assetSymbol}</span>
 	</div>
@@ -140,7 +139,7 @@
 				x2={w - padR}
 				y1={ty(v, yMin, yMax)}
 				y2={ty(v, yMin, yMax)}
-				stroke={v === 1 ? 'rgba(255,255,255,0.18)' : 'rgba(255,255,255,0.06)'}
+				stroke={v === 1 ? 'var(--line-strong)' : 'var(--line)'}
 				stroke-dasharray={v === 1 ? '0' : '2 3'}
 			/>
 			<text
@@ -148,7 +147,7 @@
 				y={ty(v, yMin, yMax) + 3}
 				text-anchor="end"
 				font-size="10"
-				fill={v === 1 ? 'rgba(229,231,235,0.85)' : 'rgba(156,163,175,0.7)'}
+				fill={v === 1 ? 'var(--text-2)' : 'var(--text-3)'}
 				class="font-mono"
 			>
 				{fmtTick(v)}
@@ -156,7 +155,7 @@
 		{/each}
 
 		{#if stepPath}
-			<path d={stepPath} fill="none" stroke="#facc15" stroke-width="1.75" />
+			<path d={stepPath} fill="none" stroke="#2de3a6" stroke-width="1.75" />
 		{/if}
 
 		{#each pts as p}
@@ -164,8 +163,8 @@
 				cx={tx(p.ev.blockTimestamp * 1000)}
 				cy={ty(p.rate, yMin, yMax)}
 				r="3.5"
-				fill="#facc15"
-				stroke="#0e1422"
+				fill="#2de3a6"
+				stroke="var(--surface-1)"
 				stroke-width="1.5"
 			>
 				<title>{`${fmtDateShort(p.ev.blockTimestamp)} — 1 : ${p.rate}`}</title>
@@ -177,19 +176,13 @@
 			x2={w - padR}
 			y1={padT}
 			y2={padT + innerH}
-			stroke="rgba(255,255,255,0.15)"
+			stroke="var(--line-strong)"
 			stroke-dasharray="2 2"
 		/>
-		<text x={w - padR - 2} y={padT + 9} text-anchor="end" font-size="9" fill="rgba(156,163,175,0.7)"
+		<text x={w - padR - 2} y={padT + 9} text-anchor="end" font-size="9" fill="var(--text-3)"
 			>now</text
 		>
-		<line
-			x1={padL}
-			x2={w - padR}
-			y1={padT + innerH}
-			y2={padT + innerH}
-			stroke="rgba(255,255,255,0.1)"
-		/>
+		<line x1={padL} x2={w - padR} y1={padT + innerH} y2={padT + innerH} stroke="var(--line)" />
 
 		{#each pts as p, i (p.ev.blockTimestamp + '-' + i)}
 			{#if pts.length <= 4 || i === 0 || i === pts.length - 1 || i % Math.ceil(pts.length / 4) === 0}
@@ -198,7 +191,7 @@
 					y={h - 6}
 					text-anchor="middle"
 					font-size="9"
-					fill="rgba(156,163,175,0.65)"
+					fill="var(--text-3)"
 				>
 					{fmtDateShort(p.ev.blockTimestamp)}
 				</text>

--- a/src/lib/components/wrap/ReceiveGiveCallout.svelte
+++ b/src/lib/components/wrap/ReceiveGiveCallout.svelte
@@ -44,23 +44,23 @@
 	class="rounded-lg px-3.5 py-3"
 	style="background: linear-gradient(180deg, rgba(250,204,21,0.06), rgba(250,204,21,0.02)); border: 1px solid rgba(250,204,21,0.18);"
 >
-	<p class="text-[10px] uppercase tracking-[0.14em] text-yellow-200/80">
+	<p class="text-[10px] uppercase tracking-[0.14em] text-accent">
 		{side === 'Buy' ? 'Your wallet will receive' : 'Your wallet will spend'}
 	</p>
 	<div class="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-		<span class="font-mono text-2xl font-semibold tabular-nums text-white">
+		<span class="font-mono text-2xl font-semibold tabular-nums text-text">
 			{empty ? '—' : fmtNum(wrappedAmount, 4)}
 		</span>
-		<span class="text-sm text-yellow-200">{wrappedSymbol}</span>
+		<span class="text-sm text-accent">{wrappedSymbol}</span>
 	</div>
-	<p class="mt-1 text-[11.5px] text-gray-400">
+	<p class="mt-1 text-[11.5px] text-text-2">
 		{#if empty}
 			1 {wrappedSymbol} bundles {ratioLabel}
 			{assetSymbol} shares — you'll see the {wrappedSymbol} count in your wallet, not the share count.
 		{:else}
-			= <span class="font-mono tabular-nums text-gray-200">{fmtNum(sharesAmount, 4)}</span>
+			= <span class="font-mono tabular-nums text-text-2">{fmtNum(sharesAmount, 4)}</span>
 			{assetSymbol} shares ·
-			<span class="font-mono tabular-nums text-gray-200">{fmtUsd(totalUsd)}</span>
+			<span class="font-mono tabular-nums text-text-2">{fmtUsd(totalUsd)}</span>
 		{/if}
 	</p>
 </div>

--- a/src/lib/components/wrap/WrapExplainerModal.svelte
+++ b/src/lib/components/wrap/WrapExplainerModal.svelte
@@ -47,18 +47,18 @@
 			aria-modal="true"
 			aria-labelledby="wrap-explainer-title"
 			data-testid="wrap-explainer-modal"
-			class="relative w-full max-w-[640px] overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-b from-gray-900 to-gray-950 shadow-2xl"
+			class="relative w-full max-w-[640px] overflow-hidden rounded-2xl border border-line bg-surface-1 shadow-2xl dark:bg-gradient-to-b dark:from-gray-900 dark:to-gray-950"
 			transition:fly={{ y: 12, duration: 180 }}
 		>
 			<!-- Header -->
 			<div
-				class="flex items-start justify-between gap-4 border-b border-white/10 px-5 py-4 sm:px-6 sm:py-5"
+				class="flex items-start justify-between gap-4 border-b border-line px-5 py-4 sm:px-6 sm:py-5"
 			>
 				<div class="min-w-0">
-					<p class="text-[10px] uppercase tracking-[0.14em] text-yellow-300/80 sm:text-xs">
+					<p class="text-[10px] uppercase tracking-[0.14em] text-accent sm:text-xs">
 						New on {wrappedSymbol}
 					</p>
-					<h2 id="wrap-explainer-title" class="mt-0.5 text-lg font-semibold text-white sm:text-xl">
+					<h2 id="wrap-explainer-title" class="mt-0.5 text-lg font-semibold text-text sm:text-xl">
 						What's a Wrapped tStock?
 					</h2>
 				</div>
@@ -66,7 +66,7 @@
 					type="button"
 					on:click={onClose}
 					aria-label="Close explainer"
-					class="rounded-lg p-2 text-gray-400 transition hover:bg-white/5 hover:text-white"
+					class="rounded-lg p-2 text-text-2 transition hover:bg-surface-2 hover:text-text"
 				>
 					<svg
 						viewBox="0 0 24 24"
@@ -87,65 +87,63 @@
 			<div class="max-h-[68vh] overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">
 				<!-- Ratio illustration -->
 				<div class="mb-5 rounded-xl border border-yellow-400/25 bg-yellow-400/[0.06] p-4 sm:p-5">
-					<p class="text-[11px] uppercase tracking-wide text-yellow-300/80">The Wrap Ratio</p>
+					<p class="text-[11px] uppercase tracking-wide text-accent">The Wrap Ratio</p>
 					<div class="mt-2 flex flex-wrap items-baseline gap-x-3 leading-tight">
 						<span
-							class="whitespace-nowrap font-mono text-2xl font-semibold tabular-nums text-white sm:text-3xl"
+							class="whitespace-nowrap font-mono text-2xl font-semibold tabular-nums text-text sm:text-3xl"
 							>1&nbsp;{wrappedSymbol}</span
 						>
-						<span class="text-2xl text-gray-400 sm:text-3xl">=</span>
+						<span class="text-2xl text-text-2 sm:text-3xl">=</span>
 						<span
-							class="whitespace-nowrap font-mono text-2xl font-semibold tabular-nums text-white sm:text-3xl"
+							class="whitespace-nowrap font-mono text-2xl font-semibold tabular-nums text-text sm:text-3xl"
 							>{ratioLabel}&nbsp;{assetSymbol}</span
 						>
 					</div>
-					<p class="mt-3 text-xs text-gray-400 sm:text-sm">
-						Each <span class="text-gray-200">{wrappedSymbol}</span> in your wallet is redeemable for
-						<span class="text-gray-200">{ratioLabel}</span>
+					<p class="mt-3 text-xs text-text-2 sm:text-sm">
+						Each <span class="text-text-2">{wrappedSymbol}</span> in your wallet is redeemable for
+						<span class="text-text-2">{ratioLabel}</span>
 						{assetSymbol} — each of which has right of redemption for one share of {equityName}.
 					</p>
 				</div>
 
-				<h3 class="text-sm font-semibold text-white">Prices and history use shares.</h3>
-				<p class="mt-1 text-sm text-gray-400">
+				<h3 class="text-sm font-semibold text-text">Prices and history use shares.</h3>
+				<p class="mt-1 text-sm text-text-2">
 					Every chart, oracle price, and quote on this page is shown in
-					<span class="text-gray-200">shares of {equityName}</span> — the same units you'd see on a brokerage.
+					<span class="text-text-2">shares of {equityName}</span> — the same units you'd see on a brokerage.
 				</p>
 
 				<div class="my-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-					<div class="rounded-lg border border-white/10 bg-white/[0.03] p-3">
-						<p class="text-[10px] uppercase tracking-wide text-gray-500">On the chart</p>
-						<p class="mt-1 font-mono text-base font-medium tabular-nums text-gray-100">
-							$ per share
-						</p>
-						<p class="text-[11px] text-gray-500">{assetSymbol} — same price as {equityName}</p>
+					<div class="rounded-lg border border-line bg-surface-2 p-3">
+						<p class="text-[10px] uppercase tracking-wide text-text-3">On the chart</p>
+						<p class="mt-1 font-mono text-base font-medium tabular-nums text-text-2">$ per share</p>
+						<p class="text-[11px] text-text-3">{assetSymbol} — same price as {equityName}</p>
 					</div>
-					<div class="rounded-lg border border-white/10 bg-white/[0.03] p-3">
-						<p class="text-[10px] uppercase tracking-wide text-gray-500">In your wallet</p>
-						<p class="mt-1 font-mono text-base font-medium tabular-nums text-gray-100">
+					<div class="rounded-lg border border-line bg-surface-2 p-3">
+						<p class="text-[10px] uppercase tracking-wide text-text-3">In your wallet</p>
+						<p class="mt-1 font-mono text-base font-medium tabular-nums text-text-2">
 							{wrappedSymbol}
 						</p>
-						<p class="text-[11px] text-gray-500">
+						<p class="text-[11px] text-text-3">
 							1 {wrappedSymbol} bundles {ratioLabel}
 							{assetSymbol}
 						</p>
 					</div>
 				</div>
 
-				<h3 class="mt-5 text-sm font-semibold text-white">What you'll actually receive.</h3>
-				<p class="mt-1 text-sm text-gray-400">
+				<h3 class="mt-5 text-sm font-semibold text-text">What you'll actually receive.</h3>
+				<p class="mt-1 text-sm text-text-2">
 					When you order
-					<span class="text-gray-200">{EXAMPLE_SHARES} shares</span>, your wallet will show
-					<span class="text-gray-200">{exampleWrapped} {wrappedSymbol}</span>
+					<span class="text-text-2">{EXAMPLE_SHARES} shares</span>, your wallet will show
+					<span class="text-text-2">{exampleWrapped} {wrappedSymbol}</span>
 					— not {EXAMPLE_SHARES} tokens. The token count is smaller because each one is worth
 					{ratioLabel}× more.
 				</p>
 				<div
-					class="mt-3 flex flex-wrap items-center gap-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-3 text-sm"
+					class="mt-3 flex flex-wrap items-center gap-3 rounded-lg border border-line bg-surface-2 px-3 py-3 text-sm"
 				>
 					<div class="flex items-baseline gap-1.5">
-						<span class="text-gray-400">You order</span>
-						<span class="font-mono font-medium tabular-nums text-gray-100"
+						<span class="text-text-2">You order</span>
+						<span class="font-mono font-medium tabular-nums text-text-2"
 							>{EXAMPLE_SHARES} {assetSymbol}</span
 						>
 					</div>
@@ -153,7 +151,7 @@
 						viewBox="0 0 24 24"
 						width="16"
 						height="16"
-						class="text-gray-500"
+						class="text-text-3"
 						fill="none"
 						stroke="currentColor"
 						stroke-width="2"
@@ -162,15 +160,15 @@
 						<path d="M5 12h14M13 5l7 7-7 7" stroke-linecap="round" stroke-linejoin="round" />
 					</svg>
 					<div class="flex items-baseline gap-1.5">
-						<span class="text-gray-400">Wallet shows</span>
-						<span class="font-mono font-medium tabular-nums text-yellow-200"
+						<span class="text-text-2">Wallet shows</span>
+						<span class="font-mono font-medium tabular-nums text-accent"
 							>{exampleWrapped} {wrappedSymbol}</span
 						>
 					</div>
 				</div>
 
-				<h3 class="mt-6 text-sm font-semibold text-white">Built for DeFi</h3>
-				<p class="mt-1 text-sm text-gray-400">
+				<h3 class="mt-6 text-sm font-semibold text-text">Built for DeFi</h3>
+				<p class="mt-1 text-sm text-text-2">
 					Wrapping makes the token DeFi-ready. DeFi protocols track deposited balances internally —
 					they can't see when a dividend or stock split changes your underlying holdings. By rolling
 					those events into the wrap ratio, your {wrappedSymbol} quietly compounds (each token becomes
@@ -178,31 +176,31 @@
 					sync.
 				</p>
 
-				<h3 class="mt-6 text-sm font-semibold text-white">
+				<h3 class="mt-6 text-sm font-semibold text-text">
 					Need {assetSymbol} instead? Unwrap them.
 				</h3>
-				<p class="mt-1 text-sm text-gray-400">
+				<p class="mt-1 text-sm text-text-2">
 					Wrapping is reversible at the ratio above and at no cost. Head to
 					<a
 						href={dashboardHref}
-						class="inline-flex items-center gap-1 text-blue-300 hover:text-blue-200 hover:underline"
+						class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-300 dark:hover:text-blue-200"
 					>
 						Dashboard → Holdings <IconExternalLink width="11" height="11" />
 					</a>
-					and use <span class="text-gray-200">Unwrap</span> on any {wrappedSymbol} balance to get back
+					and use <span class="text-text-2">Unwrap</span> on any {wrappedSymbol} balance to get back
 					the underlying {assetSymbol}.
 				</p>
 			</div>
 
 			<!-- Footer -->
 			<div
-				class="flex flex-col-reverse gap-2 border-t border-white/10 bg-black/30 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6"
+				class="flex flex-col-reverse gap-2 border-t border-line bg-surface-2 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6"
 			>
 				{#if onDontShow}
 					<button
 						type="button"
 						on:click={onDontShow}
-						class="text-xs text-gray-400 transition hover:text-gray-200 sm:text-sm"
+						class="text-xs text-text-2 transition hover:text-text-2 sm:text-sm"
 					>
 						Don't show this again
 					</button>
@@ -212,7 +210,7 @@
 				<button
 					type="button"
 					on:click={onClose}
-					class="rounded-xl bg-yellow-500/90 px-4 py-2.5 text-sm font-semibold text-gray-950 shadow-lg shadow-yellow-500/20 transition hover:bg-yellow-400 sm:text-base"
+					class="rounded-xl bg-accent px-4 py-2.5 text-sm font-semibold text-[#05231a] shadow-lg transition hover:bg-accent-bright sm:text-base"
 				>
 					Got it
 				</button>

--- a/src/lib/components/wrap/WrapRatioCard.svelte
+++ b/src/lib/components/wrap/WrapRatioCard.svelte
@@ -38,17 +38,17 @@
 <div class="mb-3 rounded-lg border border-yellow-400/25 bg-yellow-400/[0.05] p-3 sm:p-4">
 	<div class="flex flex-wrap items-start justify-between gap-3">
 		<div class="min-w-0">
-			<p class="text-[10px] uppercase tracking-wide text-yellow-300/80 sm:text-xs">Wrap Ratio</p>
-			<p class="mt-1 font-mono text-base font-semibold tabular-nums text-gray-100 sm:text-lg">
+			<p class="text-[10px] uppercase tracking-wide text-accent sm:text-xs">Wrap Ratio</p>
+			<p class="mt-1 font-mono text-base font-semibold tabular-nums text-text-2 sm:text-lg">
 				1 {wrappedSymbol} = {ratioLabel}
 				{assetSymbol}
 			</p>
-			<p class="mt-1 text-xs text-gray-400">
+			<p class="mt-1 text-xs text-text-2">
 				Each {wrappedSymbol} bundles {ratioLabel}
 				{assetSymbol} shares. Trades and prices on this page are shown <b>per share</b>.
 			</p>
 			{#if lastChangedRelative}
-				<p class="mt-2 text-[11px] text-gray-500">
+				<p class="mt-2 text-[11px] text-text-3">
 					Last changed {lastChangedRelative}{#if lastChangeLabel}
 						· {lastChangeLabel}{/if}
 					{#if onViewHistory}
@@ -56,7 +56,7 @@
 						<button
 							type="button"
 							on:click={onViewHistory}
-							class="inline-flex items-center gap-0.5 text-blue-300 hover:text-blue-200 hover:underline"
+							class="inline-flex items-center gap-0.5 text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-300 dark:hover:text-blue-200"
 						>
 							view history
 							<svg
@@ -81,14 +81,14 @@
 				<button
 					type="button"
 					on:click={onLearnMore}
-					class="rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-gray-200 transition hover:border-yellow-300/40 hover:bg-yellow-400/10"
+					class="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-xs text-text-2 transition hover:border-yellow-300/40 hover:bg-yellow-400/10"
 				>
 					How it works
 				</button>
 			{/if}
 			<a
 				href={dashboardHref}
-				class="rounded-md border border-yellow-400/40 bg-yellow-500/20 px-2.5 py-1.5 text-xs font-medium text-yellow-200 transition hover:bg-yellow-500/30"
+				class="rounded-md border border-yellow-400/40 bg-yellow-500/20 px-2.5 py-1.5 text-xs font-medium text-accent transition hover:bg-yellow-500/30"
 			>
 				Unwrap in Dashboard <IconExternalLink width="10" height="10" class="ml-1 inline" />
 			</a>

--- a/src/lib/components/wrap/WrapRatioChip.svelte
+++ b/src/lib/components/wrap/WrapRatioChip.svelte
@@ -18,11 +18,11 @@
 {#if showChip}
 	<div class="flex items-center gap-2" data-testid="wrap-ratio-chip">
 		<span
-			class="inline-flex items-center gap-1.5 rounded-full border border-yellow-400/35 bg-yellow-400/10 px-2 py-0.5 text-[11px] leading-tight text-yellow-200"
+			class="inline-flex items-center gap-1.5 rounded-full border border-yellow-400/35 bg-yellow-400/10 px-2 py-0.5 text-[11px] leading-tight text-accent"
 			title="Wrap ratio"
 		>
 			<span class="font-mono tabular-nums">1 {wrappedSymbol}</span>
-			<span class="text-yellow-300/70">=</span>
+			<span class="text-accent">=</span>
 			<span class="font-mono tabular-nums">{ratioLabel} {assetSymbol}</span>
 		</span>
 		{#if onLearnMore}
@@ -30,7 +30,7 @@
 				type="button"
 				on:click={onLearnMore}
 				data-testid="wrap-explainer-trigger"
-				class="inline-flex items-center gap-1 text-[11px] text-gray-400 transition hover:text-yellow-200 sm:text-xs"
+				class="inline-flex items-center gap-1 text-[11px] text-text-2 transition hover:text-accent sm:text-xs"
 			>
 				<svg
 					viewBox="0 0 24 24"

--- a/src/lib/stores/themeStore.ts
+++ b/src/lib/stores/themeStore.ts
@@ -1,0 +1,33 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'st0x-theme';
+
+function readInitialTheme(): Theme {
+	if (!browser) return 'dark';
+	const attr = document.documentElement.getAttribute('data-theme');
+	return attr === 'light' ? 'light' : 'dark';
+}
+
+export const theme = writable<Theme>(readInitialTheme());
+
+export function setTheme(next: Theme): void {
+	if (!browser) return;
+	document.documentElement.setAttribute('data-theme', next);
+	try {
+		localStorage.setItem(STORAGE_KEY, next);
+	} catch {
+		/* localStorage unavailable — persistence is best-effort */
+	}
+	theme.set(next);
+	// Let the ambient canvas re-read the theme's token colors.
+	window.dispatchEvent(new CustomEvent('st0x-retint'));
+}
+
+export function toggleTheme(): void {
+	const current =
+		document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+	setTheme(current === 'light' ? 'dark' : 'light');
+}

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -1,0 +1,25 @@
+import { derived, writable } from 'svelte/store';
+
+// Whether the top-bar inline nav has collapsed (the header sets this from its
+// width/offset breakpoint). When true, the bottom MobileTabBar is the primary
+// navigation — it replaces the old hamburger dropdown. Default false so SSR /
+// first paint on desktop never flashes the mobile bar.
+export const navCollapsed = writable(false);
+
+// Registry of open bottom-sheet modals, keyed by id. The MobileTabBar hides
+// whenever any sheet is open so the sheet's action button never sits behind it.
+const openSheets = writable<Set<string>>(new Set());
+
+export function setSheetOpen(id: string, open: boolean): void {
+	openSheets.update((sheets) => {
+		const next = new Set(sheets);
+		if (open) {
+			next.add(id);
+		} else {
+			next.delete(id);
+		}
+		return next;
+	});
+}
+
+export const anySheetOpen = derived(openSheets, ($openSheets) => $openSheets.size > 0);

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -1,0 +1,136 @@
+/* ============================================================
+   st0x · refreshed design language — TOKENS
+   Dark is primary; light is a first-class alternate.
+   Theme is driven by [data-theme] on <html>.
+   ============================================================ */
+
+:root,
+[data-theme='dark'] {
+	color-scheme: dark;
+
+	/* — surfaces (deep blue-black, faint green undertone) — */
+	--bg: #070b11;
+	--bg-deep: #04070c;
+	--surface-1: #0c121b; /* cards */
+	--surface-2: #111a25; /* raised / inputs */
+	--surface-3: #18222f; /* hover / segmented track */
+
+	/* — hairlines & strokes — */
+	--line: rgba(255, 255, 255, 0.07);
+	--line-strong: rgba(255, 255, 255, 0.12);
+	--line-accent: rgba(45, 227, 166, 0.35);
+
+	/* — theme-aware translucent overlays (depth on cards/fields/hover that still
+	     works in light mode — translucent white in dark, translucent ink in light) — */
+	--overlay-1: rgba(255, 255, 255, 0.03);
+	--overlay-2: rgba(255, 255, 255, 0.06);
+	--overlay-strong: rgba(0, 0, 0, 0.3);
+	--overlay-hover: rgba(255, 255, 255, 0.05);
+
+	/* — text — */
+	--text: #eef3f8;
+	--text-2: #9aa9bb;
+	--text-3: #7b8a9c;
+	--text-muted: #5c6a7c;
+
+	/* — signature accent: mint-emerald — */
+	--accent: #2de3a6;
+	--accent-bright: #4af0bb;
+	--accent-deep: #15c78c;
+	--accent-ink: #042b1f; /* text on accent fills */
+	--accent-soft: rgba(45, 227, 166, 0.12);
+	--accent-line: rgba(45, 227, 166, 0.3);
+	--accent-glow: rgba(45, 227, 166, 0.45);
+
+	/* — secondary brand: iris (bridges official st0x indigo) — */
+	--iris: #7d8bff;
+	--iris-soft: rgba(125, 139, 255, 0.12);
+
+	/* — semantic — */
+	--up: #2de3a6;
+	--down: #fb6a5d;
+	--down-soft: rgba(251, 106, 93, 0.12);
+
+	/* — ambient background (canvas reads these) — */
+	--aura-a: rgba(45, 227, 166, 0.16);
+	--aura-b: rgba(125, 139, 255, 0.1);
+	--aura-c: rgba(45, 227, 166, 0.05);
+	--line-field: rgba(120, 200, 170, 0.1);
+
+	/* — elevation — */
+	--shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+	--shadow-2: 0 12px 40px -12px rgba(0, 0, 0, 0.7);
+	--shadow-pop: 0 24px 70px -20px rgba(0, 0, 0, 0.85);
+	--shadow-accent: 0 10px 30px -10px rgba(45, 227, 166, 0.45);
+}
+
+[data-theme='light'] {
+	color-scheme: light;
+
+	/* v2 light redesign (2026-06-11): cool Tailwind-slate neutrals, crisp white
+	   cards, mint accent deepened for AA contrast on white. Surfaces map the
+	   prototype's #070b11→#f6f8fb (page), #0c121b→#eceff4 (mid), white→raised. */
+	--bg: #f6f8fb;
+	--bg-deep: #eceff4;
+	--surface-1: #ffffff;
+	--surface-2: #eceff4;
+	--surface-3: #e2e8f0;
+
+	/* slate-ink hairlines (prototype border-white/10 → rgba(15,23,42,0.12)) */
+	--line: rgba(15, 23, 42, 0.11);
+	--line-strong: rgba(15, 23, 42, 0.16);
+	--line-accent: rgba(15, 158, 114, 0.32);
+
+	--overlay-1: rgba(15, 23, 42, 0.03);
+	--overlay-2: rgba(15, 23, 42, 0.05);
+	--overlay-strong: rgba(15, 23, 42, 0.05);
+	--overlay-hover: rgba(15, 23, 42, 0.05);
+
+	/* text → Tailwind slate scale (900/600/500/400) for cooler, higher-contrast copy */
+	--text: #0f172a;
+	--text-2: #475569;
+	--text-3: #64748b;
+	--text-muted: #94a3b8;
+
+	/* mint deepened for AA on white (emerald-400→#0f9e72, emerald-300→#0b8f63) */
+	--accent: #0f9e72;
+	--accent-bright: #14b886;
+	--accent-deep: #0b8f63;
+	--accent-ink: #ffffff;
+	--accent-soft: rgba(15, 158, 114, 0.1);
+	--accent-line: rgba(15, 158, 114, 0.28);
+	--accent-glow: rgba(15, 158, 114, 0.3);
+
+	--iris: #4f46e5;
+	--iris-soft: rgba(79, 70, 229, 0.1);
+
+	--up: #0f9e72;
+	--down: #dc2626;
+	--down-soft: rgba(220, 38, 38, 0.1);
+
+	--aura-a: rgba(15, 158, 114, 0.16);
+	--aura-b: rgba(79, 70, 229, 0.1);
+	--aura-c: rgba(15, 158, 114, 0.06);
+	--line-field: rgba(20, 140, 100, 0.1);
+
+	--shadow-1: 0 1px 2px rgba(20, 30, 50, 0.06);
+	--shadow-2: 0 18px 44px -18px rgba(30, 45, 70, 0.22);
+	--shadow-pop: 0 30px 70px -22px rgba(30, 45, 70, 0.3);
+	--shadow-accent: 0 12px 34px -12px rgba(15, 158, 114, 0.4);
+}
+
+/* — radii / type tokens — */
+:root {
+	--r-sm: 8px;
+	--r: 12px;
+	--r-lg: 16px;
+	--r-xl: 22px;
+	--r-2xl: 28px;
+	--pill: 999px;
+
+	--font-display: 'Space Grotesk', 'DM Sans', system-ui, sans-serif;
+	--font-sans: 'DM Sans', system-ui, sans-serif;
+	--font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+	--ease: cubic-bezier(0.22, 1, 0.36, 1);
+}

--- a/src/lib/utils/ohlc.ts
+++ b/src/lib/utils/ohlc.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Trade-history → OHLC / volume helpers.
+//
+// Extracted from trade/[id]/+page.svelte so the home QuickTrade chart and the
+// trade page share one implementation. The bucket functions are verbatim; the
+// behaviour is unchanged.
+// ─────────────────────────────────────────────────────────────────────────
+import type {
+	TradeHistoryPoint,
+	OHLCBucket,
+	VolumeBucket
+} from '$lib/components/charts/token-chart-types';
+
+// Convert trade points into OHLC candles bucketed by `bucketSeconds`.
+export function tradesToOHLCBuckets(
+	trades: TradeHistoryPoint[],
+	bucketSeconds: number
+): OHLCBucket[] {
+	if (trades.length === 0) return [];
+	const buckets = new Map<number, TradeHistoryPoint[]>();
+	for (const trade of trades) {
+		const bucketTime = Math.floor(trade.timestamp / 1000 / bucketSeconds) * bucketSeconds * 1000;
+		if (!buckets.has(bucketTime)) {
+			buckets.set(bucketTime, []);
+		}
+		buckets.get(bucketTime)!.push(trade);
+	}
+	const ohlcData: OHLCBucket[] = [];
+	const sortedBuckets = Array.from(buckets.entries()).sort((a, b) => a[0] - b[0]);
+	for (const [time, bucketTrades] of sortedBuckets) {
+		if (bucketTrades.length === 0) continue;
+		const sortedTrades = bucketTrades
+			.filter((t) => Number.isFinite(t.price))
+			.sort((a, b) => a.timestamp - b.timestamp);
+		if (sortedTrades.length === 0) continue;
+		const prices = sortedTrades.map((t) => t.price);
+		ohlcData.push({
+			x: time,
+			o: sortedTrades[0].price,
+			h: Math.max(...prices),
+			l: Math.min(...prices),
+			c: sortedTrades[sortedTrades.length - 1].price
+		});
+	}
+	return ohlcData;
+}
+
+// Aggregate traded token volume by the same bucket size as the candles.
+export function tradesToVolumeBuckets(
+	trades: TradeHistoryPoint[],
+	bucketSeconds: number
+): VolumeBucket[] {
+	if (trades.length === 0) return [];
+	const bucketMap = new Map<number, number>();
+	for (const trade of trades) {
+		const bucketTime = Math.floor(trade.timestamp / 1000 / bucketSeconds) * bucketSeconds * 1000;
+		bucketMap.set(bucketTime, (bucketMap.get(bucketTime) ?? 0) + trade.tokens);
+	}
+	return Array.from(bucketMap.entries())
+		.sort((a, b) => a[0] - b[0])
+		.map(([start, tokens]) => ({ start, tokens }));
+}
+
+export interface ApiTradeLike {
+	timestamp: number;
+	inputToken?: { address?: string | null } | null;
+	outputToken?: { address?: string | null } | null;
+	inputAmount: string;
+	outputAmount: string;
+}
+
+// Convert raw API trades into price/volume history points for a given asset.
+// `assetAddresses` is the lowercased set of address variants for the asset;
+// `quoteAddress` is the lowercased settlement-token address. Mirrors the
+// trade page's tradeHistoryPoints derivation (dedup + chronological sort).
+export function apiTradesToHistoryPoints(
+	trades: ApiTradeLike[],
+	assetAddresses: Set<string>,
+	quoteAddress: string
+): TradeHistoryPoint[] {
+	const quote = quoteAddress.toLowerCase();
+	const points: TradeHistoryPoint[] = [];
+
+	for (const trade of trades) {
+		const timestamp = trade.timestamp * 1000;
+		const inputAddr = trade.inputToken?.address?.toLowerCase();
+		const outputAddr = trade.outputToken?.address?.toLowerCase();
+		const inputAmount = parseFloat(trade.inputAmount);
+		const outputAmount = parseFloat(trade.outputAmount);
+
+		let tokens = 0;
+		let quoteAmount = 0;
+		let side: 'bid' | 'ask';
+
+		if (assetAddresses.has(inputAddr ?? '') && outputAddr === quote) {
+			// Order receives asset, gives quote → bid.
+			tokens = Math.abs(inputAmount);
+			quoteAmount = Math.abs(outputAmount);
+			side = 'bid';
+		} else if (assetAddresses.has(outputAddr ?? '') && inputAddr === quote) {
+			// Order gives asset, receives quote → ask.
+			tokens = Math.abs(outputAmount);
+			quoteAmount = Math.abs(inputAmount);
+			side = 'ask';
+		} else {
+			continue;
+		}
+
+		if (tokens <= 0) continue;
+		const price = quoteAmount / tokens;
+		if (!Number.isFinite(price) || price <= 0) continue;
+
+		points.push({ timestamp, price, tokens, quote: quoteAmount, side });
+	}
+
+	const seen = new Set<string>();
+	return points
+		.filter((p) => {
+			const key = `${p.timestamp}-${p.price}-${p.tokens}`;
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.sort((a, b) => a.timestamp - b.timestamp);
+}

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -5,9 +5,12 @@
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Header from '$lib/components/Header.svelte';
 	import TickerTape from '$lib/components/TickerTape.svelte';
+	import AmbientBackground from '$lib/components/AmbientBackground.svelte';
+	import MobileTabBar from '$lib/components/MobileTabBar.svelte';
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { rainlangConfirmationModal, tradePanelOpen } from '$lib/stores';
+	import { navCollapsed } from '$lib/stores/uiStore';
 	import { checkAndStoreAccessCodeFromUrl } from '$lib/utils/accessCodeStorage';
 	// Note: Access check is handled by accessStore's subscription to walletAddress
 
@@ -92,15 +95,10 @@
 	let mobileSidebarOpen = false;
 	let sidebarCollapsed = false;
 
-	// Check if current page should use the clean/floating layout (no sidebar, transparent header)
+	// Landing page uses the clean/floating layout (no sidebar, transparent header)
 	$: isLandingPage = $page.url.pathname === '/';
 	$: isTradePage = $page.url.pathname.startsWith('/trade/');
-	$: isDashboardPage = $page.url.pathname === '/dashboard';
-	$: isMetricsPage = $page.url.pathname === '/platform-metrics';
-	// Landing page: no sidebar, transparent header
-	// Trade/Dashboard/Metrics pages: sidebar visible, with enhanced background
 	$: useCleanLayout = isLandingPage;
-	$: useEnhancedBackground = isLandingPage || isTradePage || isDashboardPage || isMetricsPage;
 
 	// Prevent background scroll when mobile sidebar is open
 	$: if (browser) {
@@ -144,35 +142,9 @@
 	}
 </script>
 
-<div class="relative min-h-screen overflow-x-hidden bg-gray-900 text-white">
-	<!-- Background - enhanced for clean layout pages -->
-	{#if useEnhancedBackground}
-		<div class="pointer-events-none fixed inset-0 z-0">
-			<!-- Gradient overlay -->
-			<div
-				class="absolute inset-0 bg-gradient-to-b from-gray-900 via-gray-900/95 to-gray-900"
-			></div>
-			<!-- Subtle grid pattern -->
-			<div
-				class="absolute inset-0 opacity-[0.02]"
-				style="background-image: linear-gradient(rgba(255,255,255,.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.1) 1px, transparent 1px); background-size: 60px 60px;"
-			></div>
-			<!-- Radial glow accents -->
-			<div
-				class="absolute left-1/4 top-1/4 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-yellow-500/5 blur-3xl"
-			></div>
-			<div
-				class="absolute bottom-1/4 right-1/4 h-[500px] w-[500px] translate-x-1/2 translate-y-1/2 rounded-full bg-blue-500/5 blur-3xl"
-			></div>
-		</div>
-	{:else if !useEnhancedBackground}
-		<!-- Standard background pattern for other pages -->
-		<div class="pointer-events-none fixed inset-0 z-0 opacity-5">
-			<div
-				class="bg-[url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 2000 1000%27%3E%3Cpath d=%27M0,500 Q250,400 500,500 T1000,500 T1500,500 T2000,500%27 stroke=%27%23F3B13C%27 fill=%27none%27 stroke-width=%271%27 opacity=%270.3%27/%3E%3Cpath d=%27M0,400 Q250,300 500,400 T1000,400 T1500,400 T2000,400%27 stroke=%27%231A5C8E%27 fill=%27none%27 stroke-width=%271%27 opacity=%270.3%27/%3E%3Cpath d=%27M0,600 Q250,500 500,600 T1000,600 T1500,600 T2000,600%27 stroke=%27%2337134D%27 fill=%27none%27 stroke-width=%271%27 opacity=%270.3%27/%3E%3C/svg%3E')] h-full w-full bg-cover"
-			/>
-		</div>
-	{/if}
+<div class="relative min-h-screen overflow-x-hidden bg-bg text-text">
+	<!-- Ambient v2 background: drifting auroras + bokeh canvas + grid veil -->
+	<AmbientBackground />
 
 	<!-- Mobile/Tablet sidebar (hidden on clean layout pages) -->
 	{#if !useCleanLayout}
@@ -201,6 +173,7 @@
 		class:lg:ml-64={!useCleanLayout && !sidebarCollapsed}
 		class:lg:ml-0={useCleanLayout || sidebarCollapsed}
 		class:lg:mr-[22rem]={isTradePage && $tradePanelOpen}
+		style={$navCollapsed ? 'padding-bottom: calc(60px + env(safe-area-inset-bottom));' : ''}
 	>
 		<!-- Header for all screen sizes -->
 		<Header
@@ -266,4 +239,7 @@
 	{#if Tutorial}
 		<svelte:component this={Tutorial} />
 	{/if}
+
+	<!-- Mobile bottom tab bar: primary nav once the header collapses -->
+	<MobileTabBar />
 </div>

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -11,6 +11,7 @@
 	import { goto } from '$app/navigation';
 	import Table from '$lib/components/ui/table/Table.svelte';
 	import QuickTrade from '$lib/components/QuickTrade.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { tutorialActive, tutorialStep } from '$lib/stores/tutorialStore';
 	import Footer from '$lib/components/Footer.svelte';
 	import { track, trackPageView } from '$lib/services/analytics';
@@ -172,170 +173,89 @@
 	<section class="px-4 pb-16 pt-20 sm:px-6 sm:pb-24 sm:pt-28 lg:px-8 lg:pb-32 lg:pt-36">
 		<div class="mx-auto max-w-5xl text-center">
 			<h1
-				class="mb-6 text-3xl font-bold tracking-tight text-white sm:mb-8 sm:text-4xl lg:text-5xl xl:text-6xl"
+				class="mb-6 text-3xl font-bold tracking-tight text-text sm:mb-8 sm:text-4xl lg:text-5xl xl:text-6xl"
 			>
 				Tokenised Equities.<br class="sm:hidden" />
-				<span class="text-yellow-400">{displayedText}</span><span
-					class="animate-blink text-yellow-400">|</span
+				<span class="text-accent">{displayedText}</span><span class="animate-blink text-accent"
+					>|</span
 				>
 			</h1>
 
 			<!-- Rewards APY Banner - temporarily hidden -->
 
-			<!-- QuickTrade widget centered below hero -->
-			<div class="flex w-full flex-col items-center gap-4 px-2 sm:px-0">
+			<div
+				class="mx-auto flex w-full max-w-md flex-col items-stretch gap-5 px-2 text-left sm:px-0 md:max-w-none"
+			>
 				<QuickTrade />
+			</div>
+
+			<div class="mt-4 flex justify-center">
 				<button
 					type="button"
-					class="w-full max-w-md rounded-lg bg-yellow-500 px-6 py-3 text-sm font-medium text-black transition hover:bg-yellow-400 sm:w-auto sm:py-2.5"
-					on:click={() => goto('/trade/0x2289249984f1fa2ce86c4e8867e7eb819ea7df95')}
-				>
-					Launch Trading Terminal
-				</button>
-				<button
-					type="button"
-					class="hidden text-sm text-gray-400 underline decoration-gray-500 underline-offset-4 transition hover:text-yellow-500 hover:decoration-yellow-500 sm:inline-block"
+					class="hidden text-sm text-text-3 underline decoration-text-muted underline-offset-4 transition hover:text-accent hover:decoration-accent sm:inline-block"
 					on:click={startTour}
 				>
 					New? Take the tour 👉
 				</button>
 			</div>
 
-			<!-- Trust Indicators -->
-			<div class="mt-12 grid grid-cols-3 gap-3 text-center sm:mt-20 sm:gap-10 lg:mt-24 lg:gap-16">
-				<!-- Decentralised -->
-				<div class="p-2 sm:p-5">
-					<div class="mb-2 flex justify-center sm:mb-4">
+			<!-- Why st0x — trust pillars -->
+			<div class="mt-16 sm:mt-24 lg:mt-28">
+				<p class="text-accent/70 text-xs font-semibold uppercase tracking-[0.2em]">Why st0x</p>
+				<h2 class="mt-3 text-2xl font-bold tracking-tight text-text sm:text-[32px]">
+					Tokenised equities &amp; yield, done properly.
+				</h2>
+				<div class="mt-10 grid gap-8 sm:grid-cols-3">
+					<!-- Decentralised -->
+					<div class="flex flex-col items-center text-center">
 						<div
-							class="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-500/10 sm:h-20 sm:w-20"
+							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
 						>
-							<svg
-								class="h-6 w-6 text-yellow-500 sm:h-10 sm:w-10"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-								/>
-							</svg>
+							<Icon name="blocks" className="h-7 w-7" />
 						</div>
+						<h3 class="mt-4 text-base font-semibold text-text">Decentralised</h3>
+						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
+							Withdraw to your wallet. Compatible with DeFi protocols.
+						</p>
 					</div>
-					<h3 class="mb-1 text-sm font-semibold text-white sm:mb-2 sm:text-xl lg:text-2xl">
-						Decentralised
-					</h3>
-					<p class="hidden text-sm text-gray-300 sm:block sm:text-base">
-						Withdraw to your wallet. Compatible with DeFi protocols
-					</p>
-				</div>
 
-				<!-- Exchange-Linked Liquidity -->
-				<div class="p-2 sm:p-5">
-					<div class="mb-2 flex justify-center sm:mb-4">
+					<!-- Liquid -->
+					<div class="flex flex-col items-center text-center">
 						<div
-							class="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-500/10 sm:h-20 sm:w-20"
+							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
 						>
-							<svg
-								class="h-8 w-8 text-yellow-500 sm:h-12 sm:w-12"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 36 24"
-							>
-								<!-- Swap arrows in center -->
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M21 5l3 3-3 3"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M24 8H16a4 4 0 00-4 4"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M15 19l-3-3 3-3"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M12 16h8a4 4 0 004-4"
-								/>
-								<!-- Institution building (top-left) -->
-								<g transform="translate(1, 1)" stroke-width="1.2">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M0 4l4.5-3 4.5 3" />
-									<path d="M1 4v4" />
-									<path d="M4.5 4v4" />
-									<path d="M8 4v4" />
-									<path stroke-linecap="round" d="M0 8h9" />
-								</g>
-								<!-- Ethereum diamond (bottom-right) -->
-								<g transform="translate(28, 14)" stroke-width="1.2">
-									<path d="M3.5 0L7 5L3.5 6.5L0 5L3.5 0Z" />
-									<path d="M0 5L3.5 4L7 5" />
-									<path d="M3.5 6.5L7 5L3.5 9.5L0 5L3.5 6.5Z" />
-								</g>
-							</svg>
+							<Icon name="swap" className="h-7 w-7" />
 						</div>
+						<h3 class="mt-4 text-base font-semibold text-text">Liquid</h3>
+						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
+							Supply bridged real-time from stock markets. 24/7 trading.
+						</p>
 					</div>
-					<h3 class="mb-1 text-sm font-semibold text-white sm:mb-2 sm:text-xl lg:text-2xl">
-						Liquid
-					</h3>
-					<p class="hidden text-sm text-gray-300 sm:block sm:text-base">
-						Supply bridged real-time from stock markets. 24/7 trading.
-					</p>
-				</div>
 
-				<!-- Fully Backed -->
-				<div class="p-2 sm:p-5">
-					<div class="mb-2 flex justify-center sm:mb-4">
+					<!-- 1:1 Collateralised -->
+					<div class="flex flex-col items-center text-center">
 						<div
-							class="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-500/10 sm:h-20 sm:w-20"
+							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
 						>
-							<svg
-								class="h-6 w-6 text-yellow-500 sm:h-10 sm:w-10"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<!-- Layered security circles with $ -->
-								<circle cx="12" cy="12" r="10" stroke-width="1.5" />
-								<circle cx="12" cy="12" r="7" stroke-dasharray="3 2" stroke-width="1.5" />
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M12 9c-1.1 0-2 .6-2 1.3s.9 1.3 2 1.3 2 .6 2 1.3-.9 1.3-2 1.3m0-5.2c.7 0 1.4.3 1.7.6M12 9v-.5m0 .5v5.2m0 0v.5m0-.5c-.7 0-1.4-.3-1.7-.6"
-								/>
-							</svg>
+							<Icon name="shield" className="h-7 w-7" />
 						</div>
+						<h3 class="mt-4 text-base font-semibold text-text">1:1 Collateralised</h3>
+						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
+							Every token fully collateralised with a legal right of exchange.
+						</p>
 					</div>
-					<h3 class="mb-1 text-sm font-semibold text-white sm:mb-2 sm:text-xl lg:text-2xl">
-						1:1 Collateralised
-					</h3>
-					<p class="hidden text-sm text-gray-300 sm:block sm:text-base">
-						Every token fully collateralised with a legal right of exchange.
-					</p>
 				</div>
 			</div>
 
 			<!-- Pioneer Logos -->
 			<div class="relative z-0 mt-8 text-center sm:mt-16">
-				<p class="mb-3 text-xs text-gray-400 sm:mb-4 sm:text-sm">Built by pioneers from</p>
-				<div class="flex flex-wrap items-center justify-center gap-3 sm:gap-6">
+				<p class="mb-5 text-[13px] font-medium text-text-2">Built by pioneers from</p>
+				<div class="flex flex-wrap items-center justify-center gap-x-10 gap-y-5">
 					{#each pioneerLogos as logo}
 						<img
 							src={logo.src}
 							alt={logo.alt}
-							class="h-4 w-auto opacity-60 grayscale transition-opacity hover:opacity-100 hover:grayscale-0 sm:h-6"
+							class="pioneer-logo h-4 w-auto opacity-60 grayscale transition-opacity hover:opacity-100 hover:grayscale-0 sm:h-6"
 							style="transform: scale({logo.scale})"
 							loading="lazy"
 						/>
@@ -353,31 +273,35 @@
 					<LoadingSpinner variant="fullscreen" size="lg" text="Loading assets..." />
 				</div>
 			{:else if vaultsError}
-				<div class="flex w-full items-center justify-center py-16 text-sm text-red-400">
+				<div class="flex w-full items-center justify-center py-16 text-sm text-down">
 					Failed to load assets: {vaultsError}
 				</div>
 			{:else if hasVaults}
-				<div class="overflow-hidden rounded-xl" data-tutorial="token-list">
+				<div
+					class="overflow-hidden rounded-xl border border-line bg-overlay-1"
+					data-tutorial="token-list"
+				>
 					<Table>
 						<thead>
 							<tr>
 								<th
-									class="sticky left-0 z-10 px-3 py-3 text-left text-xs font-medium text-gray-400 sm:px-5 sm:py-4"
+									class="sticky left-0 z-10 px-3 py-3 text-left text-[11px] font-medium uppercase tracking-wider text-text-3 sm:px-5"
 									>Token</th
 								>
-								<th class="px-3 py-3 text-left text-xs font-medium text-gray-400 sm:px-5 sm:py-4"
+								<th
+									class="px-3 py-3 text-left text-[11px] font-medium uppercase tracking-wider text-text-3 sm:px-5"
 									>Price</th
 								>
 								<th
-									class="hidden px-3 py-3 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-5 sm:py-4"
+									class="hidden px-3 py-3 text-left text-[11px] font-medium uppercase tracking-wider text-text-3 sm:table-cell sm:px-5"
 									>TVL</th
 								>
 								<th
-									class="hidden px-3 py-3 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-5 sm:py-4"
+									class="hidden px-3 py-3 text-left text-[11px] font-medium uppercase tracking-wider text-text-3 sm:table-cell sm:px-5"
 									>Bridged On-Chain</th
 								>
 								<th
-									class="hidden px-3 py-3 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-5 sm:py-4"
+									class="hidden px-3 py-3 text-left text-[11px] font-medium uppercase tracking-wider text-text-3 sm:table-cell sm:px-5"
 									>Holders</th
 								>
 								<th class="w-10"></th>
@@ -386,7 +310,7 @@
 						<tbody>
 							{#if !processedTokens.length}
 								<tr>
-									<td colspan="6" class="px-5 py-8 text-center text-sm text-gray-400">
+									<td colspan="6" class="px-5 py-8 text-center text-sm text-text-3">
 										No assets available.
 									</td>
 								</tr>
@@ -400,7 +324,7 @@
 											? bridgedSupply * displayPrice
 											: null}
 									<tr
-										class="cursor-pointer transition-all hover:bg-yellow-500/5"
+										class="cursor-pointer transition-all hover:bg-surface-2"
 										on:click={() => {
 											track('token_clicked', {
 												token_symbol: token.symbol,
@@ -411,19 +335,21 @@
 										}}
 									>
 										<td class="sticky left-0 z-10 px-3 py-3 sm:px-5 sm:py-4">
-											<TokenDisplay
-												logoUrl={findApiTokenByAnyAddress(apiTokens, token.address)?.logoUrl}
-												symbol={token.symbol}
-												name={token.name}
-											/>
+											<div class="flex items-center gap-2">
+												<TokenDisplay
+													logoUrl={findApiTokenByAnyAddress(apiTokens, token.address)?.logoUrl}
+													symbol={token.symbol}
+													showName={false}
+												/>
+											</div>
 										</td>
 										<td class="px-3 py-3 sm:px-5 sm:py-4">
-											<div class="font-medium text-white">
+											<div class="font-mono font-medium text-text">
 												{Number.isFinite(displayPrice) ? `$${displayPrice.toFixed(2)}` : 'N/A'}
 											</div>
 										</td>
 										<td class="hidden px-3 py-3 sm:table-cell sm:px-5 sm:py-4">
-											<div class="text-sm text-gray-300">
+											<div class="font-mono text-sm text-text-2">
 												{#if marketCap != null}
 													{marketCap >= 1_000_000
 														? `$${(marketCap / 1_000_000).toFixed(2)}M`
@@ -436,29 +362,17 @@
 											</div>
 										</td>
 										<td class="hidden px-3 py-3 sm:table-cell sm:px-5 sm:py-4">
-											<div class="text-sm text-gray-300">
+											<div class="font-mono text-sm text-text-2">
 												{bridgedSupply >= 1000
 													? `${(bridgedSupply / 1000).toFixed(2)}K`
 													: bridgedSupply.toFixed(2)}
 											</div>
 										</td>
 										<td class="hidden px-3 py-3 sm:table-cell sm:px-5 sm:py-4">
-											<div class="text-sm text-gray-300">{token.totalHolders}</div>
+											<div class="font-mono text-sm text-text-2">{token.totalHolders}</div>
 										</td>
 										<td class="px-3 py-3 sm:px-5 sm:py-4">
-											<svg
-												class="h-4 w-4 text-gray-500"
-												fill="none"
-												stroke="currentColor"
-												viewBox="0 0 24 24"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M9 5l7 7-7 7"
-												/>
-											</svg>
+											<Icon name="arrowRight" className="h-4 w-4 text-text-muted" />
 										</td>
 									</tr>
 								{/each}
@@ -468,7 +382,7 @@
 				</div>
 
 				<!-- More Coming Soon -->
-				<p class="mt-6 text-center text-base text-gray-400">More equities coming soon!</p>
+				<p class="mt-5 text-center text-sm text-text-3">More equities coming soon</p>
 			{:else}
 				<div class="flex w-full items-center justify-center py-16">
 					<EmptyState
@@ -487,6 +401,17 @@
 	/* Blinking cursor animation for typewriter */
 	.animate-blink {
 		animation: blink 1s step-end infinite;
+	}
+
+	/* Pioneer logos are light/white assets (drawn for the dark shell). In light mode
+	   darken them to a legible silhouette instead of near-invisible light-grey. */
+	:global([data-theme='light']) .pioneer-logo {
+		filter: brightness(0);
+		opacity: 0.55;
+	}
+	:global([data-theme='light']) .pioneer-logo:hover {
+		filter: brightness(0);
+		opacity: 0.85;
 	}
 
 	@keyframes blink {

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -207,11 +207,13 @@
 				</h2>
 				<div class="mt-10 grid gap-8 sm:grid-cols-3">
 					<!-- Decentralised -->
-					<div class="flex flex-col items-center text-center">
-						<div
-							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
-						>
-							<Icon name="blocks" className="h-7 w-7" />
+					<div class="icon-trigger flex flex-col items-center text-center">
+						<div class="pillar-float">
+							<div
+								class="pillar-tile flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
+							>
+								<Icon name="blocks" className="h-7 w-7" />
+							</div>
 						</div>
 						<h3 class="mt-4 text-base font-semibold text-text">Decentralised</h3>
 						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
@@ -220,11 +222,13 @@
 					</div>
 
 					<!-- Liquid -->
-					<div class="flex flex-col items-center text-center">
-						<div
-							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
-						>
-							<Icon name="swap" className="h-7 w-7" />
+					<div class="icon-trigger flex flex-col items-center text-center">
+						<div class="pillar-float" style="animation-delay: -2.3s">
+							<div
+								class="pillar-tile flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
+							>
+								<Icon name="swap" className="h-7 w-7" />
+							</div>
 						</div>
 						<h3 class="mt-4 text-base font-semibold text-text">Liquid</h3>
 						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
@@ -233,11 +237,13 @@
 					</div>
 
 					<!-- 1:1 Collateralised -->
-					<div class="flex flex-col items-center text-center">
-						<div
-							class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
-						>
-							<Icon name="shield" className="h-7 w-7" />
+					<div class="icon-trigger flex flex-col items-center text-center">
+						<div class="pillar-float" style="animation-delay: -4.6s">
+							<div
+								class="pillar-tile flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-400/[0.08] text-accent"
+							>
+								<Icon name="shield" className="h-7 w-7" />
+							</div>
 						</div>
 						<h3 class="mt-4 text-base font-semibold text-text">1:1 Collateralised</h3>
 						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
@@ -324,7 +330,7 @@
 											? bridgedSupply * displayPrice
 											: null}
 									<tr
-										class="cursor-pointer transition-all hover:bg-surface-2"
+										class="icon-trigger cursor-pointer transition-all hover:bg-surface-2"
 										on:click={() => {
 											track('token_clicked', {
 												token_symbol: token.symbol,
@@ -372,7 +378,7 @@
 											<div class="font-mono text-sm text-text-2">{token.totalHolders}</div>
 										</td>
 										<td class="px-3 py-3 sm:px-5 sm:py-4">
-											<Icon name="arrowRight" className="h-4 w-4 text-text-muted" />
+											<Icon name="arrowRight" className="icon-slide h-4 w-4 text-text-muted" />
 										</td>
 									</tr>
 								{/each}

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -1178,10 +1178,10 @@
 								href={basescanUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="rounded p-1 text-text-3 hover:bg-surface-2 hover:text-text-2"
+								class="icon-trigger rounded p-1 text-text-3 hover:bg-surface-2 hover:text-text-2"
 								title="View on Basescan"
 							>
-								<Icon name="arrowUpRight" className="h-3.5 w-3.5" />
+								<Icon name="arrowUpRight" className="icon-slide-up h-3.5 w-3.5" />
 							</a>
 						</div>
 					</div>

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -23,6 +23,8 @@
 	import { formatUnits, erc20Abi } from 'viem';
 	import { readContracts, getBalance } from '@wagmi/core';
 	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
+	import type { CategorizedToken } from '$lib/config/network';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { goto } from '$app/navigation';
 	import { transformApiTakerTradesToDisplay } from '$lib/utils/tradeTransform';
 	import Table from '$lib/components/ui/table/Table.svelte';
@@ -73,7 +75,13 @@
 	const DEFAULT_VAULT_ID = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
 	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	// Default to [] (not undefined): the createQuery(derived(...)) closures below run
+	// at component init, BEFORE these reactive statements first flush. Reading
+	// ALL_TOKENS.length on an undefined value there threw an intermittent
+	// "Cannot read properties of undefined (reading 'length')" on dashboard load.
+	let ALL_TOKENS: CategorizedToken[] = [];
 	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
+	let paymentTokens: CategorizedToken[] = [];
 	$: paymentTokens = ALL_TOKENS.filter((token) => token.category === 'CRYPTO');
 
 	// Set of valid token addresses (asset tokens + payment tokens) for filtering
@@ -1109,8 +1117,8 @@
 </script>
 
 <!-- Main Content -->
-<div class="relative z-10 min-h-screen text-white">
-	<PageContainer>
+<div class="relative z-10 min-h-screen text-text">
+	<PageContainer className="mx-auto max-w-5xl">
 		{#if isNetworkLoading}
 			<div class="flex flex-col items-center justify-center gap-4 py-8">
 				<LoadingSpinner
@@ -1130,19 +1138,19 @@
 				<div class="mb-6 flex flex-wrap items-start justify-between gap-4">
 					<div>
 						<h1 class="text-2xl font-bold">My Dashboard</h1>
-						<div class="flex items-center gap-2 text-gray-400">
+						<div class="flex items-center gap-2 font-mono text-sm text-text-2">
 							<span class="sm:hidden">…{($walletAddress || '').slice(-6)}</span>
 							<span class="hidden sm:inline">{truncateAddress($walletAddress || '')}</span>
 							<!-- Copy button -->
 							<button
 								type="button"
 								on:click={copyAddress}
-								class="rounded p-1 text-gray-500 hover:bg-white/10 hover:text-gray-300"
+								class="rounded p-1 text-text-3 hover:bg-surface-2 hover:text-text-2"
 								title="Copy address"
 							>
 								{#if addressCopied}
 									<svg
-										class="h-4 w-4 text-green-400"
+										class="h-4 w-4 text-up"
 										fill="none"
 										stroke="currentColor"
 										viewBox="0 0 24 24"
@@ -1170,31 +1178,17 @@
 								href={basescanUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="rounded p-1 text-gray-500 hover:bg-white/10 hover:text-gray-300"
+								class="rounded p-1 text-text-3 hover:bg-surface-2 hover:text-text-2"
 								title="View on Basescan"
 							>
-								<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="2"
-										d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-									/>
-								</svg>
+								<Icon name="arrowUpRight" className="h-3.5 w-3.5" />
 							</a>
 						</div>
 					</div>
 					<div class="flex gap-2">
 						<Button variant="primary" size="sm" on:click={() => openDepositModal()}>
 							<span class="flex items-center gap-1.5">
-								<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="2"
-										d="M12 4v16m8-8H4"
-									/>
-								</svg>
+								<Icon name="plus" className="h-4 w-4" />
 								Deposit
 							</span>
 						</Button>
@@ -1217,15 +1211,16 @@
 				</div>
 
 				<!-- Overview Stats -->
-				<div class="grid grid-cols-3 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-4">
+				<div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
 					<MetricCard
 						label="Total Value"
 						value={`$${totalValue.toFixed(2)}`}
+						cardClass="h-full border border-line bg-overlay-1"
 						paddingClass="p-3 sm:p-4"
 						showGradient={false}
-						valueClass="text-lg font-bold sm:text-2xl"
+						valueClass="font-mono text-lg font-bold sm:text-2xl"
 					/>
-					<div class="hidden sm:block">
+					<div class="hidden h-full sm:block">
 						<MetricCard
 							label="Unrealized P&L"
 							value={$costBasisQuery?.isLoading
@@ -1233,33 +1228,36 @@
 								: totalUnrealizedPnL === 0
 									? '$0.00'
 									: `${totalUnrealizedPnL >= 0 ? '+' : ''}$${totalUnrealizedPnL.toFixed(2)}`}
+							cardClass="h-full border border-line bg-overlay-1"
 							paddingClass="p-4"
 							showGradient={false}
 							change=""
-							valueClass={`text-2xl font-bold ${
+							valueClass={`font-mono text-2xl font-bold ${
 								$costBasisQuery?.isLoading
-									? 'animate-pulse text-gray-400'
+									? 'animate-pulse text-text-2'
 									: totalUnrealizedPnL > 0
-										? 'text-green-400'
+										? 'text-up'
 										: totalUnrealizedPnL < 0
-											? 'text-red-400'
-											: 'text-gray-400'
+											? 'text-down'
+											: 'text-text-2'
 							}`}
 						/>
 					</div>
 					<MetricCard
 						label="Active Orders"
 						value={`${activeOrdersCount}`}
+						cardClass="h-full border border-line bg-overlay-1"
 						paddingClass="p-3 sm:p-4"
 						showGradient={false}
-						valueClass="text-lg font-bold sm:text-2xl"
+						valueClass="font-mono text-lg font-bold sm:text-2xl"
 					/>
 					<MetricCard
 						label="Active Vaults"
 						value={`${activeVaultsCount}`}
+						cardClass="h-full border border-line bg-overlay-1"
 						paddingClass="p-3 sm:p-4"
 						showGradient={false}
-						valueClass="text-lg font-bold sm:text-2xl"
+						valueClass="font-mono text-lg font-bold sm:text-2xl"
 					/>
 				</div>
 			</Section>
@@ -1272,12 +1270,12 @@
 				<!-- Hide Dust Checkbox -->
 				<div class="flex justify-end px-1 pb-2 pt-1">
 					<label
-						class="flex cursor-pointer items-center gap-1.5 text-xs text-gray-400 sm:gap-2 sm:text-sm"
+						class="flex cursor-pointer items-center gap-1.5 text-xs text-text-2 sm:gap-2 sm:text-sm"
 					>
 						<input
 							type="checkbox"
 							bind:checked={hideDust}
-							class="h-3.5 w-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-gray-900 sm:h-4 sm:w-4"
+							class="h-3.5 w-3.5 rounded border-line bg-surface-3 text-accent focus:ring-accent-line focus:ring-offset-surface-1 sm:h-4 sm:w-4"
 						/>
 						Hide dust
 					</label>
@@ -1290,79 +1288,83 @@
 					<!-- Funds Section (Payment Tokens) -->
 					<Section>
 						<h2 class="mb-3 text-base font-semibold sm:mb-4 sm:text-lg">Funds</h2>
-						<p class="mb-3 hidden text-sm text-gray-400 sm:mb-4 sm:block">
+						<p class="mb-3 hidden text-sm text-text-2 sm:mb-4 sm:block">
 							Payment tokens available for trading
 						</p>
 						{#if fundsHoldings.length > 0}
-							<div class="overflow-x-auto">
-								<Table>
-									<thead>
-										<tr>
-											<th
-												class="sticky left-0 z-10 px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>Token</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Wallet</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Vaults</th
-											>
-											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>Total</th
-											>
-											{#if $authMethod === 'dynamic'}
+							<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1">
+								<div class="overflow-x-auto">
+									<Table>
+										<thead>
+											<tr>
 												<th
-													class="px-2 py-2 text-center text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+													class="sticky left-0 z-10 bg-surface-1 px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>Token</th
+												>
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Wallet</th
+												>
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Vaults</th
+												>
+												<th
+													class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>Total</th
+												>
+												<th
+													class="px-2 py-2 text-right text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												></th>
-											{/if}
-										</tr>
-									</thead>
-									<tbody>
-										{#each fundsHoldings as holding}
-											{@const isEth = holding.address === 'native'}
-											{@const paymentToken = isEth
-												? null
-												: paymentTokens.find(
-														(t) => t.address.toLowerCase() === holding.address.toLowerCase()
-													)}
-											{@const logoUrl = isEth ? '/images/ETH.svg' : paymentToken?.logoUrl}
-											{@const decimalsForDisplay = holding.decimals === 6 ? 2 : 4}
-											<tr class="hover:bg-white/5">
-												<td class="sticky left-0 px-2 py-2 sm:px-4 sm:py-3">
-													<TokenDisplay {logoUrl} symbol={holding.symbol} name={holding.name} />
-												</td>
-												<td class="hidden px-2 py-2 text-gray-300 sm:table-cell sm:px-4 sm:py-3"
-													>{holding.walletBalanceNum.toFixed(decimalsForDisplay)}</td
-												>
-												<td class="hidden px-2 py-2 text-gray-300 sm:table-cell sm:px-4 sm:py-3"
-													>{holding.vaultBalanceNum.toFixed(decimalsForDisplay)}</td
-												>
-												<td class="px-2 py-2 text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
-													>{holding.totalBalance.toFixed(decimalsForDisplay)}</td
-												>
-												{#if $authMethod === 'dynamic'}
-													<td class="px-2 py-2 sm:px-4 sm:py-3">
-														{#if holding.walletBalanceNum > 0}
-															<Button
-																variant="secondary"
-																size="sm"
-																on:click={() => handleWithdraw(holding)}
-															>
-																Withdraw
-															</Button>
-														{:else}
-															<span class="text-gray-500">—</span>
-														{/if}
-													</td>
-												{/if}
 											</tr>
-										{/each}
-									</tbody>
-								</Table>
+										</thead>
+										<tbody>
+											{#each fundsHoldings as holding}
+												{@const isEth = holding.address === 'native'}
+												{@const isUsdc = holding.symbol === 'USDC'}
+												{@const paymentToken = isEth
+													? null
+													: paymentTokens.find(
+															(t) => t.address.toLowerCase() === holding.address.toLowerCase()
+														)}
+												{@const logoUrl = isEth ? '/images/ETH.svg' : paymentToken?.logoUrl}
+												{@const decimalsForDisplay = holding.decimals === 6 ? 2 : 4}
+												<tr class="border-t border-line hover:bg-overlay-hover">
+													<td class="sticky left-0 bg-surface-1 px-2 py-2 sm:px-4 sm:py-3">
+														<TokenDisplay {logoUrl} symbol={holding.symbol} name={holding.name} />
+													</td>
+													<td
+														class="hidden px-2 py-2 font-mono text-text-2 sm:table-cell sm:px-4 sm:py-3"
+														>{holding.walletBalanceNum.toFixed(decimalsForDisplay)}</td
+													>
+													<td
+														class="hidden px-2 py-2 font-mono text-text-2 sm:table-cell sm:px-4 sm:py-3"
+														>{holding.vaultBalanceNum.toFixed(decimalsForDisplay)}</td
+													>
+													<td
+														class="px-2 py-2 font-mono text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
+														>{holding.totalBalance.toFixed(decimalsForDisplay)}</td
+													>
+													<td class="px-2 py-2 text-right sm:px-4 sm:py-3">
+														<div class="flex items-center justify-end gap-2">
+															{#if $authMethod === 'dynamic' && holding.walletBalanceNum > 0}
+																<Button
+																	variant="secondary"
+																	size="sm"
+																	on:click={() => handleWithdraw(holding)}
+																>
+																	Withdraw
+																</Button>
+															{:else if !isUsdc}
+																<span class="text-text-3">—</span>
+															{/if}
+														</div>
+													</td>
+												</tr>
+											{/each}
+										</tbody>
+									</Table>
+								</div>
 							</div>
 						{:else}
 							<EmptyState description="No funds found in your wallet or vaults." />
@@ -1375,7 +1377,7 @@
 						<div class="mb-3 flex flex-wrap items-center justify-between gap-3 sm:mb-4">
 							<h2 class="text-base font-semibold sm:text-lg">Holdings</h2>
 							<label
-								class="inline-flex cursor-pointer items-center gap-2 text-xs text-gray-300 sm:text-sm"
+								class="inline-flex cursor-pointer items-center gap-2 text-xs text-text-2 sm:text-sm"
 							>
 								<input
 									type="checkbox"
@@ -1383,226 +1385,234 @@
 									checked={$holdingsDenom === 'unwrapped'}
 									on:change={(e) =>
 										holdingsDenom.set(e.currentTarget.checked ? 'unwrapped' : 'wrapped')}
-									class="h-3.5 w-3.5 rounded border-white/20 bg-transparent text-yellow-400 focus:ring-yellow-400/40"
+									class="h-3.5 w-3.5 rounded border-line-strong bg-transparent text-accent focus:ring-accent-line"
 								/>
 								<span>Display holdings in unwrapped equivalents</span>
 							</label>
 						</div>
-						<p class="mb-3 hidden text-sm text-gray-400 sm:mb-4 sm:block">
+						<p class="mb-3 hidden text-sm text-text-2 sm:mb-4 sm:block">
 							Wrapped tokens combined across wallet and vaults. We recommend only using wrapped
 							tokens for DEX/DeFi usage.
 						</p>
 						{#if assetHoldings.length > 0}
-							<div class="overflow-x-auto">
-								<Table>
-									<thead>
-										<tr>
-											<th
-												class="sticky left-0 z-10 px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>Token</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Wallet</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Vaults</th
-											>
-											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>Holdings</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Price</th
-											>
-											<th
-												class="hidden px-2 py-2 text-left text-xs font-medium text-gray-400 sm:table-cell sm:px-4 sm:py-3"
-												>Cost Basis</th
-											>
-											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>Value</th
-											>
-											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-												>P&L</th
-											>
-											<th
-												class="px-2 py-2 text-center text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
-											></th>
-										</tr>
-									</thead>
-									<tbody>
-										{#each assetHoldings as holding}
-											{@const rowRatio = resolveHoldingRatio(holding.address)}
-											{@const rowSymbol = displayUnwrappedSymbol(holding.symbol)}
-											<tr class="hover:bg-white/5">
-												<td class="sticky left-0 px-2 py-2 sm:px-4 sm:py-3">
-													<TokenDisplay
-														logoUrl={findApiTokenByAnyAddress(ALL_TOKENS, holding.address)?.logoUrl}
-														symbol={rowSymbol}
-														name={holding.name}
-														hideNameOnMobile={true}
-													/>
-												</td>
-												<td
-													class="hidden px-2 py-2 text-sm text-gray-300 sm:table-cell sm:px-4 sm:py-3"
-													>{(holding.walletBalanceNum * rowRatio).toFixed(4)}</td
+							<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1">
+								<div class="overflow-x-auto">
+									<Table>
+										<thead>
+											<tr>
+												<th
+													class="sticky left-0 z-10 bg-surface-1 px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>Token</th
 												>
-												<td
-													class="hidden px-2 py-2 text-sm text-gray-300 sm:table-cell sm:px-4 sm:py-3"
-													>{(holding.vaultBalanceNum * rowRatio).toFixed(4)}</td
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Wallet</th
 												>
-												<td class="px-2 py-2 text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
-													>{(holding.totalBalance * rowRatio).toFixed(4)}</td
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Vaults</th
 												>
-												<td class="hidden px-2 py-2 text-sm sm:table-cell sm:px-4 sm:py-3"
-													>${(holding.price / rowRatio).toFixed(2)}</td
+												<th
+													class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>Holdings</th
 												>
-												<td class="hidden px-2 py-2 text-sm sm:table-cell sm:px-4 sm:py-3">
-													{#if $costBasisQuery?.isLoading}
-														<span class="animate-pulse text-gray-400">Loading...</span>
-													{:else}
-														<div class="flex items-center gap-1">
-															{#if holding.avgCostBasis !== null}
-																<span>${(holding.avgCostBasis / rowRatio).toFixed(2)}</span>
-															{:else}
-																<span class="text-gray-500">—</span>
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Price</th
+												>
+												<th
+													class="hidden px-2 py-2 text-left text-xs font-medium text-text-2 sm:table-cell sm:px-4 sm:py-3"
+													>Cost Basis</th
+												>
+												<th
+													class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>Value</th
+												>
+												<th
+													class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+													>P&L</th
+												>
+												<th
+													class="px-2 py-2 text-center text-xs font-medium text-text-2 sm:px-4 sm:py-3"
+												></th>
+											</tr>
+										</thead>
+										<tbody>
+											{#each assetHoldings as holding}
+												{@const rowRatio = resolveHoldingRatio(holding.address)}
+												{@const rowSymbol = displayUnwrappedSymbol(holding.symbol)}
+												<tr class="border-t border-line hover:bg-overlay-hover">
+													<td class="sticky left-0 bg-surface-1 px-2 py-2 sm:px-4 sm:py-3">
+														<div class="flex items-center gap-2">
+															<TokenDisplay
+																logoUrl={findApiTokenByAnyAddress(ALL_TOKENS, holding.address)
+																	?.logoUrl}
+																symbol={rowSymbol}
+																name={holding.name}
+																hideNameOnMobile={true}
+															/>
+														</div>
+													</td>
+													<td
+														class="hidden px-2 py-2 font-mono text-sm text-text-2 sm:table-cell sm:px-4 sm:py-3"
+														>{(holding.walletBalanceNum * rowRatio).toFixed(4)}</td
+													>
+													<td
+														class="hidden px-2 py-2 font-mono text-sm text-text-2 sm:table-cell sm:px-4 sm:py-3"
+														>{(holding.vaultBalanceNum * rowRatio).toFixed(4)}</td
+													>
+													<td
+														class="px-2 py-2 font-mono text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
+														>{(holding.totalBalance * rowRatio).toFixed(4)}</td
+													>
+													<td
+														class="hidden px-2 py-2 font-mono text-sm sm:table-cell sm:px-4 sm:py-3"
+														>${(holding.price / rowRatio).toFixed(2)}</td
+													>
+													<td class="hidden px-2 py-2 text-sm sm:table-cell sm:px-4 sm:py-3">
+														{#if $costBasisQuery?.isLoading}
+															<span class="animate-pulse text-text-2">Loading...</span>
+														{:else}
+															<div class="flex items-center gap-1">
+																{#if holding.avgCostBasis !== null}
+																	<span class="font-mono"
+																		>${(holding.avgCostBasis / rowRatio).toFixed(2)}</span
+																	>
+																{:else}
+																	<span class="text-text-3">—</span>
+																{/if}
+																{#if holding.untrackedBalance > 0.0001}
+																	<button
+																		type="button"
+																		on:click={() => openCostBasisModal(holding)}
+																		class="ml-1 rounded p-0.5 text-text-2 transition hover:bg-surface-2 hover:text-accent"
+																		title={holding.manualEntry
+																			? `Edit cost basis for ${holding.untrackedBalance.toFixed(
+																					4
+																				)} untracked tokens`
+																			: `Add cost basis for ${holding.untrackedBalance.toFixed(
+																					4
+																				)} untracked tokens`}
+																	>
+																		<svg
+																			class="h-3.5 w-3.5"
+																			fill="none"
+																			stroke="currentColor"
+																			viewBox="0 0 24 24"
+																		>
+																			<path
+																				stroke-linecap="round"
+																				stroke-linejoin="round"
+																				stroke-width="2"
+																				d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+																			/>
+																		</svg>
+																	</button>
+																{/if}
+															</div>
+															{#if holding.untrackedBalance > 0.0001 && !holding.manualEntry}
+																<div class="mt-0.5 text-xs text-text-3">
+																	{holding.untrackedBalance.toFixed(2)} untracked
+																</div>
 															{/if}
-															{#if holding.untrackedBalance > 0.0001}
+														{/if}
+													</td>
+													<td
+														class="px-2 py-2 font-mono text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
+														>${holding.value.toFixed(2)}</td
+													>
+													<td class="px-2 py-2 font-mono text-sm sm:px-4 sm:py-3">
+														{#if $costBasisQuery?.isLoading}
+															<span class="animate-pulse text-text-2">Loading...</span>
+														{:else if holding.unrealizedPnL !== null}
+															<div class={holding.unrealizedPnL >= 0 ? 'text-up' : 'text-down'}>
+																<div class="font-medium">
+																	{holding.unrealizedPnLPercent !== null
+																		? `${
+																				holding.unrealizedPnLPercent >= 0 ? '+' : ''
+																			}${holding.unrealizedPnLPercent.toFixed(1)}%`
+																		: '—'}
+																</div>
+																<div class="hidden text-xs opacity-75 sm:block">
+																	{holding.unrealizedPnL >= 0
+																		? '+'
+																		: ''}${holding.unrealizedPnL.toFixed(2)}
+																</div>
+															</div>
+														{:else if holding.untrackedBalance > 0.0001}
+															<button
+																type="button"
+																on:click={() => openCostBasisModal(holding)}
+																class="text-accent underline decoration-dotted underline-offset-2 transition hover:text-accent"
+															>
+																Add cost basis
+															</button>
+														{:else}
+															<span class="text-text-3">—</span>
+														{/if}
+													</td>
+													<td class="px-2 py-2 sm:px-4 sm:py-3">
+														<div class="flex justify-center gap-2">
+															<Button
+																size="sm"
+																variant="primary"
+																on:click={() => goto(`/trade/${holding.id}`)}>Trade</Button
+															>
+															{#if getWrappingMappingByWrappedAddress(holding.address) && holding.walletBalanceNum > 0}
+																<Button
+																	size="sm"
+																	variant="secondary"
+																	on:click={() => handleUnwrapToken(holding)}
+																>
+																	Unwrap
+																</Button>
+															{/if}
+															{#if $authMethod === 'dynamic' && holding.walletBalanceNum > 0}
+																<Button
+																	size="sm"
+																	variant="secondary"
+																	on:click={() => handleWithdraw(holding)}
+																>
+																	Transfer
+																</Button>
+															{/if}
+															{#if !isEmbeddedWallet}
 																<button
 																	type="button"
-																	on:click={() => openCostBasisModal(holding)}
-																	class="ml-1 rounded p-0.5 text-gray-400 transition hover:bg-white/10 hover:text-yellow-400"
-																	title={holding.manualEntry
-																		? `Edit cost basis for ${holding.untrackedBalance.toFixed(
-																				4
-																			)} untracked tokens`
-																		: `Add cost basis for ${holding.untrackedBalance.toFixed(
-																				4
-																			)} untracked tokens`}
+																	on:click={() =>
+																		addTokenToWallet({
+																			address: holding.address,
+																			symbol: holding.symbol,
+																			decimals: holding.decimals,
+																			image: findApiTokenByAnyAddress(ALL_TOKENS, holding.address)
+																				?.logoUrl
+																		})}
+																	class="inline-flex items-center justify-center rounded-md border border-line bg-surface-2 p-1.5 text-text-2 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-700 dark:hover:text-blue-300"
+																	title="Track in Wallet"
+																	aria-label="Track in Wallet"
 																>
 																	<svg
-																		class="h-3.5 w-3.5"
+																		class="h-4 w-4"
+																		viewBox="0 0 24 24"
 																		fill="none"
 																		stroke="currentColor"
-																		viewBox="0 0 24 24"
+																		stroke-width="2"
 																	>
 																		<path
+																			d="M12 5v14M5 12h14"
 																			stroke-linecap="round"
 																			stroke-linejoin="round"
-																			stroke-width="2"
-																			d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
 																		/>
 																	</svg>
 																</button>
 															{/if}
 														</div>
-														{#if holding.untrackedBalance > 0.0001 && !holding.manualEntry}
-															<div class="mt-0.5 text-xs text-yellow-500/70">
-																{holding.untrackedBalance.toFixed(2)} untracked
-															</div>
-														{/if}
-													{/if}
-												</td>
-												<td class="px-2 py-2 text-xs font-medium sm:px-4 sm:py-3 sm:text-sm"
-													>${holding.value.toFixed(2)}</td
-												>
-												<td class="px-2 py-2 text-sm sm:px-4 sm:py-3">
-													{#if $costBasisQuery?.isLoading}
-														<span class="animate-pulse text-gray-400">Loading...</span>
-													{:else if holding.unrealizedPnL !== null}
-														<div
-															class={holding.unrealizedPnL >= 0 ? 'text-green-400' : 'text-red-400'}
-														>
-															<div class="font-medium">
-																{holding.unrealizedPnLPercent !== null
-																	? `${
-																			holding.unrealizedPnLPercent >= 0 ? '+' : ''
-																		}${holding.unrealizedPnLPercent.toFixed(1)}%`
-																	: '—'}
-															</div>
-															<div class="hidden text-xs opacity-75 sm:block">
-																{holding.unrealizedPnL >= 0
-																	? '+'
-																	: ''}${holding.unrealizedPnL.toFixed(2)}
-															</div>
-														</div>
-													{:else if holding.untrackedBalance > 0.0001}
-														<button
-															type="button"
-															on:click={() => openCostBasisModal(holding)}
-															class="text-yellow-500/70 underline decoration-dotted underline-offset-2 transition hover:text-yellow-400"
-														>
-															Add cost basis
-														</button>
-													{:else}
-														<span class="text-gray-500">—</span>
-													{/if}
-												</td>
-												<td class="px-2 py-2 sm:px-4 sm:py-3">
-													<div class="flex justify-center gap-2">
-														<Button
-															size="sm"
-															variant="primary"
-															on:click={() => goto(`/trade/${holding.id}`)}>Trade</Button
-														>
-														{#if getWrappingMappingByWrappedAddress(holding.address) && holding.walletBalanceNum > 0}
-															<Button
-																size="sm"
-																variant="secondary"
-																on:click={() => handleUnwrapToken(holding)}
-															>
-																Unwrap
-															</Button>
-														{/if}
-														{#if $authMethod === 'dynamic' && holding.walletBalanceNum > 0}
-															<Button
-																size="sm"
-																variant="secondary"
-																on:click={() => handleWithdraw(holding)}
-															>
-																Transfer
-															</Button>
-														{/if}
-														{#if !isEmbeddedWallet}
-															<button
-																type="button"
-																on:click={() =>
-																	addTokenToWallet({
-																		address: holding.address,
-																		symbol: holding.symbol,
-																		decimals: holding.decimals,
-																		image: findApiTokenByAnyAddress(ALL_TOKENS, holding.address)
-																			?.logoUrl
-																	})}
-																class="inline-flex items-center justify-center rounded-md border border-white/10 bg-white/5 p-1.5 text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300"
-																title="Track in Wallet"
-																aria-label="Track in Wallet"
-															>
-																<svg
-																	class="h-4 w-4"
-																	viewBox="0 0 24 24"
-																	fill="none"
-																	stroke="currentColor"
-																	stroke-width="2"
-																>
-																	<path
-																		d="M12 5v14M5 12h14"
-																		stroke-linecap="round"
-																		stroke-linejoin="round"
-																	/>
-																</svg>
-															</button>
-														{/if}
-													</div>
-												</td>
-											</tr>
-										{/each}
-									</tbody>
-								</Table>
+													</td>
+												</tr>
+											{/each}
+										</tbody>
+									</Table>
+								</div>
 							</div>
 						{:else}
 							<EmptyState description="No asset holdings found in your wallet or vaults." />
@@ -1612,10 +1622,10 @@
 					<!-- Unwrapped Tokens Section -->
 					{#if unwrappedHoldings.length > 0}
 						<Section>
-							<h2 class="mb-3 text-base font-semibold text-yellow-500 sm:mb-4 sm:text-lg">
+							<h2 class="mb-3 text-base font-semibold text-text sm:mb-4 sm:text-lg">
 								Unwrapped Tokens
 							</h2>
-							<p class="mb-3 hidden text-sm text-gray-400 sm:mb-4 sm:block">
+							<p class="mb-3 hidden text-sm text-text-2 sm:mb-4 sm:block">
 								Unwrapped tokens are always redeemable for 1 unit of off-chain equity. We recommend
 								wrapping them for safe use with DEX/DeFi protocols.
 							</p>
@@ -1624,26 +1634,26 @@
 									<thead>
 										<tr>
 											<th
-												class="sticky left-0 z-10 px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="sticky left-0 z-10 bg-surface-1 px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Token</th
 											>
 											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Balance</th
 											>
 											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Value</th
 											>
 											<th
-												class="px-2 py-2 text-center text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-center text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 											></th>
 										</tr>
 									</thead>
 									<tbody>
 										{#each unwrappedHoldings as token (token.address)}
-											<tr class="hover:bg-white/5">
-												<td class="sticky left-0 px-2 py-2 sm:px-4 sm:py-3">
+											<tr class="hover:bg-surface-2">
+												<td class="sticky left-0 bg-surface-1 px-2 py-2 sm:px-4 sm:py-3">
 													<span class="font-medium">{token.symbol}</span>
 												</td>
 												<td class="px-2 py-2 text-sm sm:px-4 sm:py-3"
@@ -1688,10 +1698,10 @@
 					<!-- Legacy Tokens Section -->
 					{#if legacyHoldings.length > 0}
 						<Section>
-							<h2 class="mb-3 text-base font-semibold text-yellow-500 sm:mb-4 sm:text-lg">
+							<h2 class="mb-3 text-base font-semibold text-text sm:mb-4 sm:text-lg">
 								Legacy Tokens
 							</h2>
-							<p class="mb-3 hidden text-sm text-gray-400 sm:mb-4 sm:block">
+							<p class="mb-3 hidden text-sm text-text-2 sm:mb-4 sm:block">
 								Legacy tokens maintain full equity backing and right of redemption, but should be
 								swapped ASAP to receive dividends, stock splits, and be compatible with DeFi
 								protocols.
@@ -1701,26 +1711,26 @@
 									<thead>
 										<tr>
 											<th
-												class="sticky left-0 z-10 px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="sticky left-0 z-10 bg-surface-1 px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Token</th
 											>
 											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Balance</th
 											>
 											<th
-												class="px-2 py-2 text-left text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-left text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 												>Value</th
 											>
 											<th
-												class="px-2 py-2 text-center text-xs font-medium text-gray-400 sm:px-4 sm:py-3"
+												class="px-2 py-2 text-center text-xs font-medium text-text-2 sm:px-4 sm:py-3"
 											></th>
 										</tr>
 									</thead>
 									<tbody>
 										{#each legacyHoldings as token (token.address)}
-											<tr class="hover:bg-white/5">
-												<td class="sticky left-0 px-2 py-2 sm:px-4 sm:py-3">
+											<tr class="hover:bg-surface-2">
+												<td class="sticky left-0 bg-surface-1 px-2 py-2 sm:px-4 sm:py-3">
 													<span class="font-medium">{token.symbol}</span>
 												</td>
 												<td class="px-2 py-2 text-sm sm:px-4 sm:py-3"
@@ -1732,7 +1742,6 @@
 														<Button
 															size="sm"
 															variant="primary"
-															className="bg-yellow-500 hover:bg-yellow-400"
 															on:click={() => handleSwapLegacyToken(token)}
 														>
 															Swap
@@ -1776,11 +1785,11 @@
 						<!-- Default Vaults Section -->
 						<div class="mb-6 sm:mb-8">
 							<h2 class="mb-2 text-base font-semibold sm:text-lg">Default Vaults</h2>
-							<p class="mb-3 hidden text-sm text-gray-400 sm:mb-4 sm:block">
+							<p class="mb-3 hidden text-sm text-text-2 sm:mb-4 sm:block">
 								Your primary vault for each token
 							</p>
 							{#if defaultVaults.length === 0}
-								<div class="py-4 text-sm text-gray-500">
+								<div class="py-4 text-sm text-text-3">
 									No default vaults found. Default vaults are created automatically when you make a
 									limit or DCA order.
 								</div>
@@ -1788,7 +1797,7 @@
 								<div class="overflow-x-auto">
 									<table class="w-full text-sm">
 										<thead>
-											<tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+											<tr class="text-left text-xs uppercase tracking-wide text-text-2">
 												<th class="pb-2 pr-2 font-medium sm:pb-3 sm:pr-4">Token</th>
 												<th class="pb-2 pr-2 font-medium sm:pb-3 sm:pr-4">Balance</th>
 												<th class="hidden pb-2 pr-2 font-medium sm:table-cell sm:pb-3 sm:pr-4"
@@ -1804,10 +1813,10 @@
 												{@const balanceNum = parseFloat(formatUnits(balance, decimals))}
 												{@const ordersCount =
 													(vault.ordersAsInput?.length ?? 0) + (vault.ordersAsOutput?.length ?? 0)}
-												<tr class="hover:bg-white/5">
+												<tr class="hover:bg-surface-2">
 													<td class="py-2 pr-2 sm:py-3 sm:pr-4">
 														<div class="flex items-center gap-2">
-															<span class="text-xs text-gray-200 sm:text-sm"
+															<span class="text-xs text-text-2 sm:text-sm"
 																>{vault.token.symbol}</span
 															>
 															<a
@@ -1818,7 +1827,7 @@
 																)}
 																target="_blank"
 																rel="noopener noreferrer"
-																class="text-blue-400 hover:text-blue-300"
+																class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 																title="View on Raindex"
 															>
 																<svg
@@ -1838,10 +1847,10 @@
 															</a>
 														</div>
 													</td>
-													<td class="py-2 pr-2 text-xs text-gray-300 sm:py-3 sm:pr-4 sm:text-sm"
+													<td class="py-2 pr-2 text-xs text-text-2 sm:py-3 sm:pr-4 sm:text-sm"
 														>{balanceNum.toFixed(4)}</td
 													>
-													<td class="hidden py-2 pr-2 text-gray-400 sm:table-cell sm:py-3 sm:pr-4"
+													<td class="hidden py-2 pr-2 text-text-2 sm:table-cell sm:py-3 sm:pr-4"
 														>{ordersCount}</td
 													>
 													<td class="py-2 sm:py-3">
@@ -1853,7 +1862,7 @@
 																>Withdraw</Button
 															>
 														{:else}
-															<span class="text-gray-500">—</span>
+															<span class="text-text-3">—</span>
 														{/if}
 													</td>
 												</tr>
@@ -1870,18 +1879,18 @@
 								<div class="mb-3 flex items-center justify-between sm:mb-4">
 									<div>
 										<h2 class="text-base font-semibold sm:text-lg">Other Vaults</h2>
-										<p class="hidden text-sm text-gray-400 sm:block">
+										<p class="hidden text-sm text-text-2 sm:block">
 											Additional vaults with custom IDs
 										</p>
 									</div>
 									{#if dustVaultsCount > 0 || showDustVaults}
 										<label
-											class="flex cursor-pointer items-center gap-1.5 text-xs text-gray-400 sm:gap-2 sm:text-sm"
+											class="flex cursor-pointer items-center gap-1.5 text-xs text-text-2 sm:gap-2 sm:text-sm"
 										>
 											<input
 												type="checkbox"
 												bind:checked={showDustVaults}
-												class="h-3.5 w-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-gray-900 sm:h-4 sm:w-4"
+												class="h-3.5 w-3.5 rounded border-line bg-surface-3 text-accent focus:ring-accent-line focus:ring-offset-surface-1 sm:h-4 sm:w-4"
 											/>
 											<span class="sm:hidden">Dust ({dustVaultsCount})</span>
 											<span class="hidden sm:inline"
@@ -1894,7 +1903,7 @@
 									<div class="overflow-x-auto">
 										<table class="w-full text-sm">
 											<thead>
-												<tr class="text-left text-xs uppercase tracking-wide text-gray-400">
+												<tr class="text-left text-xs uppercase tracking-wide text-text-2">
 													<th class="pb-2 pr-2 font-medium sm:pb-3 sm:pr-4">Token</th>
 													<th class="hidden pb-2 pr-2 font-medium sm:table-cell sm:pb-3 sm:pr-4"
 														>Vault ID</th
@@ -1914,9 +1923,9 @@
 													{@const ordersCount =
 														(vault.ordersAsInput?.length ?? 0) +
 														(vault.ordersAsOutput?.length ?? 0)}
-													<tr class="hover:bg-white/5">
+													<tr class="hover:bg-surface-2">
 														<td class="py-2 pr-2 sm:py-3 sm:pr-4">
-															<span class="text-xs text-gray-200 sm:text-sm"
+															<span class="text-xs text-text-2 sm:text-sm"
 																>{vault.token.symbol}</span
 															>
 														</td>
@@ -1929,16 +1938,16 @@
 																)}
 																target="_blank"
 																rel="noopener noreferrer"
-																class="font-mono text-xs text-blue-400 hover:text-blue-300 hover:underline"
+																class="font-mono text-xs text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
 																title={vault.vaultId}
 															>
 																{vault.vaultId.slice(0, 10)}...{vault.vaultId.slice(-6)}
 															</a>
 														</td>
-														<td class="py-2 pr-2 text-xs text-gray-300 sm:py-3 sm:pr-4 sm:text-sm"
+														<td class="py-2 pr-2 text-xs text-text-2 sm:py-3 sm:pr-4 sm:text-sm"
 															>{balanceNum.toFixed(4)}</td
 														>
-														<td class="hidden py-2 pr-2 text-gray-400 sm:table-cell sm:py-3 sm:pr-4"
+														<td class="hidden py-2 pr-2 text-text-2 sm:table-cell sm:py-3 sm:pr-4"
 															>{ordersCount}</td
 														>
 														<td class="py-2 sm:py-3">
@@ -1950,7 +1959,7 @@
 																	>Withdraw</Button
 																>
 															{:else}
-																<span class="text-gray-500">—</span>
+																<span class="text-text-3">—</span>
 															{/if}
 														</td>
 													</tr>
@@ -1959,7 +1968,7 @@
 										</table>
 									</div>
 								{:else}
-									<div class="py-4 text-sm text-gray-500">
+									<div class="py-4 text-sm text-text-3">
 										All other vaults contain only dust amounts.
 									</div>
 								{/if}
@@ -2023,13 +2032,13 @@
 							<div class="mb-3 flex items-center justify-between sm:mb-4">
 								<div>
 									<h2 class="text-base font-semibold sm:text-lg">Transaction History</h2>
-									<p class="text-sm text-gray-400">Raw blockchain transactions from your wallet</p>
+									<p class="text-sm text-text-2">Raw blockchain transactions from your wallet</p>
 								</div>
 								<a
 									href={basescanUrl}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="flex items-center gap-1.5 text-sm text-blue-400 hover:text-blue-300"
+									class="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 								>
 									View all on Basescan
 									<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -2042,8 +2051,8 @@
 									</svg>
 								</a>
 							</div>
-							<div class="rounded-lg border border-gray-700 bg-gray-800/50 p-6 text-center">
-								<p class="text-sm text-gray-400">
+							<div class="rounded-lg border border-line bg-surface-2 p-6 text-center">
+								<p class="text-sm text-text-2">
 									Transaction history is available on Basescan. Click the link above to view all
 									your wallet transactions.
 								</p>
@@ -2070,26 +2079,26 @@
 	>
 		<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 		<div
-			class="mx-4 w-full max-w-md rounded-xl border border-white/10 bg-gray-900 p-6 shadow-2xl"
+			class="mx-4 w-full max-w-md rounded-xl border border-line bg-surface-1 p-6 shadow-2xl"
 			on:click|stopPropagation
 			on:keydown|stopPropagation
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="cost-basis-modal-title"
 		>
-			<h3 id="cost-basis-modal-title" class="mb-4 text-lg font-semibold text-white">
+			<h3 id="cost-basis-modal-title" class="mb-4 text-lg font-semibold text-text">
 				{costBasisEditToken.existingEntry ? 'Edit' : 'Add'} Cost Basis for {costBasisEditToken.symbol}
 			</h3>
 
-			<p class="mb-4 text-sm text-gray-400">
-				You have <span class="font-medium text-yellow-400"
+			<p class="mb-4 text-sm text-text-2">
+				You have <span class="font-medium text-accent"
 					>{costBasisEditToken.untrackedBalance.toFixed(4)}</span
 				> tokens without trade history. Enter the cost basis for these tokens.
 			</p>
 
 			<div class="space-y-4">
 				<div>
-					<label for="cb-quantity" class="mb-1 block text-sm font-medium text-gray-300">
+					<label for="cb-quantity" class="mb-1 block text-sm font-medium text-text-2">
 						Quantity
 					</label>
 					<input
@@ -2099,16 +2108,16 @@
 						min="0"
 						max={costBasisEditToken.untrackedBalance}
 						bind:value={costBasisInputQuantity}
-						class="w-full rounded-lg border border-white/10 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+						class="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-text placeholder-text-3 focus:border-accent-line focus:outline-none focus:ring-1 focus:ring-accent-line"
 						placeholder="0.0000"
 					/>
-					<p class="mt-1 text-xs text-gray-500">
+					<p class="mt-1 text-xs text-text-3">
 						Max: {costBasisEditToken.untrackedBalance.toFixed(4)}
 					</p>
 				</div>
 
 				<div>
-					<label for="cb-price" class="mb-1 block text-sm font-medium text-gray-300">
+					<label for="cb-price" class="mb-1 block text-sm font-medium text-text-2">
 						Cost per Token (USD)
 					</label>
 					<input
@@ -2117,29 +2126,29 @@
 						step="any"
 						min="0"
 						bind:value={costBasisInputPrice}
-						class="w-full rounded-lg border border-white/10 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+						class="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-text placeholder-text-3 focus:border-accent-line focus:outline-none focus:ring-1 focus:ring-accent-line"
 						placeholder="0.00 (use 0 for gifts/airdrops)"
 					/>
 				</div>
 
 				<div>
-					<label for="cb-note" class="mb-1 block text-sm font-medium text-gray-300">
-						Note <span class="text-gray-500">(optional)</span>
+					<label for="cb-note" class="mb-1 block text-sm font-medium text-text-2">
+						Note <span class="text-text-3">(optional)</span>
 					</label>
 					<input
 						id="cb-note"
 						type="text"
 						bind:value={costBasisInputNote}
-						class="w-full rounded-lg border border-white/10 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-yellow-500 focus:outline-none focus:ring-1 focus:ring-yellow-500"
+						class="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-text placeholder-text-3 focus:border-accent-line focus:outline-none focus:ring-1 focus:ring-accent-line"
 						placeholder="e.g., Gift, Purchased on Coinbase"
 					/>
 				</div>
 
 				{#if costBasisInputQuantity && costBasisInputPrice}
-					<div class="rounded-lg bg-gray-800/50 p-3">
+					<div class="rounded-lg bg-surface-2 p-3">
 						<div class="flex justify-between text-sm">
-							<span class="text-gray-400">Total Cost:</span>
-							<span class="font-medium text-white">
+							<span class="text-text-2">Total Cost:</span>
+							<span class="font-medium text-text">
 								${(parseFloat(costBasisInputQuantity) * parseFloat(costBasisInputPrice)).toFixed(2)}
 							</span>
 						</div>
@@ -2161,14 +2170,14 @@
 				<button
 					type="button"
 					on:click={closeCostBasisModal}
-					class="rounded-lg border border-white/10 px-4 py-2 text-sm font-medium text-gray-300 transition hover:bg-white/5"
+					class="rounded-lg border border-line px-4 py-2 text-sm font-medium text-text-2 transition hover:bg-surface-2"
 				>
 					Cancel
 				</button>
 				<button
 					type="button"
 					on:click={saveCostBasisEntry}
-					class="rounded-lg bg-yellow-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-yellow-400"
+					class="rounded-lg bg-gradient-to-b from-accent-bright to-accent px-4 py-2 text-sm font-medium text-accent-ink transition hover:brightness-105"
 				>
 					Save
 				</button>

--- a/src/routes/(main)/faqs/+page.svelte
+++ b/src/routes/(main)/faqs/+page.svelte
@@ -58,34 +58,34 @@
 <div class="relative z-10 min-h-screen">
 	<section class="px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
 		<div class="mx-auto max-w-3xl">
-			<h1 class="mb-12 text-4xl font-bold tracking-tight text-white sm:text-5xl">FAQs</h1>
+			<h1 class="mb-12 text-4xl font-bold tracking-tight text-text sm:text-5xl">FAQs</h1>
 
 			<div class="space-y-8">
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">What is ST0x?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">What is ST0x?</h3>
+					<p class="leading-relaxed text-text-2">
 						ST0x is a decentralized exchange (DEX) enabling 24/7 trading of tokenized real-world
 						equities such as Nvidia, Tesla, and ETFs on-chain. It bridges traditional finance and
 						DeFi.
 					</p>
 				</div>
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">How does ST0x work?</h3>
-					<p class="leading-relaxed text-gray-400">ST0x operates using a dual-entity structure:</p>
-					<ul class="ml-6 mt-3 list-disc space-y-2 text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">How does ST0x work?</h3>
+					<p class="leading-relaxed text-text-2">ST0x operates using a dual-entity structure:</p>
+					<ul class="ml-6 mt-3 list-disc space-y-2 text-text-2">
 						<li>S1 Issuer GmbH issues tokenized equities.</li>
 						<li>SarkX BVI Ltd manages the decentralized matching and execution engine.</li>
 					</ul>
-					<p class="mt-3 leading-relaxed text-gray-400">
+					<p class="mt-3 leading-relaxed text-text-2">
 						Users place intent-based orders on-chain, executed via solvers when matched with
 						liquidity.
 					</p>
 				</div>
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">What assets can I trade on ST0x?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">What assets can I trade on ST0x?</h3>
+					<p class="leading-relaxed text-text-2">
 						Tokenized public equities, ETFs, and potentially other real-world assets (RWAs). The
 						underlying issued asset tokens represent corresponding assets held with a regulated
 						broker such as Charles Schwab. ST0x markets trade wrapped vault shares whose exchange
@@ -93,56 +93,56 @@
 					</p>
 				</div>
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">How is liquidity handled?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">How is liquidity handled?</h3>
+					<p class="leading-relaxed text-text-2">
 						Liquidity is demand-driven. Arbitrageurs create or redeem tokens via the Core Bridge,
 						aligning prices between off-chain markets and on-chain tokens.
 					</p>
 				</div>
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">Is ST0x custodial?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">Is ST0x custodial?</h3>
+					<p class="leading-relaxed text-text-2">
 						No. ST0x is non-custodial. Users maintain control of their assets in smart contract
 						vaults. Custody of underlying equities is separately managed by S1 via a regulated
 						broker.
 					</p>
 				</div>
 
-				<!-- <div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">Is ST0x regulated?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<!-- <div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">Is ST0x regulated?</h3>
+					<p class="leading-relaxed text-text-2">
 						ST0x is structured to avoid exchange or brokerage licensing by:
 					</p>
-					<ul class="ml-6 mt-3 list-disc space-y-2 text-gray-400">
+					<ul class="ml-6 mt-3 list-disc space-y-2 text-text-2">
 						<li>Keeping matching logic decentralized.</li>
 						<li>Utilizing separate regulated issuers.</li>
 						<li>Requiring KYC/KYB only during token issuance, not secondary trading.</li>
 					</ul>
 				</div> -->
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">How do I access ST0x?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">How do I access ST0x?</h3>
+					<p class="leading-relaxed text-text-2">
 						Connect your DeFi wallet (e.g., MetaMask, WalletConnect). Regional restrictions apply at
 						token issuance.
 					</p>
 				</div>
 
-				<div class="border-b border-white/10 pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">Are there trading fees?</h3>
-					<p class="leading-relaxed text-gray-400">
+				<div class="border-b border-line pb-8">
+					<h3 class="mb-3 text-xl font-semibold text-text">Are there trading fees?</h3>
+					<p class="leading-relaxed text-text-2">
 						Yes. Fees include trading fees, gas costs, and potential withdrawal fees, structured
 						transparently.
 					</p>
 				</div>
 
 				<div class="pb-8">
-					<h3 class="mb-3 text-xl font-semibold text-white">
+					<h3 class="mb-3 text-xl font-semibold text-text">
 						What happens if I lose my wallet's private key?
 					</h3>
-					<p class="leading-relaxed text-gray-400">
+					<p class="leading-relaxed text-text-2">
 						ST0x is non-custodial. Users are solely responsible for safeguarding their private keys.
 					</p>
 				</div>

--- a/src/routes/(main)/platform-metrics/+page.svelte
+++ b/src/routes/(main)/platform-metrics/+page.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import Footer from '$lib/components/Footer.svelte';
-	import Section from '$lib/components/ui/Section.svelte';
 	import { networks } from '$lib/config/network';
 	import type { CategorizedToken, Network } from '$lib/config/network';
 	import { apiGetTokens } from '$lib/api/st0xApi';
 	import type { TradingViewQuote } from '$lib/api/tradingview';
 	import PageContainer from '$lib/components/ui/PageContainer.svelte';
-	import MetricCard from '$lib/components/ui/MetricCard.svelte';
 	import Table from '$lib/components/ui/table/Table.svelte';
 	import InfoBlock from '$lib/components/ui/InfoBlock.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
@@ -576,21 +574,51 @@
 	}
 
 	$: metricsLoading = vaultsLoading || tradeActivityLoading || adminTvlLoading;
+
+	// Count of distinct active markets (tokens) across networks — used for the
+	// header "Live · N markets" pill. Derived from existing per-network active sets.
+	$: liveMarketCount = (() => {
+		const markets = new Set<string>();
+		activeTokensByNetwork.forEach((set) => {
+			set.forEach((address) => markets.add(address));
+		});
+		return markets.size;
+	})();
 </script>
 
-<div class="relative z-10 min-h-screen text-white">
+<div class="relative z-10 min-h-screen text-text">
 	<PageContainer>
 		{#if metricsLoading}
 			<div class="flex min-h-[60vh] items-center justify-center">
 				<LoadingSpinner size="lg" text="Loading metrics..." />
 			</div>
 		{:else}
-			<div class="hidden sm:block">
-				<InfoBlock
-					variant="info"
-					title="Multi-Network Data"
-					description="Metrics aggregate active orderbook vaults and trades across all supported networks."
-				/>
+			<div class="mb-7 flex flex-wrap items-end justify-between gap-4">
+				<div>
+					<div
+						class="mb-2 flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.18em] text-accent"
+					>
+						<span class="h-px w-5 bg-accent-line"></span>Transparency · Live
+					</div>
+					<h1 class="font-display text-3xl font-bold tracking-tight text-text sm:text-4xl">
+						Platform metrics
+					</h1>
+					<p class="mt-2 max-w-xl text-[15px] text-text-2">
+						Onchain activity across st0x — every figure is read from Base mainnet and refreshes each
+						block.
+					</p>
+				</div>
+				<div
+					class="flex items-center gap-2 rounded-full border border-accent-line bg-accent-soft px-3.5 py-2 font-mono text-[12px] font-semibold text-accent"
+				>
+					<span class="relative flex h-1.5 w-1.5">
+						<span
+							class="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-70"
+						></span>
+						<span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent"></span>
+					</span>
+					Live · {liveMarketCount} markets
+				</div>
 			</div>
 
 			{#if vaultsError}
@@ -609,55 +637,67 @@
 				/>
 			{/if}
 
-			<div class="grid grid-cols-2 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-5">
-				<MetricCard
-					label="TVL"
-					value={adminTvl !== null ? `$${formatQuote(adminTvl)}` : 'N/A'}
-					subtitle="Total value locked"
-					paddingClass="p-4 sm:p-6"
-					showGradient={false}
-					valueClass="text-xl font-bold sm:text-3xl"
-				/>
-				<MetricCard
-					label="Trading Volume"
-					value={formatQuoteDisplay(tradingVolume)}
-					subtitle="Last 30 days"
-					paddingClass="p-4 sm:p-6"
-					showGradient={false}
-					valueClass="text-xl font-bold sm:text-3xl"
-				/>
-				<div class="hidden sm:block">
-					<MetricCard
-						label="Total Trades"
-						value={`${totalTrades}`}
-						subtitle="Last 30 days"
-						paddingClass="p-6"
-						showGradient={false}
-						valueClass="text-3xl font-bold"
-					/>
+			<div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+				<!-- Headline TVL card — accent treatment (mint glow + live ping dot) -->
+				<div
+					class="relative overflow-hidden rounded-2xl border border-accent-line bg-gradient-to-br from-accent-soft to-transparent p-5"
+				>
+					<div
+						class="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-accent-glow blur-2xl"
+					></div>
+					<div class="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-text-3">
+						<span class="relative flex h-1.5 w-1.5">
+							<span
+								class="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-70"
+							></span>
+							<span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent"></span>
+						</span>
+						Total value locked
+					</div>
+					<div class="mt-2 font-mono text-3xl font-bold text-accent">
+						{adminTvl !== null ? `$${formatQuote(adminTvl)}` : 'N/A'}
+					</div>
+					<div class="mt-2 font-mono text-[12px] text-text-2">Across all vaults</div>
 				</div>
-				<div class="hidden sm:block">
-					<MetricCard
-						label="DEX Liquidity"
-						value={`$${formatQuote(dexLiquidity)}`}
-						subtitle="tStock order liquidity"
-						paddingClass="p-6"
-						showGradient={false}
-						valueClass="text-3xl font-bold"
-					/>
+
+				<div class="rounded-2xl border border-line bg-overlay-1 p-5">
+					<div class="text-[11px] uppercase tracking-wider text-text-3">24h Volume</div>
+					<div class="mt-2 font-mono text-3xl font-bold text-text">
+						{formatQuoteDisplay(tradingVolume)}
+					</div>
+					<div class="mt-2 font-mono text-[12px] text-text-2">Last 30 days</div>
+				</div>
+
+				<div class="hidden rounded-2xl border border-line bg-overlay-1 p-5 sm:block">
+					<div class="text-[11px] uppercase tracking-wider text-text-3">Total trades</div>
+					<div class="mt-2 font-mono text-3xl font-bold text-text">{totalTrades}</div>
+					<div class="mt-2 font-mono text-[12px] text-text-2">Last 30 days</div>
+				</div>
+
+				<div class="hidden rounded-2xl border border-line bg-overlay-1 p-5 sm:block">
+					<div class="text-[11px] uppercase tracking-wider text-text-3">DEX liquidity</div>
+					<div class="mt-2 font-mono text-3xl font-bold text-text">
+						${formatQuote(dexLiquidity)}
+					</div>
+					<div class="mt-2 font-mono text-[12px] text-text-2">tStock order liquidity</div>
 				</div>
 			</div>
 
-			<Section>
+			<div class="mt-4 rounded-2xl border border-line bg-overlay-1 p-5">
 				<div class="mb-4 flex items-center justify-between sm:mb-6">
 					<div>
-						<h2 class="text-base font-semibold sm:text-lg">Stats by Network</h2>
-						<p class="mt-1 hidden text-sm text-gray-400 sm:block">
+						<h2 class="text-base font-semibold text-text sm:text-lg">Stats by Network</h2>
+						<p class="mt-1 hidden text-sm text-text-2 sm:block">
 							Live metrics sourced from active orderbook vaults
 						</p>
 					</div>
-					<div class="flex items-center gap-1.5 text-xs text-green-400 sm:gap-2 sm:text-sm">
-						<div class="h-2 w-2 rounded-full bg-green-400"></div>
+					<div class="flex items-center gap-1.5 text-xs text-accent sm:gap-2 sm:text-sm">
+						<span class="relative flex h-2 w-2">
+							<span
+								class="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-70"
+							></span>
+							<span class="relative inline-flex h-2 w-2 rounded-full bg-accent"></span>
+						</span>
 						Live
 					</div>
 				</div>
@@ -666,22 +706,22 @@
 					<thead>
 						<tr>
 							<th
-								class="sticky left-0 z-10 p-2 text-left text-xs font-medium uppercase tracking-wide text-gray-400 sm:p-3"
+								class="sticky left-0 z-10 p-2 text-left text-xs font-medium uppercase tracking-wide text-text-2 sm:p-3"
 							>
 								Network
 							</th>
 							<th
-								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-gray-400 sm:p-3"
+								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-text-2 sm:p-3"
 							>
 								TVL
 							</th>
 							<th
-								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-gray-400 sm:p-3"
+								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-text-2 sm:p-3"
 							>
 								DEX Liquidity
 							</th>
 							<th
-								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-gray-400 sm:p-3"
+								class="p-2 text-right text-xs font-medium uppercase tracking-wide text-text-2 sm:p-3"
 							>
 								Volume
 							</th>
@@ -689,7 +729,7 @@
 					</thead>
 					<tbody>
 						{#each networkStats as stats}
-							<tr class="hover:bg-white/5">
+							<tr class="hover:bg-overlay-hover">
 								<td class="sticky left-0 p-2 sm:p-3 sm:text-sm">
 									<div class="flex items-center gap-2 sm:gap-3">
 										<img
@@ -703,37 +743,39 @@
 										/>
 										<div class="min-w-0">
 											<div class="truncate font-medium">{stats.network.displayName}</div>
-											<div class="hidden text-xs text-gray-400 sm:block">{stats.network.name}</div>
+											<div class="hidden text-xs text-text-2 sm:block">{stats.network.name}</div>
 										</div>
 									</div></td
 								>
-								<td class="p-2 text-right text-xs font-medium text-green-400 sm:p-3 sm:text-sm">
+								<td
+									class="p-2 text-right font-mono text-xs font-medium text-accent sm:p-3 sm:text-sm"
+								>
 									{formatQuoteDisplayWithNetwork(stats.networkTvl, stats.network)}
 								</td>
-								<td class="p-2 text-right text-xs sm:p-3 sm:text-sm">
+								<td class="p-2 text-right font-mono text-xs sm:p-3 sm:text-sm">
 									{formatQuoteDisplayWithNetwork(stats.dexLiquidity, stats.network)}
 								</td>
-								<td class="p-2 text-right text-xs sm:p-3 sm:text-sm">
+								<td class="p-2 text-right font-mono text-xs sm:p-3 sm:text-sm">
 									{formatQuoteDisplayWithNetwork(stats.tradingVolume, stats.network)}
 								</td>
 							</tr>
 						{/each}
 					</tbody>
 				</Table>
-			</Section>
+			</div>
 
-			<Section>
+			<div class="mt-4 rounded-2xl border border-line bg-overlay-1 p-5">
 				<div class="mb-4 sm:mb-6">
 					<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
 						<div>
-							<h2 class="text-base font-semibold sm:text-lg">Token Volumes</h2>
-							<p class="mt-1 hidden text-sm text-gray-400 sm:block">
+							<h2 class="text-base font-semibold text-text sm:text-lg">Token Volumes</h2>
+							<p class="mt-1 hidden text-sm text-text-2 sm:block">
 								Aggregated orderbook activity for {selectedNetwork.displayName}
 							</p>
 						</div>
 						<select
 							bind:value={selectedNetwork}
-							class="rounded-lg bg-gray-800/50 px-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500"
+							class="rounded-lg border border-line bg-overlay-strong px-4 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-accent"
 						>
 							{#each networks as network}
 								<option value={network}>{network.displayName}</option>
@@ -745,7 +787,7 @@
 				<div class="overflow-x-auto">
 					<table class="w-full">
 						<thead>
-							<tr class="text-left text-xs font-medium uppercase tracking-wide text-gray-400">
+							<tr class="text-left text-xs font-medium uppercase tracking-wide text-text-2">
 								<th class="sticky left-0 z-10 p-2 sm:p-3">Token</th>
 								<th class="hidden p-2 text-right sm:table-cell sm:p-3">Total Volume</th>
 								<th class="p-2 text-right sm:p-3">Value</th>
@@ -754,37 +796,37 @@
 						</thead>
 						<tbody>
 							{#each tokenTradingData as token}
-								<tr class="hover:bg-white/5">
+								<tr class="hover:bg-overlay-hover">
 									<td class="sticky left-0 p-2 sm:p-3">
 										<div class="flex items-center gap-3">
 											{#if token.logoUrl}
 												<img src={token.logoUrl} alt={token.symbol} class="h-8 w-8 rounded-full" />
 											{:else}
 												<div
-													class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-700 text-xs font-bold"
+													class="flex h-8 w-8 items-center justify-center rounded-full bg-surface-3 text-xs font-bold"
 												>
 													{token.symbol?.charAt(0)}
 												</div>
 											{/if}
 											<div>
 												<div class="text-xs font-medium sm:text-sm">{token.symbol}</div>
-												<div class="hidden text-[11px] text-gray-400 sm:block">{token.name}</div>
+												<div class="hidden text-[11px] text-text-2 sm:block">{token.name}</div>
 											</div>
 										</div>
 									</td>
-									<td class="hidden p-2 text-right text-yellow-400 sm:table-cell sm:p-3"
+									<td class="hidden p-2 text-right font-mono text-text sm:table-cell sm:p-3"
 										>{token.totalVolume.toFixed(3)}</td
 									>
-									<td class="p-2 text-right text-xs font-medium sm:p-3 sm:text-sm"
+									<td class="p-2 text-right font-mono text-xs font-medium sm:p-3 sm:text-sm"
 										>{token.quoteValue}</td
 									>
-									<td class="p-2 text-right text-xs sm:p-3 sm:text-sm">{token.trades}</td>
+									<td class="p-2 text-right font-mono text-xs sm:p-3 sm:text-sm">{token.trades}</td>
 								</tr>
 							{/each}
 						</tbody>
 					</table>
 				</div>
-			</Section>
+			</div>
 		{/if}
 	</PageContainer>
 

--- a/src/routes/(main)/privacy-policy/+page.svelte
+++ b/src/routes/(main)/privacy-policy/+page.svelte
@@ -5,27 +5,29 @@
 <div class="relative z-10 min-h-screen">
 	<section class="px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
 		<div class="mx-auto max-w-3xl">
-			<h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">Privacy Policy</h1>
+			<h1 class="mb-6 text-4xl font-bold tracking-tight text-text sm:text-5xl">Privacy Policy</h1>
 
-			<p class="mb-8 text-gray-400">
+			<p class="mb-8 text-text-2">
 				In the following, we would like to inform you about what happens to your personal data when
 				you visit our website and use the services offered on the website.
 			</p>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				1. Name and contact details of the responsible body
 			</h2>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The person responsible for the processing of personal data on this website is:
 			</p>
-			<div class="mb-6 text-gray-400">
-				<p class="font-semibold text-white">SARK X (BVI) Ltd</p>
+			<div class="mb-6 text-text-2">
+				<p class="font-semibold text-text">SARK X (BVI) Ltd</p>
 				<p>represented by the managing directors</p>
 				<p>Toby Meller and Nicholas Magliocchetti</p>
 				<p>Craigmuir Chambers, Road Town, Tortola</p>
 				<p>VG 1110, British Virgin Islands</p>
 				<p>
-					E-Mail: <a href="mailto:toby@st0x.io" class="text-blue-400 underline hover:text-blue-300"
+					E-Mail: <a
+						href="mailto:toby@st0x.io"
+						class="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 						>toby@st0x.io</a
 					>
 				</p>
@@ -34,24 +36,25 @@
 						href="https://st0x.io"
 						target="_blank"
 						rel="noopener noreferrer"
-						class="text-blue-400 underline hover:text-blue-300">www.st0x.io</a
+						class="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+						>www.st0x.io</a
 					>
 				</p>
 			</div>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				2. Purpose and legal basis of data processing
 			</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">(1) Accessing the website</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">(1) Accessing the website</h3>
+			<p class="mb-4 text-text-2">
 				When you access our website, information is automatically provided to the server of our
 				website, depending on the browser used on your device. The website is hosted by an external
 				service provider, so that the data is stored on the hoster's servers. We will not use the
 				information to draw conclusions about your person. The following information is
 				automatically recorded in a log file and stored there until automated deletion:
 			</p>
-			<ul class="mb-4 ml-6 list-disc space-y-1 text-gray-400">
+			<ul class="mb-4 ml-6 list-disc space-y-1 text-text-2">
 				<li>the date and time of the call,</li>
 				<li>Name and URL of the retrieved file/page,</li>
 				<li>IP address and hostname of the accessing computer,</li>
@@ -59,7 +62,7 @@
 				<li>Browser type and version, operating system used</li>
 				<li>and the name of your access provider.</li>
 			</ul>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The aforementioned information is used to provide a smooth and comfortable use of the
 				website, to evaluate system security and stability, and for other administrative purposes.
 				The legal basis for this data processing is Art. 6 (1) (f) GDPR. Our legitimate interest
@@ -71,21 +74,21 @@
 				website. You can find more detailed explanations in this privacy policy.
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">(2) Cookies</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">(2) Cookies</h3>
+			<p class="mb-4 text-text-2">
 				We use cookies on our site. These are small files that are automatically created by your
 				browser and stored on your device (laptop, tablet, smartphone, etc.) and contain information
 				about the data of your visit. However, the use of cookies does not give us direct knowledge
 				of your identity. The cookies are used to make your use of our website more pleasant. We
 				also use cookies to evaluate the surfing behaviour of our users.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The legal bases for the setting of cookies are legitimate interests under Art. 6 (1) (f)
 				GDPR and, if applicable, your consent in accordance with Art. 6 (1) (a) GDPR in conjunction
 				with. &sect; 25 TTDSG. In the case of the initiation of a contract or an ongoing contractual
 				relationship, the legal basis also follows from Art. 6 (1) (b) GDPR.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				When you enter our website for the first time, you have the option of customizing the
 				setting of cookies. Most browsers are also automatically preset for the use of cookies.
 				However, you can set your browser so that no cookies are stored on your computer at all or
@@ -93,8 +96,8 @@
 				disable the use of cookies, you may not be able to use all the features of our website.
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">(3) Contact us</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">(3) Contact us</h3>
+			<p class="mb-4 text-text-2">
 				If you contact us via the options provided on the website to make an enquiry, we will
 				process the data you provide in connection with the inquiry to process your inquiry. The
 				legal basis for this data processing is our legitimate interest in processing such enquiries
@@ -103,15 +106,15 @@
 				we cannot respond to your request without your contact details and information about your
 				request.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				After your enquiry is done, the data provided will be deleted unless it is required for a
 				following contractual relationship, or it must be kept due to mandatory retention
 				obligations. You can also request deleting your data at any time. You are also entitled to
 				further rights in accordance with this declaration.
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">(4) Social media</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">(4) Social media</h3>
+			<p class="mb-4 text-text-2">
 				We operate a company profile on X (formerly Twitter), offered by X Corp., San Francisco,
 				USA. If you access our profile there or interact with us via X (e.g. through comments, likes
 				or direct messages), X processes personal data about you, e.g: IP address, device
@@ -123,7 +126,7 @@
 				and data protection as well as privacy settings can be found on the website of the operator
 				of the X platform.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The operators of X can provide us with usage statistics in summarized and anonymized form
 				(so-called insights data). We have no influence on the creation of usage statistics. It is
 				not possible for us to assign your person to this data. The aggregated statistics may
@@ -131,7 +134,7 @@
 				defined period, reach and interaction of certain posts, actions on the company website,
 				number of page views, post performances, shared content.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				We operate a public information channel on the Telegram messaging service. When you access
 				the channel or communicate with us there, Telegram processes personal data, including your
 				IP address, usage data, possibly your Telegram user name and communication content. If you
@@ -141,18 +144,18 @@
 				data may also be processed outside the EU. Further information can be found in Telegram's
 				privacy policy.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The platforms listed above are for general information purposes only. For support requests
 				and confidential communication, please use the secure channels provided for this purpose.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The contact person for exercising your rights on the above-mentioned platforms is generally
 				the respective operator, as they have the power of disposal over the data stored on the
 				platform, possess all detailed and unencrypted information and can therefore take the
 				necessary measures and provide information. The respective contact persons can be found in
 				the data guidelines of the platform operator.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				The data processing described above is based on our legitimate interest in communication and
 				information (Art. 6 (1) (f) GDPR). This consists of constantly optimising our information
 				offering and our content to be able to respond to our target group in the best possible way.
@@ -166,10 +169,10 @@
 				data policy of the operator of the respective social media platform.
 			</p>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				3. Disclosure of personal data to third parties
 			</h2>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				Within the scope of the processing purposes stated above, service providers and vicarious
 				agents (e.g. technical service providers) employed by us may receive data. The disclosure of
 				your personal data will be limited to what is necessary. The service providers commissioned
@@ -185,13 +188,13 @@
 				GDPR.
 			</p>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">4. Rights of the persons concerned</h2>
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">4. Rights of the persons concerned</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">
 				(1) Right to information, rectification, deletion as well as rights to restriction of
 				processing or transfer of your data to another body
 			</h3>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				You have the right to request information (Art. 15 GDPR) about your personal data and
 				related information. In addition, you can request the rectification (Art. 16 GDPR) and
 				erasure (Art. 17 (1) GDPR) of your personal data. You can also request that the processing
@@ -200,10 +203,10 @@
 				controller (Art. 20 GDPR).
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">
 				(2) Revocation of consent to data processing
 			</h3>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				You can revoke your consent in accordance with Art. 6 (1) sentence 1 (a) GDPR at any time
 				with immediate effect in accordance with Art. 7 (3) sentence 1 GDPR. Please note that data
 				processing that took place before the revocation is not affected by the revocation and is
@@ -211,13 +214,13 @@
 				revocation, a simple notification to the person listed under no. 1.
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">
 				(3) Objection to profiling and direct marketing
 			</h3>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				In certain cases, you also have the right to object (Art. 21 GDPR) to the data processing.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				In particular, you have the right to object at any time to the processing of your data (in
 				particular in the case of so-called profiling) based on Art. 6 (1) (f) GDPR (data processing
 				on the basis of a balancing of interests) or Art. 6 (1) (e) GDPR (data processing in the
@@ -226,23 +229,23 @@
 				for the processing which override the interests, rights and freedoms of the data subject, or
 				the processing serves to establish, exercise or defend legal claims.
 			</p>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				If your personal data is processed for direct marketing, you can also object to the
 				processing of your data for the purpose of direct marketing at any time in accordance with
 				Art. 21 (2) GDPR, including profiling, insofar as it is related to such direct marketing. If
 				you object, your personal data will no longer be used for these direct marketing purposes.
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">
 				(4) Right to lodge a complaint with the competent data protection supervisory authority
 			</h3>
-			<p class="mb-4 text-gray-400">
+			<p class="mb-4 text-text-2">
 				If you believe that we have not complied with data protection regulations when processing
 				your data, you can submit a complaint to the supervisory authority responsible for us.
 			</p>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">5. Data integrity</h2>
-			<p class="mb-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">5. Data integrity</h2>
+			<p class="mb-4 text-text-2">
 				To ensure data security on our website, we encrypt it using the SSL method in accordance
 				with the current state of the art. We use appropriate technical and organizational measures
 				to prevent accidental or intentional manipulation, partial or total loss, destruction or
@@ -252,10 +255,10 @@
 				appropriate measures in accordance with the current state of the art to prevent the risks.
 			</p>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				6. Up-to-dateness and modification of this privacy policy
 			</h2>
-			<p class="text-gray-400">
+			<p class="text-text-2">
 				Due to the further development of our website and offers or due to changes in legal or
 				official requirements, it may become necessary to change this data protection declaration.
 				The current data protection declaration can be accessed and printed by you at any time on

--- a/src/routes/(main)/strategies/+page.svelte
+++ b/src/routes/(main)/strategies/+page.svelte
@@ -6,6 +6,7 @@
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import PageContainer from '$lib/components/ui/PageContainer.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { isAuthenticated, walletAddress } from '$lib/stores/authStore';
 	import { walletRegistered, promptLogin } from '$lib/stores/accessStore';
 	import { openAuthModal } from '$lib/stores/dynamicStore';
@@ -63,25 +64,11 @@
 			<!-- Login gate for strategies -->
 			<div class="flex min-h-[60vh] items-center justify-center">
 				<div class="max-w-md text-center">
-					<div
-						class="mb-6 inline-flex rounded-full bg-gradient-to-br from-blue-600/20 to-purple-700/20 p-6"
-					>
-						<svg
-							class="h-12 w-12 text-blue-400"
-							fill="none"
-							stroke="currentColor"
-							viewBox="0 0 24 24"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-							/>
-						</svg>
+					<div class="mb-6 inline-flex rounded-full bg-accent-soft p-6 text-accent">
+						<Icon name="lock" className="h-12 w-12" />
 					</div>
 					<h2 class="mb-2 text-2xl font-bold">Connect to Access Strategies</h2>
-					<p class="mb-6 text-gray-400">
+					<p class="mb-6 text-text-2">
 						Connect and register your wallet to access advanced trading strategies including
 						portfolio management and market making.
 					</p>
@@ -96,24 +83,12 @@
 			</div>
 		{:else}
 			<!-- Warning banner -->
-			<div class="mb-4 rounded-lg border border-red-500/50 bg-red-500/15 p-4 sm:mb-6">
+			<div class="mb-4 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 sm:mb-6">
 				<div class="flex items-start gap-3">
-					<svg
-						class="mt-0.5 h-5 w-5 flex-shrink-0 text-red-400"
-						fill="none"
-						stroke="currentColor"
-						viewBox="0 0 24 24"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-						/>
-					</svg>
+					<Icon name="info" className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-400" />
 					<div>
-						<p class="font-semibold text-red-400">Warning: Experimental Strategies</p>
-						<p class="mt-1 text-sm text-red-300/90">
+						<p class="font-semibold text-amber-400">Warning: Experimental Strategies</p>
+						<p class="mt-1 text-sm text-amber-300/90">
 							These strategies have not been tested and should only be used if you are very familiar
 							with Rainlang. Always review the Rainlang source code before deploying.
 						</p>
@@ -121,16 +96,18 @@
 				</div>
 			</div>
 			<!-- Strategy Type Selector -->
-			<div class="mb-4 flex flex-col gap-2 rounded-lg bg-white/5 p-1 sm:mb-6 sm:flex-row sm:gap-0">
+			<div
+				class="mb-4 flex flex-col gap-2 rounded-lg bg-surface-2 p-1 sm:mb-6 sm:flex-row sm:gap-0"
+			>
 				{#each STRATEGY_TYPES as type}
 					<Button
 						fullWidth={true}
 						variant="ghost"
 						size="md"
-						className={`gap-2 rounded-lg px-4 py-2 text-xs font-medium transition-all sm:py-3 sm:text-sm ${
+						className={`gap-2 rounded-lg border-transparent px-4 py-2 text-xs font-medium transition-all hover:bg-transparent sm:py-3 sm:text-sm ${
 							activeStrategyType === type.id
-								? 'bg-yellow-500/20 text-yellow-500'
-								: 'text-gray-400 hover:text-white'
+								? 'bg-accent-soft text-accent'
+								: 'text-text-2 hover:text-text'
 						}`}
 						on:click={() => handleStrategyTypeChange(type.id)}
 					>
@@ -139,7 +116,7 @@
 				{/each}
 			</div>
 
-			<div class="rounded-2xl border border-white/10 bg-gray-800/50 p-3 backdrop-blur-sm sm:p-6">
+			<div class="rounded-2xl border border-line bg-surface-2 p-3 backdrop-blur-sm sm:p-6">
 				{#if isNetworkLoading}
 					<div class="flex flex-col items-center justify-center gap-4 py-8">
 						<LoadingSpinner
@@ -147,7 +124,7 @@
 							size="md"
 							text="Switching to {$currentNetwork?.displayName || 'network'}..."
 						/>
-						<p class="text-center text-gray-400">
+						<p class="text-center text-text-2">
 							Loading strategy interface for {$currentNetwork?.displayName || 'this network'}.
 						</p>
 					</div>

--- a/src/routes/(main)/terms/+page.svelte
+++ b/src/routes/(main)/terms/+page.svelte
@@ -6,37 +6,37 @@
 <div class="relative z-10 min-h-screen">
 	<section class="px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
 		<div class="mx-auto max-w-3xl">
-			<h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+			<h1 class="mb-6 text-4xl font-bold tracking-tight text-text sm:text-5xl">
 				DEX Website Terms of Use
 			</h1>
 
-			<p class="mb-8 text-gray-500"><em>Last Updated: 30 June 2025</em></p>
+			<p class="mb-8 text-text-3"><em>Last Updated: 30 June 2025</em></p>
 
-			<div class="mb-10 rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-5">
-				<p class="font-semibold text-yellow-100">
+			<div class="mb-10 rounded-xl border border-amber-500/40 bg-amber-500/10 p-5">
+				<p class="font-semibold text-amber-300">
 					YOU MUST READ THESE TERMS OF USE BEFORE USING THE WEBSITE. BY USING THE WEBSITE, YOU WILL
 					BE DEEMED TO HAVE ACCEPTED THESE TERMS OF USE.
 				</p>
 			</div>
 
-			<ol class="space-y-4 text-gray-400">
+			<ol class="space-y-4 text-text-2">
 				<li>
 					SARK X (BVI) Ltd located at Craigmuir Chambers, Road Town, Tortola, VG 1110, British
-					Virgin Islands ("<strong class="text-white">Provider</strong>") is the owner and operator
+					Virgin Islands ("<strong class="text-text">Provider</strong>") is the owner and operator
 					of the website at
 					<ExternalLink
 						href="https://st0x.io"
 						label="https://st0x.io"
-						className="text-blue-400 underline hover:text-blue-300"
+						className="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 					/>
-					(the "<strong class="text-white">Website</strong>"). Provider is a business company
-					limited by shares incorporated under the laws of the British Virgin Islands ("<strong
-						class="text-white">BVI</strong
+					(the "<strong class="text-text">Website</strong>"). Provider is a business company limited
+					by shares incorporated under the laws of the British Virgin Islands ("<strong
+						class="text-text">BVI</strong
 					>").
 				</li>
 				<li>
 					These terms of use (as may be amended or varied from time to time in accordance with the
-					terms set out below, the "<strong class="text-white">Terms of Use</strong>") will govern
+					terms set out below, the "<strong class="text-text">Terms of Use</strong>") will govern
 					your access to and use of the Website and represent an agreement between you and Provider.
 				</li>
 				<li>
@@ -49,11 +49,11 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">1. About the Website</h2>
-			<ol class="space-y-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">1. About the Website</h2>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					The Website acts as an interface with the decentralised exchange known as ST0x 'order
-					book' ("<strong class="text-white">DEX</strong>"). The DEX is decentralised, meaning that
+					book' ("<strong class="text-text">DEX</strong>"). The DEX is decentralised, meaning that
 					it has no single controller or owner. Specifically, Provider does not own, operate or
 					control the DEX.
 				</li>
@@ -73,8 +73,8 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">2. Who May Use the Website</h2>
-			<ol class="space-y-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">2. Who May Use the Website</h2>
+			<ol class="space-y-4 text-text-2">
 				<li>The Website is offered and available to users who are 18 years of age or older.</li>
 				<li>The Website is not intended for children under 18 years of age.</li>
 				<li>
@@ -88,8 +88,8 @@
 				<li>If you do not meet these requirements, you must not access or use the Website.</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">3. Changes to the Terms of Use</h2>
-			<ol class="space-y-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">3. Changes to the Terms of Use</h2>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					We may revise and update these Terms of Use from time to time in our sole discretion. All
 					changes are effective immediately when they are posted to the Website.
@@ -104,10 +104,10 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				4. Accessing the Website and Account Security
 			</h2>
-			<ol class="space-y-4 text-gray-400">
+			<ol class="space-y-4 text-text-2">
 				<li>
 					We reserve the right to withdraw or amend the Website, and any service or material we
 					provide on the Website, in our sole discretion without notice.
@@ -138,20 +138,20 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">5. Intellectual Property Rights</h2>
-			<ol class="space-y-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">5. Intellectual Property Rights</h2>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					Unless otherwise indicated, the Website is our exclusive property and all:
 					<ol type="a" class="ml-6 mt-2 space-y-2">
 						<li>
 							source code, databases, functionality, software, website designs, information, audio,
 							video, text, photographs, and graphics on the Website (collectively, the "<strong
-								class="text-white">Content</strong
+								class="text-text">Content</strong
 							>"), and
 						</li>
 						<li>
 							the trademarks, service marks, and logos contained therein (collectively, the "<strong
-								class="text-white">Marks</strong
+								class="text-text">Marks</strong
 							>"),
 						</li>
 						<li>
@@ -186,14 +186,14 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">6. Prohibited Uses</h2>
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">6. Prohibited Uses</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">6.1 Lawful Purpose</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">6.1 Lawful Purpose</h3>
+			<p class="mb-4 text-text-2">
 				You may use the Website only for lawful purposes and in accordance with these Terms of Use.
 				You agree not to use the Website:
 			</p>
-			<ol class="space-y-4 text-gray-400">
+			<ol class="space-y-4 text-text-2">
 				<li>
 					in any way that violates any applicable federal, state, local, or international law or
 					regulation (including, without limitation, any laws regarding the export of data or
@@ -225,9 +225,9 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">6.2 Lawful Use</h3>
-			<p class="mb-4 text-gray-400">Additionally, you agree not to:</p>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">6.2 Lawful Use</h3>
+			<p class="mb-4 text-text-2">Additionally, you agree not to:</p>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					use the Website in any manner that could disable, overburden, damage, or impair the
 					Website or interfere with any other party's use of the Website, including their ability to
@@ -261,10 +261,10 @@
 				<li>otherwise attempt to interfere with the proper working of the Website.</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">7. Reliance on Information Posted</h2>
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">7. Reliance on Information Posted</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">7.1 Reliance Disclaimer</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">7.1 Reliance Disclaimer</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					The information presented on or through the Website is made available solely for general
 					information purposes. We do not warrant the accuracy, completeness or usefulness of this
@@ -298,8 +298,8 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">7.2 Changes to the Website</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">7.2 Changes to the Website</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					We may update the content on the Website from time to time, but we make no warranty or
 					representation that its content is necessarily complete or up-to-date at any specific
@@ -311,10 +311,10 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">8. Website Links</h2>
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">8. Website Links</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">8.1 Linking to the Website</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">8.1 Linking to the Website</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					You may link to our homepage, provided you do so in a way that is fair and legal and does
 					not damage our reputation or take advantage of it.
@@ -330,8 +330,8 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">8.2 Links from the Website</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">8.2 Links from the Website</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					If the Website contain links to other sites and resources provided by third parties, these
 					links are provided for your convenience only. This includes links contained in
@@ -348,8 +348,8 @@
 				<li>We reserve the right to withdraw linking permission without notice.</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">9. Geographic Restrictions</h2>
-			<ol class="space-y-4 text-gray-400">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">9. Geographic Restrictions</h2>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					The owner of the Website is based in the British Virgin Islands. We make no claims that
 					the Website or any of its content is accessible or appropriate outside of the British
@@ -362,12 +362,12 @@
 				</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">
 				10. Warranties, Limitation of Liability and Indemnity
 			</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">10.1 Warranties disclaimer</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">10.1 Warranties disclaimer</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					You understand that we cannot and do not guarantee or warrant that files available for
 					downloading from the internet or the Website will be free of viruses or other destructive
@@ -381,7 +381,7 @@
 					lost data.
 				</li>
 				<li>
-					<strong class="text-white"
+					<strong class="text-text"
 						>WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE
 						ATTACK, VIRUSES, OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER
 						EQUIPMENT, COMPUTER PROGRAMS, DATA, OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE
@@ -390,13 +390,13 @@
 					>
 				</li>
 				<li>
-					<strong class="text-white"
+					<strong class="text-text"
 						>YOUR USE OF THE WEBSITE, THEIR CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE
 						WEBSITE IS AT YOUR OWN RISK.</strong
 					>
 				</li>
 				<li>
-					<strong class="text-white"
+					<strong class="text-text"
 						>THE WEBSITE, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE WEBSITE IS
 						PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT ANY WARRANTIES OF ANY KIND,
 						EITHER EXPRESS OR IMPLIED. NEITHER SARK NOR ANY PERSON ASSOCIATED WITH SARK MAKES ANY
@@ -405,7 +405,7 @@
 					>
 				</li>
 				<li>
-					<strong class="text-white"
+					<strong class="text-text"
 						>WITHOUT LIMITING THE FOREGOING, NEITHER SARK NOR ANYONE ASSOCIATED WITH SARK REPRESENTS
 						OR WARRANTS THAT THE WEBSITE, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE
 						WEBSITE WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE
@@ -415,7 +415,7 @@
 					>
 				</li>
 				<li>
-					<strong class="text-white"
+					<strong class="text-text"
 						>SARK HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
 						STATUTORY, OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
 						NON-INFRINGEMENT, AND FITNESS FOR PARTICULAR PURPOSE.</strong
@@ -428,9 +428,9 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">10.2 Limitation on Liability</h3>
-			<p class="mb-4 text-gray-400">
-				<strong class="text-white"
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">10.2 Limitation on Liability</h3>
+			<p class="mb-4 text-text-2">
+				<strong class="text-text"
 					>IN NO EVENT WILL SARK, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES,
 					AGENTS, OFFICERS, OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY,
 					ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE WEBSITE, ANY
@@ -438,7 +438,7 @@
 					ITEMS OBTAINED THROUGH THE WEBSITE OR SUCH OTHER WEBSITE, INCLUDING:</strong
 				>
 			</p>
-			<ol class="space-y-2 text-gray-400">
+			<ol class="space-y-2 text-text-2">
 				<li>
 					ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING
 					BUT NOT LIMITED TO EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS
@@ -449,15 +449,15 @@
 					FORESEEABLE.
 				</li>
 			</ol>
-			<p class="text-gray-400">
-				<strong class="text-white"
+			<p class="text-text-2">
+				<strong class="text-text"
 					>THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER
 					APPLICABLE LAW WHICH MAY INCLUDE FRAUD.</strong
 				>
 			</p>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">10.3 Indemnification</h3>
-			<p class="mb-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">10.3 Indemnification</h3>
+			<p class="mb-4 text-text-2">
 				You agree to defend, indemnify, and hold harmless Provider, its affiliates, licensors, and
 				service providers, and its and their respective officers, directors, employees, contractors,
 				agents, licensors, suppliers, successors, and assigns from and against any claims,
@@ -465,7 +465,7 @@
 				reasonable attorneys' fees) arising out of or relating to your violation of these Terms of
 				Use or your use of the Website, including, but not limited to:
 			</p>
-			<ol class="space-y-4 text-gray-400">
+			<ol class="space-y-4 text-text-2">
 				<li>
 					any use of the Website' content, services and products other than as expressly authorized
 					in these Terms of Use; or
@@ -473,12 +473,10 @@
 				<li>your use of any information obtained from the Website.</li>
 			</ol>
 
-			<h2 class="mb-4 mt-8 text-2xl font-bold text-white">11. General Provisions</h2>
+			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">11. General Provisions</h2>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">
-				11.1 Governing Law and Jurisdiction
-			</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">11.1 Governing Law and Jurisdiction</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					All matters relating to the Website and these Terms of Use and any dispute or claim
 					arising therefrom or related thereto (in each case, including non-contractual disputes or
@@ -501,8 +499,8 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">11.2 Waiver and Severability</h3>
-			<ol class="space-y-4 text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">11.2 Waiver and Severability</h3>
+			<ol class="space-y-4 text-text-2">
 				<li>
 					No waiver by Provider of any term or condition set forth in these Terms of Use shall be
 					deemed a further or continuing waiver of such term or condition or a waiver of any other
@@ -517,8 +515,8 @@
 				</li>
 			</ol>
 
-			<h3 class="mb-3 mt-6 text-xl font-semibold text-white">11.3 Entire Agreement</h3>
-			<p class="text-gray-400">
+			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">11.3 Entire Agreement</h3>
+			<p class="text-text-2">
 				The Terms of Use and other terms and conditions applicable at the time you access the
 				Website constitute the sole and entire agreement between you and Provider with respect to
 				the Website and supersede all prior and contemporaneous understandings, agreements,

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { currentNetwork, oracleQuotes, tradePanelOpen } from '$lib/stores';
+	import { setSheetOpen } from '$lib/stores/uiStore';
 	import { formatUnits } from 'viem';
 	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
@@ -13,8 +14,10 @@
 	// PERF-01: TradingViewChart is lazy-loaded — it only renders inside the
 	// chart-modal (showChartModal) which is closed on first paint.
 	import TradingViewWidget from '$lib/components/charts/TradingViewWidget.svelte';
+	import { theme } from '$lib/stores/themeStore';
 	import TxLink from '$lib/components/ui/TxLink.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import TabNav from '$lib/components/ui/TabNav.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { onMount } from 'svelte';
@@ -35,6 +38,7 @@
 		VolumeBucket,
 		OHLCBucket
 	} from '$lib/components/charts/token-chart-types';
+	import { tradesToOHLCBuckets, tradesToVolumeBuckets } from '$lib/utils/ohlc';
 	import MarketOrder from '$lib/components/orders/MarketOrder.svelte';
 	import WrapRatioChip from '$lib/components/wrap/WrapRatioChip.svelte';
 	import WrapRatioCard from '$lib/components/wrap/WrapRatioCard.svelte';
@@ -402,6 +406,9 @@
 
 	// Sync trade panel state with store (for layout squishing on lg screens)
 	$: tradePanelOpen.set(showTradePanel);
+	// On mobile the order panel is a full-screen overlay; hide the bottom tab bar
+	// while it's open so the bar never covers the panel's submit button.
+	$: setSheetOpen('tradePanel', showTradePanel);
 
 	// Track if the trade panel was opened by the tutorial
 	let panelOpenedByTutorial = false;
@@ -510,55 +517,7 @@
 		if (!Number.isFinite(tokens) || !Number.isFinite(quote) || !Number.isFinite(price)) return null;
 		return { timestamp, price, tokens, quote, side };
 	};
-	// Convert trade points to OHLC candles
-	const tradesToOHLCBuckets = (
-		trades: TradeHistoryPoint[],
-		bucketSeconds: number
-	): OHLCBucket[] => {
-		if (trades.length === 0) return [];
-		const buckets = new Map<number, TradeHistoryPoint[]>();
-		for (const trade of trades) {
-			const bucketTime = Math.floor(trade.timestamp / 1000 / bucketSeconds) * bucketSeconds * 1000;
-			if (!buckets.has(bucketTime)) {
-				buckets.set(bucketTime, []);
-			}
-			buckets.get(bucketTime)!.push(trade);
-		}
-		const ohlcData: OHLCBucket[] = [];
-		const sortedBuckets = Array.from(buckets.entries()).sort((a, b) => a[0] - b[0]);
-		for (const [time, bucketTrades] of sortedBuckets) {
-			if (bucketTrades.length === 0) continue;
-			// Sort trades within bucket by timestamp
-			const sortedTrades = bucketTrades
-				.filter((t) => Number.isFinite(t.price))
-				.sort((a, b) => a.timestamp - b.timestamp);
-			if (sortedTrades.length === 0) continue;
-			const prices = sortedTrades.map((t) => t.price);
-			ohlcData.push({
-				x: time,
-				o: sortedTrades[0].price, // first trade = open
-				h: Math.max(...prices), // highest price
-				l: Math.min(...prices), // lowest price
-				c: sortedTrades[sortedTrades.length - 1].price // last trade = close
-			});
-		}
-		return ohlcData;
-	};
-	// Aggregate volume by candlestick bucket size for proper alignment
-	const tradesToVolumeBuckets = (
-		trades: TradeHistoryPoint[],
-		bucketSeconds: number
-	): VolumeBucket[] => {
-		if (trades.length === 0) return [];
-		const bucketMap = new Map<number, number>();
-		for (const trade of trades) {
-			const bucketTime = Math.floor(trade.timestamp / 1000 / bucketSeconds) * bucketSeconds * 1000;
-			bucketMap.set(bucketTime, (bucketMap.get(bucketTime) ?? 0) + trade.tokens);
-		}
-		return Array.from(bucketMap.entries())
-			.sort((a, b) => a[0] - b[0])
-			.map(([start, tokens]) => ({ start, tokens }));
-	};
+	// tradesToOHLCBuckets / tradesToVolumeBuckets are imported from $lib/utils/ohlc.
 	let historyRange: HistoryRangeKey = '7D';
 	let historyRangeStartMs = 0;
 	let historyRangeEndMs = 0;
@@ -708,6 +667,8 @@
 		}
 	}
 	let showChartModal = false;
+	// Full-screen terminal/chart view on mobile — hide the bottom tab bar under it.
+	$: setSheetOpen('chartModal', showChartModal);
 	function openChartModal(event?: Event) {
 		event?.stopPropagation?.();
 		showChartModal = true;
@@ -1008,7 +969,7 @@
 	<div class="flex h-screen items-center justify-center">
 		<div class="text-center">
 			<p class="text-lg text-red-400">Failed to load token data</p>
-			<p class="mt-2 text-sm text-gray-400">
+			<p class="mt-2 text-sm text-text-2">
 				{$singleTokenQuery.error?.message || 'Unknown error'}
 			</p>
 		</div>
@@ -1016,8 +977,8 @@
 {:else if !currentToken}
 	<div class="flex h-screen items-center justify-center">
 		<div class="text-center">
-			<p class="text-lg text-gray-400">Token not found</p>
-			<p class="mt-2 text-sm text-gray-500">ID: {tokenId}</p>
+			<p class="text-lg text-text-2">Token not found</p>
+			<p class="mt-2 text-sm text-text-3">ID: {tokenId}</p>
 		</div>
 	</div>
 {:else}
@@ -1027,16 +988,16 @@
 				 non-parity wrapper, otherwise it's noise. -->
 			<div class="flex flex-wrap items-center justify-between gap-3">
 				<div class="min-w-0 leading-tight">
-					<h1 class="text-xl font-semibold leading-tight text-white sm:text-2xl">
+					<h1 class="text-xl font-semibold leading-tight text-text sm:text-2xl">
 						{tokenDisplayName}
 					</h1>
 					<div
-						class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-400 sm:text-sm"
+						class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-2 sm:text-sm"
 					>
 						<span class="font-mono tabular-nums"
 							>{currentPythToken?.symbol ?? currentToken.symbol}</span
 						>
-						<span class="text-gray-600">·</span>
+						<span class="text-text-muted">·</span>
 						<span>Wrapped tStock on {$currentNetwork.displayName}</span>
 					</div>
 				</div>
@@ -1054,21 +1015,24 @@
 				<!-- Left: Symbol info -->
 				<div class="space-y-3 sm:space-y-4 xl:col-span-2">
 					<div
-						class="overflow-hidden rounded-lg border border-white/5 bg-gray-800/80 backdrop-blur-sm"
+						class="relative overflow-hidden rounded-2xl border border-line bg-overlay-1 backdrop-blur"
 						data-tutorial="symbol-overview"
 					>
-						<div class="border-b border-white/10 px-3 py-2 sm:px-4 sm:py-3">
+						<div
+							class="pointer-events-none absolute -right-12 -top-16 h-56 w-56 rounded-full bg-emerald-400/15 blur-3xl"
+						></div>
+						<div class="relative border-b border-line px-3 py-2 sm:px-4 sm:py-3">
 							<div class="flex items-start justify-between gap-4">
 								<div>
-									<p class="text-[10px] uppercase tracking-wide text-gray-400 sm:text-xs">
+									<p class="text-[10px] uppercase tracking-wide text-text-2 sm:text-xs">
 										Off-chain Reference
 									</p>
-									<p class="mt-0.5 text-sm font-semibold text-gray-200 sm:mt-1 sm:text-base">
+									<p class="mt-0.5 text-sm font-semibold text-text-2 sm:mt-1 sm:text-base">
 										{tokenDisplayName}
 									</p>
 								</div>
 								{#if tradingViewSymbol}
-									<span class="text-xs text-gray-400 sm:text-sm">{tradingViewSymbol}</span>
+									<span class="text-xs text-text-2 sm:text-sm">{tradingViewSymbol}</span>
 								{/if}
 							</div>
 						</div>
@@ -1091,19 +1055,19 @@
 							</div>
 						{:else}
 							<div
-								class="flex h-32 items-center justify-center px-4 py-6 text-sm text-gray-400 sm:h-48"
+								class="flex h-32 items-center justify-center px-4 py-6 text-sm text-text-2 sm:h-48"
 							>
 								TradingView data unavailable for this token.
 							</div>
 						{/if}
 					</div>
-					<div class="rounded-lg border border-white/5 bg-gray-800/80 p-3 backdrop-blur-sm sm:p-4">
+					<div class="rounded-2xl border border-line bg-overlay-1 p-4 backdrop-blur sm:p-5">
 						<dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:gap-x-6 sm:gap-y-3 sm:text-sm">
 							<div>
-								<dt class="text-[10px] uppercase tracking-wide text-gray-500 sm:text-xs">
+								<dt class="text-[10px] uppercase tracking-wider text-text-3 sm:text-xs">
 									Oracle Price
 								</dt>
-								<dd class="mt-0.5 font-medium text-gray-100 sm:mt-1">
+								<dd class="mt-0.5 font-mono tabular-nums text-text sm:mt-1">
 									{#if oracleLoading}
 										Loading...
 									{:else if oraclePriceData}
@@ -1114,10 +1078,10 @@
 								</dd>
 							</div>
 							<div>
-								<dt class="text-[10px] uppercase tracking-wide text-gray-500 sm:text-xs">
+								<dt class="text-[10px] uppercase tracking-wider text-text-3 sm:text-xs">
 									Confidence
 								</dt>
-								<dd class="mt-0.5 font-medium text-gray-100 sm:mt-1">
+								<dd class="mt-0.5 font-mono tabular-nums text-text sm:mt-1">
 									{#if oracleLoading}
 										Loading...
 									{:else if oraclePriceData}
@@ -1128,10 +1092,10 @@
 								</dd>
 							</div>
 							<div>
-								<dt class="text-[10px] uppercase tracking-wide text-gray-500 sm:text-xs">
+								<dt class="text-[10px] uppercase tracking-wider text-text-3 sm:text-xs">
 									Bid Price
 								</dt>
-								<dd class="mt-0.5 font-medium text-gray-100 sm:mt-1">
+								<dd class="mt-0.5 font-mono tabular-nums text-text sm:mt-1">
 									{#if orderbookQuoteUiState.loadingWithoutData}
 										Loading...
 									{:else if buyPrice !== null}
@@ -1144,11 +1108,11 @@
 											<div class="leading-tight">
 												<div>
 													${formatNumeric(buyPrice / currentRatio)}
-													<span class="text-[10px] font-normal text-gray-500">/ {assetSym}</span>
+													<span class="text-[10px] font-normal text-text-3">/ {assetSym}</span>
 												</div>
-												<div class="mt-0.5 text-[11px] font-normal text-gray-400 sm:text-xs">
+												<div class="mt-0.5 text-[11px] font-normal text-text-2 sm:text-xs">
 													${formatNumeric(buyPrice)}
-													<span class="text-[10px] text-gray-500">/ {wrappedSym}</span>
+													<span class="text-[10px] text-text-3">/ {wrappedSym}</span>
 												</div>
 											</div>
 										{:else}
@@ -1160,10 +1124,10 @@
 								</dd>
 							</div>
 							<div>
-								<dt class="text-[10px] uppercase tracking-wide text-gray-500 sm:text-xs">
+								<dt class="text-[10px] uppercase tracking-wider text-text-3 sm:text-xs">
 									Offer Price
 								</dt>
-								<dd class="mt-0.5 font-medium text-gray-100 sm:mt-1">
+								<dd class="mt-0.5 font-mono tabular-nums text-text sm:mt-1">
 									{#if orderbookQuoteUiState.loadingWithoutData}
 										Loading...
 									{:else if sellPrice !== null}
@@ -1176,11 +1140,11 @@
 											<div class="leading-tight">
 												<div>
 													${formatNumeric(sellPrice / currentRatio)}
-													<span class="text-[10px] font-normal text-gray-500">/ {assetSym}</span>
+													<span class="text-[10px] font-normal text-text-3">/ {assetSym}</span>
 												</div>
-												<div class="mt-0.5 text-[11px] font-normal text-gray-400 sm:text-xs">
+												<div class="mt-0.5 text-[11px] font-normal text-text-2 sm:text-xs">
 													${formatNumeric(sellPrice)}
-													<span class="text-[10px] text-gray-500">/ {wrappedSym}</span>
+													<span class="text-[10px] text-text-3">/ {wrappedSym}</span>
 												</div>
 											</div>
 										{:else}
@@ -1202,7 +1166,7 @@
 							)}
 							{@const wrappedSym = currentPythToken?.symbol ?? currentToken.symbol}
 							<div
-								class="mt-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-white/5 pt-2 text-[11px] text-gray-400 sm:text-xs"
+								class="mt-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-line pt-2 text-[11px] text-text-2 sm:text-xs"
 							>
 								<span class="font-mono tabular-nums">
 									1 {wrappedSym} = {Number.isInteger(currentRatio)
@@ -1216,7 +1180,7 @@
 									type="button"
 									on:click={openWrapExplainer}
 									data-testid="wrap-explainer-trigger"
-									class="inline-flex items-center gap-1 text-blue-300 transition hover:text-blue-200 hover:underline"
+									class="inline-flex items-center gap-1 text-blue-600 transition hover:text-blue-700 hover:underline dark:text-blue-300 dark:hover:text-blue-200"
 								>
 									What's this?
 								</button>
@@ -1231,7 +1195,7 @@
 							type="button"
 							data-testid="open-trade"
 							data-side="buy"
-							class="rounded-xl bg-green-500 px-3 py-2.5 text-sm font-semibold text-white shadow-lg shadow-green-500/30 transition hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400/60 focus:ring-offset-2 focus:ring-offset-gray-900 sm:px-4 sm:py-3 sm:text-base"
+							class="rounded-xl bg-emerald-500 px-3 py-3.5 text-sm font-bold text-[#05231a] transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 focus:ring-offset-2 focus:ring-offset-surface-1 sm:px-4 sm:text-base"
 							on:click={() => openTradePanel('Buy')}
 						>
 							Buy
@@ -1240,7 +1204,7 @@
 							type="button"
 							data-testid="open-trade"
 							data-side="sell"
-							class="rounded-xl bg-red-500 px-3 py-2.5 text-sm font-semibold text-white shadow-lg shadow-red-500/30 transition hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400/60 focus:ring-offset-2 focus:ring-offset-gray-900 sm:px-4 sm:py-3 sm:text-base"
+							class="rounded-xl bg-red-500 px-3 py-3.5 text-sm font-bold text-[#2a0808] transition hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-red-400/60 focus:ring-offset-2 focus:ring-offset-surface-1 sm:px-4 sm:text-base"
 							on:click={() => openTradePanel('Sell')}
 						>
 							Sell
@@ -1251,7 +1215,7 @@
 				<div class="flex h-full flex-col gap-3 sm:gap-4 xl:col-span-3" data-tutorial="tradingview">
 					{#if tradingViewSymbol}
 						<div
-							class="flex-1 overflow-hidden rounded-lg border border-white/5 bg-gray-800/80 backdrop-blur-sm"
+							class="flex-1 overflow-hidden rounded-2xl border border-line bg-overlay-1 backdrop-blur"
 						>
 							<div class="hidden sm:block">
 								<TradingViewWidget
@@ -1279,9 +1243,9 @@
 							</div>
 						</div>
 					{:else}
-						<div class="flex-1 rounded-lg border border-white/5 bg-gray-800/80 backdrop-blur-sm">
+						<div class="flex-1 rounded-2xl border border-line bg-overlay-1 backdrop-blur">
 							<div
-								class="flex h-[280px] items-center justify-center text-sm text-gray-400 sm:h-[495px]"
+								class="flex h-[280px] items-center justify-center text-sm text-text-2 sm:h-[495px]"
 							>
 								TradingView data unavailable for this token.
 							</div>
@@ -1291,25 +1255,26 @@
 						<Button
 							variant="secondary"
 							size="md"
-							className="w-full rounded-xl border border-yellow-400/40 bg-yellow-500/20 px-4 py-2.5 text-sm font-semibold text-yellow-300 shadow-lg shadow-yellow-500/30 transition hover:border-yellow-300 hover:bg-yellow-500/30 hover:text-white sm:w-auto sm:py-3 sm:text-base"
+							className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-line bg-overlay-1 px-3 py-1.5 text-[12px] font-semibold text-text transition hover:bg-overlay-hover"
 							aria-label="Open terminal view"
 							on:click={(event) => openChartModal(event)}
 						>
 							Advanced Chart
+							<Icon name="arrowUpRight" className="h-3.5 w-3.5" />
 						</Button>
 					</div>
 				</div>
 			</div>
 		</div>
-		<div class="space-y-4 sm:space-y-6">
+		<div class="space-y-4 border-t border-line pt-6 sm:space-y-6">
 			<div data-tutorial="dex-activity">
 				<div class="mb-4 sm:mb-6">
 					<div
 						class="mb-3 flex flex-col gap-2 sm:mb-4 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
 					>
 						<div>
-							<h2 class="text-base font-semibold sm:text-lg">On-chain Market</h2>
-							<p class="hidden text-xs text-gray-400 sm:block sm:text-sm">
+							<h2 class="text-xl font-bold tracking-tight text-text">On-chain Market</h2>
+							<p class="hidden text-[13px] text-text-3 sm:block">
 								View on-chain trades, liquidity, orders, and vaults
 							</p>
 						</div>
@@ -1335,42 +1300,12 @@
 											decimals: 18,
 											image: currentPythToken?.logoUrl
 										})}
-									class="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-xs font-medium text-gray-300 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-300 sm:gap-2 sm:px-3 sm:py-2 sm:text-sm"
+									class="flex items-center gap-1.5 rounded-lg border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-text-2 transition hover:border-blue-400/50 hover:bg-blue-500/10 hover:text-blue-700 sm:gap-2 sm:px-3 sm:py-2 sm:text-sm dark:hover:text-blue-300"
 								>
 									<!-- Wallet icon (mobile only) -->
-									<svg
-										class="h-4 w-4 sm:hidden"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-									>
-										<path
-											d="M21 12V7H5a2 2 0 0 1 0-4h14v4"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-										/>
-										<path
-											d="M3 5v14a2 2 0 0 0 2 2h16v-5"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-										/>
-										<path
-											d="M18 12a2 2 0 0 0 0 4h4v-4Z"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-										/>
-									</svg>
+									<Icon name="wallet" className="h-4 w-4 sm:hidden" />
 									<!-- Plus icon -->
-									<svg
-										class="h-3 w-3 sm:h-4 sm:w-4"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-									>
-										<path d="M12 5v14M5 12h14" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
+									<Icon name="plus" className="h-3 w-3 sm:h-4 sm:w-4" />
 									<span class="sm:hidden">Track</span>
 									<span class="hidden sm:inline">Track in Wallet</span>
 								</button>
@@ -1410,7 +1345,7 @@
 								historyRangeOptions={HISTORY_RANGE_OPTIONS}
 								on:rangeChange={(e) => (historyRange = e.detail.key)}
 							/>
-							<div class="mt-2 hidden text-xs text-gray-400 sm:block">
+							<div class="mt-2 hidden text-xs text-text-2 sm:block">
 								All times are displayed in your local timezone{#if hasRatio}
 									· prices in USD per {tableDenom === 'unwrapped'
 										? (currentPythToken?.symbol ?? currentToken.symbol).replace(/^wt/, 't') +
@@ -1439,7 +1374,7 @@
 						<div class="mt-4">
 							{#if !$isAuthenticated}
 								<div class="flex flex-col items-center justify-center gap-4 py-12">
-									<p class="text-sm text-gray-400">Connect your wallet to view your position</p>
+									<p class="text-sm text-text-2">Connect your wallet to view your position</p>
 									<Button variant="primary" size="md" on:click={() => promptWalletConnection()}>
 										Connect Wallet
 									</Button>
@@ -1475,7 +1410,7 @@
 									vaults[0]?.token?.decimals ?? currentPythToken?.decimals ?? 18}
 
 								{#if vaults.length === 0 && walletBalance === 0n}
-									<div class="py-8 text-center text-sm text-gray-400">
+									<div class="py-8 text-center text-sm text-text-2">
 										No position found for this token
 									</div>
 								{:else}
@@ -1502,20 +1437,20 @@
 															vault.id
 														)}
 														<div
-															class="flex items-center justify-between rounded-lg border border-white/5 bg-white/5 p-2 text-sm"
+															class="flex items-center justify-between rounded-xl border border-line bg-overlay-1 p-2 text-sm"
 														>
-															<div class="flex items-center gap-2 text-xs text-gray-400">
+															<div class="flex items-center gap-2 text-xs text-text-2">
 																<a
 																	href={raindexUrl}
 																	target="_blank"
 																	rel="noopener noreferrer"
-																	class="text-blue-400 hover:text-blue-300 hover:underline"
+																	class="text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
 																	title="View on Raindex"
 																>
 																	{vaultIdHex.slice(0, 8)}...
 																</a>
 																<span>•</span>
-																<span
+																<span class="font-mono tabular-nums"
 																	>{Number(formatUnits(balance, vault.token.decimals)).toFixed(3)}
 																	{vault.token.symbol}</span
 																>
@@ -1539,8 +1474,8 @@
 																type="button"
 																class={`h-8 w-8 rounded-md text-sm font-medium transition ${
 																	pageNum === currentVaultsPage
-																		? 'bg-blue-500 text-white'
-																		: 'bg-white/5 text-gray-400 hover:bg-white/10'
+																		? 'bg-blue-500 text-text'
+																		: 'bg-surface-2 text-text-2 hover:bg-surface-2'
 																}`}
 																on:click={() => {
 																	currentVaultsPage = pageNum;
@@ -1552,35 +1487,35 @@
 													</div>
 												{/if}
 											{:else}
-												<div class="py-8 text-center text-sm text-gray-400">
+												<div class="py-8 text-center text-sm text-text-2">
 													No vaults with balance found
 												</div>
 											{/if}
 										</div>
 
 										<!-- Right: Summary table -->
-										<div class="rounded-lg border border-white/10 bg-white/5 p-4">
-											<h3 class="mb-4 text-sm font-semibold text-gray-100">Summary</h3>
+										<div class="rounded-2xl border border-line bg-overlay-1 p-4">
+											<h3 class="mb-4 text-sm font-semibold text-text-2">Summary</h3>
 											<div class="space-y-3 text-sm">
-												<div class="flex justify-between text-gray-400">
+												<div class="flex justify-between text-text-2">
 													<span>Vaults Subtotal:</span>
-													<span
+													<span class="font-mono tabular-nums"
 														>{Number(formatUnits(totalVaultBalance, tokenDecimals)).toFixed(3)}
 														{currentToken?.symbol}</span
 													>
 												</div>
-												<div class="flex justify-between text-gray-400">
+												<div class="flex justify-between text-text-2">
 													<span>Wallet Balance:</span>
-													<span
+													<span class="font-mono tabular-nums"
 														>{Number(formatUnits(walletBalance, tokenDecimals)).toFixed(3)}
 														{currentToken?.symbol}</span
 													>
 												</div>
 												<div
-													class="flex justify-between border-t border-white/10 pt-3 font-semibold text-gray-100"
+													class="flex justify-between border-t border-line pt-3 font-semibold text-text-2"
 												>
 													<span>Total:</span>
-													<span
+													<span class="font-mono tabular-nums"
 														>{Number(formatUnits(totalBalance, tokenDecimals)).toFixed(3)}
 														{currentToken?.symbol}</span
 													>
@@ -1596,32 +1531,24 @@
 			</div>
 		</div>
 		<!-- About Section - Collapsible on mobile -->
-		<div class="space-y-4 overflow-x-hidden sm:space-y-6">
+		<div class="mt-8 space-y-4 overflow-x-hidden border-t border-line pt-6 sm:space-y-6">
 			<button
 				type="button"
 				class="flex w-full items-center justify-between sm:cursor-default"
 				on:click={() => (isAboutCollapsed = !isAboutCollapsed)}
 			>
 				<div>
-					<h2 class="text-base font-semibold sm:text-lg">About</h2>
-					<p class="hidden text-sm text-gray-400 sm:block">
+					<h2 class="text-xl font-bold tracking-tight text-text">About</h2>
+					<p class="hidden text-[13px] text-text-3 sm:block">
 						Learn more about the token or the equity
 					</p>
 				</div>
-				<svg
-					class="h-5 w-5 text-gray-400 transition-transform sm:hidden"
-					class:rotate-180={!isAboutCollapsed}
-					fill="none"
-					stroke="currentColor"
-					viewBox="0 0 24 24"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M19 9l-7 7-7-7"
-					/>
-				</svg>
+				<Icon
+					name="chevronDown"
+					className="h-5 w-5 text-text-2 transition-transform sm:hidden {!isAboutCollapsed
+						? 'rotate-180'
+						: ''}"
+				/>
 			</button>
 			<div
 				class="grid gap-4 overflow-x-hidden sm:gap-6 lg:grid-cols-2"
@@ -1632,7 +1559,7 @@
 				<!-- Token Details (Left) -->
 				<div class="min-w-0 space-y-4">
 					<div class="space-y-3">
-						<h3 class="text-sm font-semibold uppercase tracking-wide text-gray-400">
+						<h3 class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-3">
 							Token Details
 						</h3>
 						<TabNav tabs={TOKEN_TABS} activeId={activeTokenTab} on:change={handleTokenTabChange} />
@@ -1652,9 +1579,9 @@
 								/>
 							{/if}
 							<h3 class="mb-3 font-semibold">Contract Information</h3>
-							<div class="space-y-3 text-sm">
-								<div class="flex items-center justify-between gap-2">
-									<span class="text-gray-400">Wrapped Token</span>
+							<div class="divide-y divide-line text-sm">
+								<div class="flex items-center justify-between gap-2 py-2.5">
+									<span class="text-text-2">Wrapped Token</span>
 									<div>
 										<div class="sm:hidden">
 											<ExternalLink
@@ -1662,7 +1589,7 @@
 													tokenId}"
 												label={currentPythToken?.address ?? tokenId}
 												truncate={{ start: 0, end: 6 }}
-												className="flex items-center gap-1 text-blue-400 hover:text-blue-300"
+												className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 											/>
 										</div>
 										<div class="hidden sm:block">
@@ -1670,48 +1597,48 @@
 												href="{$currentNetwork.blockExplorer}/token/{currentPythToken?.address ??
 													tokenId}"
 												label={truncateAddress(currentPythToken?.address ?? tokenId)}
-												className="flex items-center gap-1 text-blue-400 hover:text-blue-300"
+												className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 											/>
 										</div>
 									</div>
 								</div>
 								{#if currentPythToken?.unwrappedAddress}
-									<div class="flex items-center justify-between gap-2">
-										<span class="text-gray-400">Underlying Token</span>
+									<div class="flex items-center justify-between gap-2 py-2.5">
+										<span class="text-text-2">Underlying Token</span>
 										<div>
 											<div class="sm:hidden">
 												<ExternalLink
 													href="{$currentNetwork.blockExplorer}/token/{currentPythToken.unwrappedAddress}"
 													label={currentPythToken.unwrappedAddress}
 													truncate={{ start: 0, end: 6 }}
-													className="flex items-center gap-1 text-blue-400 hover:text-blue-300"
+													className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 												/>
 											</div>
 											<div class="hidden sm:block">
 												<ExternalLink
 													href="{$currentNetwork.blockExplorer}/token/{currentPythToken.unwrappedAddress}"
 													label={truncateAddress(currentPythToken.unwrappedAddress)}
-													className="flex items-center gap-1 text-blue-400 hover:text-blue-300"
+													className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 												/>
 											</div>
 										</div>
 									</div>
 								{/if}
-								<div class="flex justify-between">
-									<span class="text-gray-400">Network</span>
+								<div class="flex justify-between py-2.5">
+									<span class="text-text-2">Network</span>
 									<span>{$currentNetwork.displayName}</span>
 								</div>
-								<div class="flex justify-between">
-									<span class="text-gray-400">Symbol</span>
+								<div class="flex justify-between py-2.5">
+									<span class="text-text-2">Symbol</span>
 									<span>{currentPythToken?.symbol ?? currentToken.symbol}</span>
 								</div>
-								<div class="flex justify-between">
-									<span class="text-gray-400">Decimals</span>
+								<div class="flex justify-between py-2.5">
+									<span class="text-text-2">Decimals</span>
 									<span>18</span>
 								</div>
 								{#if hasRatio}
-									<div class="flex justify-between">
-										<span class="text-gray-400">Wrap ratio</span>
+									<div class="flex justify-between py-2.5">
+										<span class="text-text-2">Wrap ratio</span>
 										<span class="font-mono tabular-nums"
 											>1 {currentPythToken?.symbol ?? currentToken.symbol} ↔ {Number.isInteger(
 												currentRatio
@@ -1724,9 +1651,12 @@
 										>
 									</div>
 								{/if}
-								<div class="flex items-center justify-between">
-									<span class="text-gray-400">Proofs</span>
-									<a href={`/trade/${tokenId}/proofs`} class="text-blue-400 hover:text-blue-300">
+								<div class="flex items-center justify-between py-2.5">
+									<span class="text-text-2">Proofs</span>
+									<a
+										href={`/trade/${tokenId}/proofs`}
+										class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+									>
 										View proofs
 									</a>
 								</div>
@@ -1745,19 +1675,19 @@
 							<h3 class="mb-3 font-semibold">Supply & Distribution</h3>
 							<div class="space-y-3 text-sm">
 								<div class="flex justify-between">
-									<span class="text-gray-400">Total Supply</span>
-									<span
+									<span class="text-text-2">Total Supply</span>
+									<span class="font-mono tabular-nums"
 										>{formatBaseUnitAmount(
 											currentToken.bridgedSupply ?? currentToken.totalShares
 										)}</span
 									>
 								</div>
 								<div class="flex justify-between">
-									<span class="text-gray-400">Holders</span>
+									<span class="text-text-2">Holders</span>
 									<span>{currentToken.holderCount ?? 0}</span>
 								</div>
 								<div class="flex justify-between">
-									<span class="text-gray-400">Total Transfers</span>
+									<span class="text-text-2">Total Transfers</span>
 									<span>{currentToken.transferCount ?? 0}</span>
 								</div>
 							</div>
@@ -1769,14 +1699,14 @@
 								<ExternalLink
 									href="https://portal.s01issuer.com/metrics"
 									label="View All"
-									className="flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300"
+									className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 								/>
 							</div>
 							{#if currentToken?.deposits?.length}
 								<div>
 									{#each currentToken.deposits.slice(0, 5) as dep}
 										<div
-											class="border-b border-white/5 px-2 py-3 transition-colors hover:bg-white/5"
+											class="border-b border-line px-2 py-3 transition-colors hover:bg-surface-2"
 										>
 											<div class="flex items-center justify-between gap-3 text-xs">
 												<div class="min-w-0 truncate">
@@ -1789,21 +1719,21 @@
 													<TxLink hash={dep.transaction.id} />
 												</div>
 											</div>
-											<div class="mt-1 flex items-center gap-2 text-xs text-gray-500">
+											<div class="mt-1 flex items-center gap-2 text-xs text-text-3">
 												<span>
 													<span class="sm:hidden">…{dep.emitter.address.slice(-6)}</span>
 													<span class="hidden sm:inline">
 														{truncateAddress(dep.emitter.address)}
 													</span>
 												</span>
-												<span class="text-gray-600">•</span>
+												<span class="text-text-muted">•</span>
 												<span>{new Date(Number(dep.timestamp) * 1000).toLocaleString()}</span>
 											</div>
 										</div>
 									{/each}
 								</div>
 							{:else}
-								<div class="text-sm text-gray-400">No recent mints.</div>
+								<div class="text-sm text-text-2">No recent mints.</div>
 							{/if}
 						</div>
 					{:else}
@@ -1813,14 +1743,14 @@
 								<ExternalLink
 									href="https://portal.s01issuer.com/metrics"
 									label="View All"
-									className="flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300"
+									className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 								/>
 							</div>
 							{#if currentToken?.withdraws?.length}
 								<div>
 									{#each currentToken.withdraws.slice(0, 5) as w}
 										<div
-											class="border-b border-white/5 px-2 py-3 transition-colors hover:bg-white/5"
+											class="border-b border-line px-2 py-3 transition-colors hover:bg-surface-2"
 										>
 											<div class="flex items-center justify-between gap-3 text-xs">
 												<div class="min-w-0 truncate">
@@ -1833,21 +1763,21 @@
 													<TxLink hash={w.transaction.id} />
 												</div>
 											</div>
-											<div class="mt-1 flex items-center gap-2 text-xs text-gray-500">
+											<div class="mt-1 flex items-center gap-2 text-xs text-text-3">
 												<span>
 													<span class="sm:hidden">…{w.emitter.address.slice(-6)}</span>
 													<span class="hidden sm:inline">
 														{truncateAddress(w.emitter.address)}
 													</span>
 												</span>
-												<span class="text-gray-600">•</span>
+												<span class="text-text-muted">•</span>
 												<span>{new Date(Number(w.timestamp) * 1000).toLocaleString()}</span>
 											</div>
 										</div>
 									{/each}
 								</div>
 							{:else}
-								<div class="text-sm text-gray-400">No recent burns.</div>
+								<div class="text-sm text-text-2">No recent burns.</div>
 							{/if}
 						</div>
 					{/if}
@@ -1855,7 +1785,7 @@
 				<!-- Underlying Equity (Right) -->
 				<div class="min-w-0 space-y-4">
 					<div class="space-y-3">
-						<h3 class="text-sm font-semibold uppercase tracking-wide text-gray-400">
+						<h3 class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-3">
 							Equity Details
 						</h3>
 						<TabNav tabs={ASSET_TABS} activeId={activeAssetTab} on:change={handleAssetTabChange} />
@@ -1880,7 +1810,7 @@
 							</div>
 						{:else}
 							<div class="p-4">
-								<p class="text-sm text-gray-400">TradingView data unavailable for this token.</p>
+								<p class="text-sm text-text-2">TradingView data unavailable for this token.</p>
 							</div>
 						{/if}
 					{:else if activeAssetTab === 'fundamentals'}
@@ -1903,7 +1833,7 @@
 							</div>
 						{:else}
 							<div class="p-4">
-								<p class="text-sm text-gray-400">TradingView data unavailable for this token.</p>
+								<p class="text-sm text-text-2">TradingView data unavailable for this token.</p>
 							</div>
 						{/if}
 					{:else if activeAssetTab === 'technical'}
@@ -1926,7 +1856,7 @@
 							</div>
 						{:else}
 							<div class="p-4">
-								<p class="text-sm text-gray-400">TradingView data unavailable for this token.</p>
+								<p class="text-sm text-text-2">TradingView data unavailable for this token.</p>
 							</div>
 						{/if}
 					{:else if tradingViewSymbol}
@@ -1948,7 +1878,7 @@
 						</div>
 					{:else}
 						<div class="p-4">
-							<p class="text-sm text-gray-400">TradingView data unavailable for this token.</p>
+							<p class="text-sm text-text-2">TradingView data unavailable for this token.</p>
 						</div>
 					{/if}
 				</div>
@@ -1964,7 +1894,7 @@
 				on:click={closeTradePanel}
 			></button>
 			<aside
-				class="relative h-full w-full border-l-0 border-white/10 bg-gradient-to-b from-gray-950 to-gray-900 shadow-2xl sm:max-w-[22rem] sm:border-l"
+				class="relative h-full w-full border-l-0 border-line bg-gradient-to-b from-surface-1 to-surface-2 shadow-2xl sm:max-w-[22rem] sm:border-l"
 				in:fly={{ x: 320, duration: 220 }}
 				out:fly={{ x: 320, duration: 180 }}
 				role="dialog"
@@ -1974,14 +1904,14 @@
 			>
 				<div class="flex h-full flex-col">
 					<div
-						class="flex items-start justify-between border-b border-white/10 px-4 py-4 sm:px-6 sm:py-5"
+						class="flex items-start justify-between border-b border-line px-4 py-4 sm:px-6 sm:py-5"
 					>
 						<div class="flex items-start gap-2 sm:gap-3">
 							{#if currentPythToken?.logoUrl}
 								<img
 									src={currentPythToken.logoUrl}
 									alt={tokenDisplaySymbol || tokenDisplayName}
-									class="h-8 w-8 rounded-full border border-white/10 object-cover sm:h-10 sm:w-10"
+									class="h-8 w-8 rounded-full border border-line object-cover sm:h-10 sm:w-10"
 								/>
 							{/if}
 							<div>
@@ -1990,7 +1920,7 @@
 						</div>
 						<button
 							type="button"
-							class="rounded-lg p-2 text-gray-400 transition hover:bg-white/5 hover:text-white focus:outline-none focus:ring-2 focus:ring-yellow-500/40"
+							class="rounded-lg p-2 text-text-2 transition hover:bg-surface-2 hover:text-text focus:outline-none focus:ring-2 focus:ring-yellow-500/40"
 							on:click={closeTradePanel}
 							aria-label="Close trade panel"
 						>
@@ -2016,8 +1946,8 @@
 									data-side="buy"
 									class={`rounded-lg px-3 py-2.5 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-yellow-500/40 sm:px-4 sm:py-3 ${
 										panelOrderSide === 'Buy'
-											? 'bg-green-500 text-white shadow-lg shadow-green-500/30'
-											: 'bg-white/5 text-gray-200 hover:bg-white/10'
+											? 'bg-green-500 text-text shadow-lg shadow-green-500/30'
+											: 'bg-surface-2 text-text-2 hover:bg-surface-2'
 									}`}
 									on:click={() => (panelOrderSide = 'Buy')}
 								>
@@ -2029,8 +1959,8 @@
 									data-side="sell"
 									class={`rounded-lg px-3 py-2.5 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-yellow-500/40 sm:px-4 sm:py-3 ${
 										panelOrderSide === 'Sell'
-											? 'bg-red-500 text-white shadow-lg shadow-red-500/30'
-											: 'bg-white/5 text-gray-200 hover:bg-white/10'
+											? 'bg-red-500 text-text shadow-lg shadow-red-500/30'
+											: 'bg-surface-2 text-text-2 hover:bg-surface-2'
 									}`}
 									on:click={() => (panelOrderSide = 'Sell')}
 								>
@@ -2039,11 +1969,11 @@
 							</div>
 							<div class="space-y-1 sm:space-y-2">
 								<div
-									class="flex flex-wrap items-center gap-1 text-xs font-medium text-gray-300 sm:gap-2 sm:text-sm"
+									class="flex flex-wrap items-center gap-1 text-xs font-medium text-text-2 sm:gap-2 sm:text-sm"
 								>
 									<span>{panelSummaryVerb} {panelTokenLabel}</span>
-									<span class="text-gray-500">{panelSummaryPreposition}</span>
-									<span class="inline-flex items-center gap-1 text-gray-200">
+									<span class="text-text-3">{panelSummaryPreposition}</span>
+									<span class="inline-flex items-center gap-1 text-text-2">
 										{settlementTokenSymbol}
 										<img
 											src={settlementTokenLogo}
@@ -2057,20 +1987,20 @@
 										type="button"
 										on:click={openWrapExplainer}
 										data-testid="wrap-explainer-trigger"
-										class="block text-left font-mono text-[11px] tabular-nums text-gray-500 transition hover:text-yellow-200 hover:underline sm:text-xs"
+										class="block text-left font-mono text-[11px] tabular-nums text-text-3 transition hover:text-accent hover:underline sm:text-xs"
 									>
 										1 {panelWrappedSymbol} = {panelRatioCalloutDisplay}
 										{panelAssetSymbol}
 									</button>
 								{/if}
-								<div class="flex items-center gap-1 text-xs text-gray-400 sm:gap-2 sm:text-sm">
+								<div class="flex items-center gap-1 text-xs text-text-2 sm:gap-2 sm:text-sm">
 									<span>On</span>
 									<img src="/images/BASE.svg" alt="Base" class="h-3.5 w-3.5 sm:h-4 sm:w-4" />
 									<span>{$currentNetwork.displayName}</span>
 								</div>
 								{#if hasRatio}
 									<label
-										class="mt-2 flex cursor-pointer items-start gap-2 rounded-md border border-white/5 bg-white/[0.03] p-2 text-xs text-gray-300 sm:text-sm"
+										class="mt-2 flex cursor-pointer items-start gap-2 rounded-md border border-line bg-surface-2 p-2 text-xs text-text-2 sm:text-sm"
 									>
 										<input
 											type="checkbox"
@@ -2078,11 +2008,11 @@
 											checked={$panelDenom === 'unwrapped'}
 											on:change={(e) =>
 												panelDenom.set(e.currentTarget.checked ? 'unwrapped' : 'wrapped')}
-											class="mt-0.5 h-3.5 w-3.5 rounded border-white/20 bg-transparent text-yellow-400 focus:ring-yellow-400/40"
+											class="mt-0.5 h-3.5 w-3.5 rounded border-line-strong bg-transparent text-accent focus:ring-yellow-400/40"
 										/>
 										<span class="flex-1 leading-snug">
 											Show wrapped token quantities in {panelAssetSymbol} equivalents
-											<span class="mt-0.5 block text-[10px] text-gray-500 sm:text-[11px]">
+											<span class="mt-0.5 block text-[10px] text-text-3 sm:text-[11px]">
 												You're still trading wrapped tokens — only the displayed quantities and
 												prices change.
 											</span>
@@ -2125,7 +2055,7 @@
 							<label class="block space-y-1.5 sm:space-y-2" for={PANEL_STRATEGY_SELECT_ID}>
 								<span
 									id={PANEL_STRATEGY_LABEL_ID}
-									class="block text-xs font-medium text-gray-300 sm:text-sm"
+									class="block text-xs font-medium text-text-2 sm:text-sm"
 								>
 									Order Type
 								</span>
@@ -2216,23 +2146,23 @@
 		</div>
 	{/if}
 	<!-- Compact Footer -->
-	<footer class="border-t border-white/5 px-3 py-4 sm:px-6 sm:py-8 lg:px-8">
+	<footer class="border-t border-line px-3 py-4 sm:px-6 sm:py-8 lg:px-8">
 		<div class="mx-auto max-w-5xl">
 			<!-- Links Row - fewer on mobile -->
 			<div
-				class="mb-4 flex flex-wrap items-center justify-center gap-3 text-[10px] text-gray-400 sm:mb-6 sm:gap-6 sm:text-sm"
+				class="mb-4 flex flex-wrap items-center justify-center gap-3 text-[10px] text-text-2 sm:mb-6 sm:gap-6 sm:text-sm"
 			>
-				<a href="/terms" class="transition-colors hover:text-yellow-500">Terms</a>
-				<a href="/privacy-policy" class="transition-colors hover:text-yellow-500">Privacy</a>
-				<a href="/docs" class="transition-colors hover:text-yellow-500">Docs</a>
-				<a href="/faqs" class="hidden transition-colors hover:text-yellow-500 sm:inline">FAQs</a>
+				<a href="/terms" class="transition-colors hover:text-accent">Terms</a>
+				<a href="/privacy-policy" class="transition-colors hover:text-accent">Privacy</a>
+				<a href="/docs" class="transition-colors hover:text-accent">Docs</a>
+				<a href="/faqs" class="hidden transition-colors hover:text-accent sm:inline">FAQs</a>
 			</div>
 
 			<!-- Social Links -->
 			<div class="mb-4 flex items-center justify-center gap-3 sm:mb-6 sm:gap-4">
 				<a
 					href="mailto:toby@st0x.io"
-					class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+					class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-2 transition-all hover:bg-yellow-500/20 hover:text-accent"
 					aria-label="Email"
 				>
 					<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor"
@@ -2245,7 +2175,7 @@
 					href="https://x.com/st0x_io"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+					class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-2 transition-all hover:bg-yellow-500/20 hover:text-accent"
 					aria-label="X"
 				>
 					<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -2258,7 +2188,7 @@
 					href="https://t.me/+oIzo_I9xi745ODU0"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+					class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-2 transition-all hover:bg-yellow-500/20 hover:text-accent"
 					aria-label="Telegram"
 				>
 					<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -2271,7 +2201,7 @@
 					href="https://www.linkedin.com/company/st0x"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-gray-400 transition-all hover:bg-yellow-500/20 hover:text-yellow-500"
+					class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-2 text-text-2 transition-all hover:bg-yellow-500/20 hover:text-accent"
 					aria-label="LinkedIn"
 				>
 					<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"
@@ -2284,12 +2214,12 @@
 
 			<!-- Copyright and Risk Warning -->
 			<div class="text-center">
-				<p class="mb-4 text-xs text-gray-500">
+				<p class="mb-4 text-xs text-text-3">
 					© {new Date().getFullYear()} SARK X (BVI) Ltd. All rights reserved.
 				</p>
-				<p class="text-[10px] leading-relaxed text-gray-600 sm:text-xs">
-					<span class="text-yellow-600">Risk Warning:</span> Trading tokenized assets involves substantial
-					risk. Past performance does not guarantee future results.
+				<p class="text-[10px] leading-relaxed text-text-muted sm:text-xs">
+					<span class="text-amber-700 dark:text-amber-300">Risk Warning:</span> Trading tokenized assets
+					involves substantial risk. Past performance does not guarantee future results.
 				</p>
 			</div>
 		</div>
@@ -2309,17 +2239,15 @@
 				}
 			}}
 		></button>
-		<div class="relative z-10 flex h-full flex-col bg-gray-950">
-			<div
-				class="flex items-center justify-between border-b border-white/10 px-3 py-3 sm:px-6 sm:py-5"
-			>
+		<div class="relative z-10 flex h-full flex-col bg-surface-1">
+			<div class="flex items-center justify-between border-b border-line px-3 py-3 sm:px-6 sm:py-5">
 				<div class="min-w-0 flex-1">
-					<p class="text-[10px] uppercase tracking-wide text-gray-500 sm:text-xs">Advanced Chart</p>
-					<h2 class="truncate text-base font-semibold text-white sm:text-xl">{modalTitle}</h2>
+					<p class="text-[10px] uppercase tracking-wide text-text-3 sm:text-xs">Advanced Chart</p>
+					<h2 class="truncate text-base font-semibold text-text sm:text-xl">{modalTitle}</h2>
 				</div>
 				<button
 					type="button"
-					class="ml-2 rounded-lg p-2 text-gray-400 transition hover:bg-white/5 hover:text-white focus:outline-none focus:ring-2 focus:ring-yellow-500/40"
+					class="ml-2 rounded-lg p-2 text-text-2 transition hover:bg-surface-2 hover:text-text focus:outline-none focus:ring-2 focus:ring-yellow-500/40"
 					on:click={closeChartModal}
 					aria-label="Close terminal view"
 				>
@@ -2337,7 +2265,7 @@
 				</button>
 			</div>
 			<div class="flex-1 overflow-hidden px-2 pb-2 pt-2 sm:px-6 sm:pb-6 sm:pt-4">
-				<div class="h-full w-full rounded-xl border border-white/10 bg-gray-900 p-1 sm:p-2">
+				<div class="h-full w-full rounded-xl border border-line bg-surface-1 p-1 sm:p-2">
 					{#if tradingViewSymbol}
 						<!--
 							PERF-01: TradingViewChart lives inside the chart modal
@@ -2349,32 +2277,37 @@
 								<LoadingSpinner size="md" text="Loading TradingView chart…" />
 							</div>
 						{:then Mod}
-							<svelte:component this={Mod.default} symbol={tradingViewSymbol} interval="60" />
+							<svelte:component
+								this={Mod.default}
+								symbol={tradingViewSymbol}
+								interval="60"
+								theme={$theme}
+							/>
 						{:catch _err}
 							<div class="flex h-full items-center justify-center text-sm text-red-400">
 								Failed to load TradingView chart. Please reload the page.
 							</div>
 						{/await}
 					{:else}
-						<div class="flex h-full items-center justify-center text-sm text-gray-400">
+						<div class="flex h-full items-center justify-center text-sm text-text-2">
 							TradingView data unavailable for this token.
 						</div>
 					{/if}
 				</div>
 			</div>
 			<div
-				class="flex flex-row gap-2 border-t border-white/10 bg-gradient-to-r from-green-500/10 via-gray-900/80 to-red-500/10 px-3 py-3 sm:justify-end sm:gap-3 sm:px-6 sm:py-6"
+				class="via-surface-1/80 flex flex-row gap-2 border-t border-line bg-gradient-to-r from-green-500/10 to-red-500/10 px-3 py-3 sm:justify-end sm:gap-3 sm:px-6 sm:py-6"
 			>
 				<button
 					type="button"
-					class="flex-1 rounded-xl bg-green-500 px-4 py-3 text-base font-semibold text-white shadow-xl shadow-green-500/30 transition hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400/60 focus:ring-offset-2 focus:ring-offset-gray-900 sm:flex-none sm:rounded-2xl sm:px-8 sm:py-4 sm:text-lg"
+					class="flex-1 rounded-xl bg-green-500 px-4 py-3 text-base font-semibold text-text shadow-xl shadow-green-500/30 transition hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400/60 focus:ring-offset-2 focus:ring-offset-surface-1 sm:flex-none sm:rounded-2xl sm:px-8 sm:py-4 sm:text-lg"
 					on:click={() => openTradePanel('Buy', { closeTerminal: false })}
 				>
 					Buy
 				</button>
 				<button
 					type="button"
-					class="flex-1 rounded-xl bg-red-500 px-4 py-3 text-base font-semibold text-white shadow-xl shadow-red-500/30 transition hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400/60 focus:ring-offset-2 focus:ring-offset-gray-900 sm:flex-none sm:rounded-2xl sm:px-8 sm:py-4 sm:text-lg"
+					class="flex-1 rounded-xl bg-red-500 px-4 py-3 text-base font-semibold text-text shadow-xl shadow-red-500/30 transition hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400/60 focus:ring-offset-2 focus:ring-offset-surface-1 sm:flex-none sm:rounded-2xl sm:px-8 sm:py-4 sm:text-lg"
 					on:click={() => openTradePanel('Sell', { closeTerminal: false })}
 				>
 					Sell

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -1255,12 +1255,12 @@
 						<Button
 							variant="secondary"
 							size="md"
-							className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-line bg-overlay-1 px-3 py-1.5 text-[12px] font-semibold text-text transition hover:bg-overlay-hover"
+							className="icon-trigger inline-flex items-center justify-center gap-1.5 rounded-lg border border-line bg-overlay-1 px-3 py-1.5 text-[12px] font-semibold text-text transition hover:bg-overlay-hover"
 							aria-label="Open terminal view"
 							on:click={(event) => openChartModal(event)}
 						>
 							Advanced Chart
-							<Icon name="arrowUpRight" className="h-3.5 w-3.5" />
+							<Icon name="arrowUpRight" className="icon-slide-up h-3.5 w-3.5" />
 						</Button>
 					</div>
 				</div>

--- a/src/routes/(main)/trade/[id]/proofs/+page.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/+page.svelte
@@ -16,9 +16,9 @@
 </script>
 
 {#if $currentToken}
-	<div class="max-w-8xl mt-0 w-full px-6 text-gray-100">
+	<div class="max-w-8xl mt-0 w-full px-6 text-text">
 		<Section className="mt-12 flex flex-grow flex-col shadow-lg">
-			<h3 class="mb-2 text-left text-2xl font-bold text-gray-100">{$currentToken.name} Metadata</h3>
+			<h3 class="mb-2 text-left text-2xl font-bold text-text">{$currentToken.name} Metadata</h3>
 			<ViewMetadata vault={$currentToken} {schemas} />
 		</Section>
 	</div>

--- a/src/routes/(main)/trade/[id]/proofs/ReceiptMetadata.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/ReceiptMetadata.svelte
@@ -39,7 +39,5 @@
 			)}</pre>
 	</Section>
 {:else}
-	<div class="rounded border border-down bg-down-soft p-3 text-sm text-down">
-		No Metadata Found
-	</div>
+	<div class="rounded border border-down bg-down-soft p-3 text-sm text-down">No Metadata Found</div>
 {/if}

--- a/src/routes/(main)/trade/[id]/proofs/ReceiptMetadata.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/ReceiptMetadata.svelte
@@ -32,14 +32,14 @@
 			</Button>
 		</div>
 		<pre
-			class="max-h-96 overflow-auto rounded border border-white/10 bg-gray-900 p-3 text-xs text-gray-200">{JSON.stringify(
+			class="max-h-96 overflow-auto rounded border border-line bg-bg p-3 text-xs text-text-2">{JSON.stringify(
 				data,
 				null,
 				2
 			)}</pre>
 	</Section>
 {:else}
-	<div class="rounded border border-red-500/30 bg-red-900/30 p-3 text-sm text-red-300">
+	<div class="rounded border border-down bg-down-soft p-3 text-sm text-down">
 		No Metadata Found
 	</div>
 {/if}

--- a/src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte
@@ -35,7 +35,7 @@
 
 {#if !mappedMetaV1.length}
 	<div class="flex h-full w-full flex-col" data-testid="no-deposits">
-		<p class="text-pretty text-white dark:text-white">No metadata has been added</p>
+		<p class="text-pretty text-text dark:text-text">No metadata has been added</p>
 	</div>
 {:else}
 	<div in:fade>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -23,7 +23,7 @@
 	spinner instead of the doc content, defeating the point of server-rendering
 	docs for search crawlers.
 -->
-<div class="relative min-h-screen overflow-x-hidden bg-gray-900 text-white">
+<div class="relative min-h-screen overflow-x-hidden bg-surface-1 text-text">
 	<!-- Background Pattern -->
 	<div class="pointer-events-none fixed inset-0 z-0 opacity-5">
 		<div
@@ -52,12 +52,12 @@
 	>
 		<!-- Mobile Header with Menu Button -->
 		<div
-			class="flex items-center justify-between border-b border-white/10 bg-gray-800/95 p-4 backdrop-blur-lg lg:hidden"
+			class="bg-surface-2/95 flex items-center justify-between border-b border-line p-4 backdrop-blur-lg lg:hidden"
 		>
 			<Button
 				variant="ghost"
 				size="sm"
-				className="rounded-lg border border-white/10 p-2 hover:bg-white/5"
+				className="rounded-lg border border-line p-2 hover:bg-surface-2"
 				on:click={() => (mobileSidebarOpen = !mobileSidebarOpen)}
 			>
 				<svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -76,7 +76,7 @@
 					class="h-8 w-8 rounded-full"
 				/>
 				<span
-					class="bg-gradient-to-r from-yellow-400 via-blue-400 to-purple-500 bg-clip-text text-lg font-extrabold tracking-tight text-transparent"
+					class="bg-gradient-to-r from-emerald-400 via-blue-400 to-purple-500 bg-clip-text text-lg font-extrabold tracking-tight text-transparent"
 				>
 					ST0x
 				</span>

--- a/src/routes/docs/[slug]/+page.svelte
+++ b/src/routes/docs/[slug]/+page.svelte
@@ -16,11 +16,11 @@
 
 {#key data}
 	<div data-testid="body" in:fade={{ duration: 300 }} class="p-4 md:p-8">
-		<h1 data-testid="title" class="mb-6 text-4xl font-bold text-white">
+		<h1 data-testid="title" class="mb-6 text-4xl font-bold text-text">
 			{data.heading}
 		</h1>
 		<div
-			class="prose prose-invert max-w-full rounded-2xl border border-white/10 bg-gray-800/50 p-4 backdrop-blur-sm prose-headings:text-white prose-p:text-gray-300 prose-a:text-blue-400 prose-a:hover:text-blue-300 prose-strong:text-white sm:p-6"
+			class="prose max-w-full rounded-2xl border border-line bg-surface-2 p-4 text-text-2 backdrop-blur-sm prose-headings:text-text prose-p:text-text-2 prose-a:text-blue-600 prose-a:hover:text-blue-700 prose-blockquote:text-text-2 prose-strong:text-text prose-code:text-text prose-li:text-text-2 sm:p-6 dark:prose-a:text-blue-400 dark:prose-a:hover:text-blue-300"
 		>
 			{#if docComponent}
 				<svelte:component this={docComponent} />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,92 @@
 import type { Config } from 'tailwindcss';
-import { neutral, blue } from 'tailwindcss/colors';
+import { neutral } from 'tailwindcss/colors';
+
+// Mint-emerald signature scale (anchor 400 = #2de3a6). Yellow is RETIRED: the
+// whole `yellow` palette is remapped onto mint so legacy yellow CTAs become the
+// new green signature automatically. `emerald` is also pinned to this exact
+// scale so the v2 mockup's literal emerald-* classes render pixel-accurate.
+const mint = {
+	50: '#e9fdf6',
+	100: '#c8fae9',
+	200: '#9bf3d6',
+	300: '#62ecc1',
+	400: '#2de3a6',
+	500: '#16c78c',
+	600: '#10a877',
+	700: '#0e8a62',
+	800: '#0f6e50',
+	900: '#0e5a43',
+	950: '#053124'
+};
 
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 
+	// Dark is the default; light is opt-in via [data-theme="light"] on <html>.
+	// `dark:` variants resolve against the explicit dark attribute.
+	darkMode: ['selector', '[data-theme="dark"]'],
+
 	theme: {
 		extend: {
+			fontFamily: {
+				display: ['Space Grotesk', 'DM Sans', 'system-ui', 'sans-serif'],
+				sans: ['DM Sans', 'system-ui', 'sans-serif'],
+				mono: ['JetBrains Mono', 'ui-monospace', 'monospace']
+			},
 			colors: {
-				primary: '#4c77ba',
+				// Signature scales — concrete hex so opacity modifiers work.
+				emerald: mint,
+				yellow: mint,
+				mint,
+				iris: {
+					DEFAULT: 'var(--iris)',
+					300: '#a7b1ff',
+					400: '#8f9bff',
+					500: '#7d8bff',
+					600: '#5b66e0'
+				},
+
+				// Theme-aware, token-backed aliases. In dark these resolve to the
+				// v2 mockup's exact values; in light they flip automatically.
+				primary: 'var(--accent)',
+				accent: {
+					DEFAULT: 'var(--accent)',
+					bright: 'var(--accent-bright)',
+					deep: 'var(--accent-deep)',
+					ink: 'var(--accent-ink)',
+					soft: 'var(--accent-soft)',
+					line: 'var(--accent-line)',
+					glow: 'var(--accent-glow)'
+				},
+				bg: { DEFAULT: 'var(--bg)', deep: 'var(--bg-deep)' },
+				surface: {
+					1: 'var(--surface-1)',
+					2: 'var(--surface-2)',
+					3: 'var(--surface-3)'
+				},
+				text: {
+					DEFAULT: 'var(--text)',
+					2: 'var(--text-2)',
+					3: 'var(--text-3)',
+					muted: 'var(--text-muted)'
+				},
+				line: {
+					DEFAULT: 'var(--line)',
+					strong: 'var(--line-strong)',
+					accent: 'var(--line-accent)'
+				},
+				// Theme-aware translucent overlays. The alpha lives inside the var, so
+				// use the bare class (e.g. `bg-overlay-1`) — opacity modifiers won't work.
+				overlay: {
+					1: 'var(--overlay-1)',
+					2: 'var(--overlay-2)',
+					strong: 'var(--overlay-strong)',
+					hover: 'var(--overlay-hover)'
+				},
+				up: 'var(--up)',
+				down: { DEFAULT: 'var(--down)', soft: 'var(--down-soft)' },
+
+				// Kept during migration so un-converted gray-* utilities still resolve.
 				gray: { ...neutral }
 			}
 		}

--- a/tests/integration/ui/fixtures.ts
+++ b/tests/integration/ui/fixtures.ts
@@ -147,7 +147,7 @@ export const TOKENS = {
 		donor: ORDERBOOK_DONOR,
 		id: '0x31C2C14134e6E3B7ef9478297F199331133Fc2d8'
 	},
-	// wtSGOV: tokenized iShares 0-3M Treasury ETF — the Save & Earn product.
+	// wtSGOV: tokenized iShares 0-3M Treasury ETF.
 	// Reads a regular on-chain Pyth feed (priceFeedId in src/lib/config/tokens.ts),
 	// NOT the off-chain st0x oracle, so it behaves like wtCOIN under the fork.
 	// Funded by impersonating the Rain Orderbook donor (same strategy as the

--- a/tests/integration/ui/fixtures.ts
+++ b/tests/integration/ui/fixtures.ts
@@ -146,6 +146,18 @@ export const TOKENS = {
 		decimals: 18,
 		donor: ORDERBOOK_DONOR,
 		id: '0x31C2C14134e6E3B7ef9478297F199331133Fc2d8'
+	},
+	// wtSGOV: tokenized iShares 0-3M Treasury ETF — the Save & Earn product.
+	// Reads a regular on-chain Pyth feed (priceFeedId in src/lib/config/tokens.ts),
+	// NOT the off-chain st0x oracle, so it behaves like wtCOIN under the fork.
+	// Funded by impersonating the Rain Orderbook donor (same strategy as the
+	// other ST0x wrappers); if the donor holds no wtSGOV at the chosen fork
+	// block, swap `donor` for a known wtSGOV holder.
+	wtSGOV: {
+		address: '0x78c31580c97101694C70022c83D570150c11e935' as `0x${string}`,
+		decimals: 18,
+		donor: ORDERBOOK_DONOR,
+		id: '0x78c31580c97101694C70022c83D570150c11e935'
 	}
 } as const;
 

--- a/tests/lib/utils/ohlc.test.ts
+++ b/tests/lib/utils/ohlc.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+	apiTradesToHistoryPoints,
+	tradesToOHLCBuckets,
+	tradesToVolumeBuckets,
+	type ApiTradeLike
+} from '$lib/utils/ohlc';
+import type { TradeHistoryPoint } from '$lib/components/charts/token-chart-types';
+
+const ASSET = '0xasset';
+const QUOTE = '0xusdc';
+const assetSet = new Set([ASSET]);
+
+function trade(partial: Partial<ApiTradeLike> & Pick<ApiTradeLike, 'timestamp'>): ApiTradeLike {
+	return {
+		inputToken: { address: ASSET },
+		outputToken: { address: QUOTE },
+		inputAmount: '1',
+		outputAmount: '100',
+		...partial
+	};
+}
+
+describe('apiTradesToHistoryPoints', () => {
+	it('reads a bid: order receives asset (input), gives quote (output)', () => {
+		const [p] = apiTradesToHistoryPoints(
+			[trade({ timestamp: 1, inputAmount: '2', outputAmount: '210' })],
+			assetSet,
+			QUOTE
+		);
+		expect(p.side).toBe('bid');
+		expect(p.tokens).toBe(2);
+		expect(p.quote).toBe(210);
+		expect(p.price).toBe(105); // 210 / 2
+		expect(p.timestamp).toBe(1000); // seconds → ms
+	});
+
+	it('reads an ask: order gives asset (output), receives quote (input)', () => {
+		const [p] = apiTradesToHistoryPoints(
+			[
+				trade({
+					timestamp: 2,
+					inputToken: { address: QUOTE },
+					outputToken: { address: ASSET },
+					inputAmount: '300',
+					outputAmount: '3'
+				})
+			],
+			assetSet,
+			QUOTE
+		);
+		expect(p.side).toBe('ask');
+		expect(p.tokens).toBe(3);
+		expect(p.quote).toBe(300);
+		expect(p.price).toBe(100); // 300 / 3
+	});
+
+	it('skips trades that do not pair the asset with the quote token', () => {
+		const points = apiTradesToHistoryPoints(
+			[trade({ timestamp: 1, inputToken: { address: '0xother' }, outputToken: { address: QUOTE } })],
+			assetSet,
+			QUOTE
+		);
+		expect(points).toHaveLength(0);
+	});
+
+	it('skips zero-token / non-finite-price trades', () => {
+		const points = apiTradesToHistoryPoints(
+			[trade({ timestamp: 1, inputAmount: '0', outputAmount: '100' })],
+			assetSet,
+			QUOTE
+		);
+		expect(points).toHaveLength(0);
+	});
+
+	it('dedupes identical (timestamp, price, tokens) trades and sorts chronologically', () => {
+		const dupe = trade({ timestamp: 5, inputAmount: '1', outputAmount: '100' });
+		const earlier = trade({ timestamp: 2, inputAmount: '1', outputAmount: '90' });
+		const points = apiTradesToHistoryPoints([dupe, { ...dupe }, earlier], assetSet, QUOTE);
+		expect(points).toHaveLength(2);
+		expect(points.map((p) => p.timestamp)).toEqual([2000, 5000]);
+	});
+
+	it('matches the quote token case-insensitively', () => {
+		const points = apiTradesToHistoryPoints(
+			[trade({ timestamp: 1 })],
+			new Set([ASSET]),
+			QUOTE.toUpperCase()
+		);
+		expect(points).toHaveLength(1);
+	});
+});
+
+describe('tradesToOHLCBuckets', () => {
+	it('returns open/high/low/close per time bucket', () => {
+		const points: TradeHistoryPoint[] = [
+			{ timestamp: 1_000, price: 100, tokens: 1, quote: 100, side: 'ask' },
+			{ timestamp: 30_000, price: 110, tokens: 1, quote: 110, side: 'ask' },
+			{ timestamp: 45_000, price: 90, tokens: 1, quote: 90, side: 'ask' }
+		];
+		const [bucket] = tradesToOHLCBuckets(points, 60); // 60s bucket → all three together
+		expect(bucket.o).toBe(100);
+		expect(bucket.h).toBe(110);
+		expect(bucket.l).toBe(90);
+		expect(bucket.c).toBe(90);
+	});
+
+	it('splits points into separate buckets by bucket size', () => {
+		const points: TradeHistoryPoint[] = [
+			{ timestamp: 0, price: 100, tokens: 1, quote: 100, side: 'ask' },
+			{ timestamp: 120_000, price: 105, tokens: 1, quote: 105, side: 'ask' }
+		];
+		expect(tradesToOHLCBuckets(points, 60)).toHaveLength(2);
+	});
+
+	it('returns [] for no trades', () => {
+		expect(tradesToOHLCBuckets([], 60)).toEqual([]);
+	});
+});
+
+describe('tradesToVolumeBuckets', () => {
+	it('sums traded token volume per bucket', () => {
+		const points: TradeHistoryPoint[] = [
+			{ timestamp: 1_000, price: 100, tokens: 2, quote: 200, side: 'ask' },
+			{ timestamp: 5_000, price: 100, tokens: 3, quote: 300, side: 'ask' }
+		];
+		const [bucket] = tradesToVolumeBuckets(points, 60);
+		expect(bucket.tokens).toBe(5);
+	});
+});


### PR DESCRIPTION
**PR1 of the active 3-PR chain:** Design v2 + mobile → remove referrals/access (#207) → remove admin (#208). Base: `main`. Save & Earn (#204) is parked separately on this branch.

## What this does
App-wide brand refresh onto a token-driven design system, **plus the mobile-first navigation**, with **no Save & Earn UX** and **excluding the admin portal** (removed in #208). Sits linearly on the latest `main`.

### Design system
- **Tokens** — `src/lib/styles/tokens.css` (dark + light via `[data-theme]`), Tailwind aliases (`mint/accent/surface/line/text/iris/overlay`), `themeStore` + a pre-paint theme script in `app.html` (no flash-of-wrong-theme).
- **Repaint sweep** — shell (`Header`, `ThemeToggle`), orders, modals, dashboard, trade terminal, charts (theme-aware TradingView), docs, and the `ui/*` primitives; canonical `Icon` set; ambient background; standardized card elevation.

### Mobile-first navigation
- Bottom `MobileTabBar` replaces the hamburger; header collapse is signalled via `uiStore` so the bar appears exactly when the inline nav hides.
- Modals surface as **bottom-sheets** on phones; the tab bar hides under full-screen trade overlays.

### Animations (new)
- Home **trust-pillar icons** float gently (staggered) and, on hover, the tile lifts with a mint glow while each glyph animates — Decentralised blocks spring-reassemble, Liquid arrows flow past each other, the Collateralised shield redraws its stroke.
- Reusable hover vocabulary (`icon-trigger` + `icon-slide`/`icon-slide-up`/`icon-spin-hover`/`hover-lift`): asset-row arrows nudge toward the trade, external-link arrows nudge diagonally, metric cards lift, theme-toggle icons tilt. All disabled under `prefers-reduced-motion`.

Also merges the latest `main` (favicon/SEO/apple-touch-icon rebrand, CEG/DRAM/TSM, REST token catalog).

**Verification:** `svelte-check` 0/0; ESLint and Prettier clean; 797 unit tests passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light and dark themes with a persistent theme toggle.
  * Introduced mobile bottom navigation and responsive bottom-sheet modals.
  * Added ambient backgrounds, asset fallback visuals, reusable icons, and QuickTrade charts.
  * Added a “Launch Trading Terminal” option from QuickTrade.
  * Improved chart and TradingView appearance across themes.

* **Bug Fixes**
  * Prevented dashboard loading errors caused by unavailable token data.

* **Style**
  * Refreshed the application-wide visual design, typography, colors, tables, forms, alerts, and dialogs.
  * Added reduced-motion support and improved wallet overlay visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->