### PR TITLE
RAI-753 use REST inactive order summaries

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -145,7 +145,8 @@ function convertApiOrderToProcessedQuote(
 		orderData,
 		orderbookId: order.orderbookId,
 		inputTokenDecimals: order.inputToken.decimals ?? inputMeta.decimals ?? 18,
-		outputTokenDecimals: order.outputToken.decimals ?? outputMeta.decimals ?? 18
+		outputTokenDecimals: order.outputToken.decimals ?? outputMeta.decimals ?? 18,
+		orderType: order.orderType
 	};
 
 	// Pre-compute side and price using describeQuote (DRY with tokenMath)

--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -73,12 +73,16 @@ export interface ApiSwapCalldataResponse {
 export interface ApiOrderSummary {
 	orderHash: string;
 	owner: string;
+	chainId: number;
 	orderBytes: string;
 	inputToken: ApiTokenRef;
 	outputToken: ApiTokenRef;
 	outputVaultBalance: string;
 	maxOutput?: string | null;
 	ioRatio: string;
+	orderType: 'limit' | 'dca' | 'dynamic-spread' | 'custom';
+	active: boolean;
+	removedAt?: number | null;
 	createdAt: number;
 	orderbookId: string;
 }
@@ -169,13 +173,19 @@ function apiUrl(path: string, params?: Record<string, string | number | undefine
  */
 export async function apiGetOrdersByToken(
 	tokenAddress: string,
-	options?: { page?: number; pageSize?: number; side?: 'input' | 'output' }
+	options?: {
+		page?: number;
+		pageSize?: number;
+		side?: 'input' | 'output';
+		state?: 'active' | 'inactive' | 'all';
+	}
 ): Promise<ApiOrdersListResponse> {
 	assertBrowser('apiGetOrdersByToken');
 	const url = apiUrl(`/v1/orders/token/${tokenAddress}`, {
 		page: options?.page,
 		pageSize: options?.pageSize,
-		side: options?.side
+		side: options?.side,
+		state: options?.state
 	});
 	return fetchJson<ApiOrdersListResponse>(url);
 }
@@ -251,12 +261,13 @@ export async function apiGetTakerTrades(
  */
 export async function apiGetOrdersByOwner(
 	ownerAddress: string,
-	options?: { page?: number; pageSize?: number }
+	options?: { page?: number; pageSize?: number; state?: 'active' | 'inactive' | 'all' }
 ): Promise<ApiOrdersListResponse> {
 	assertBrowser('apiGetOrdersByOwner');
 	const url = apiUrl(`/v1/orders/owner/${ownerAddress}`, {
 		page: options?.page,
-		pageSize: options?.pageSize
+		pageSize: options?.pageSize,
+		state: options?.state
 	});
 	return fetchJson<ApiOrdersListResponse>(url);
 }

--- a/src/lib/components/orders/OrdersTable.svelte
+++ b/src/lib/components/orders/OrdersTable.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
 	import { formatUnits } from 'viem';
+	import { AbiCoder } from 'ethers';
 	import { currentNetwork } from '$lib/stores';
 	import { isAuthenticated, walletAddress } from '$lib/stores/authStore';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
+	import { normalizeAddress, parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
 	import transactionStore from '$lib/stores/transaction';
-	import { type ProcessedQuote, classifyOrderType } from '$lib/utils/orderbook';
+	import {
+		type ProcessedQuote,
+		OrderV4_ABI,
+		normalizeOrderData,
+		type OrderType
+	} from '$lib/utils/orderbook';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { createRaindexClient } from '$lib/clients/raindex';
-	import type { GetOrdersFilters } from '@rainlanguage/orderbook';
+	import type { OrderV4, SgOrder } from '@rainlanguage/orderbook';
 	import type { DisplayOrder } from '$lib/types/orders';
+	import { apiGetOrdersByOwner, type ApiOrderSummary } from '$lib/api/st0xApi';
+	import { TOKENS, type Network } from '$lib/config/network';
 	import {
 		displayAmount as denomDisplayAmount,
 		displayPrice as denomDisplayPrice,
@@ -69,6 +76,8 @@
 	// Pagination
 	let currentPage = 1;
 	const ITEMS_PER_PAGE = 10;
+	const CLOSED_ORDERS_PAGE_SIZE = 50;
+	const MAX_CLOSED_ORDER_PAGES = 100;
 
 	// Reset pagination when filter changes
 	$: if (selectedOrdersFilter || selectedOrderTypeFilter || selectedDirectionFilter) {
@@ -83,6 +92,143 @@
 	// Update selected filter when connection changes
 	$: if (!$isAuthenticated && selectedOrdersFilter === 'my') {
 		selectedOrdersFilter = 'all';
+	}
+
+	function orderInvolvesToken(order: ApiOrderSummary, token: string | null): boolean {
+		if (!token) return true;
+		const normalizedToken = normalizeAddress(token);
+		const normalizedInput = normalizeAddress(order.inputToken.address);
+		const normalizedOutput = normalizeAddress(order.outputToken.address);
+		return Boolean(
+			normalizedToken &&
+				(normalizedInput === normalizedToken || normalizedOutput === normalizedToken)
+		);
+	}
+
+	function orderMatchesNetwork(
+		order: ApiOrderSummary,
+		network: Network | null | undefined
+	): boolean {
+		return network ? order.chainId === network.chainId : false;
+	}
+
+	function findIoIndexByToken<T extends { token: string }>(
+		items: T[] | undefined,
+		token: string
+	): number {
+		const normalizedToken = normalizeAddress(token);
+		if (!items || !normalizedToken) return -1;
+		return items.findIndex((item) => normalizeAddress(item.token) === normalizedToken);
+	}
+
+	function vaultIdToHex(vaultId: unknown): string | undefined {
+		if (typeof vaultId === 'string') {
+			if (vaultId.startsWith('0x') && vaultId.length === 66) return vaultId;
+			try {
+				return `0x${BigInt(vaultId).toString(16).padStart(64, '0')}`;
+			} catch {
+				return undefined;
+			}
+		}
+		if (typeof vaultId === 'bigint') {
+			return `0x${vaultId.toString(16).padStart(64, '0')}`;
+		}
+		return undefined;
+	}
+
+	function decodeOrderData(order: ApiOrderSummary): OrderV4 | undefined {
+		if (!order.orderBytes) return undefined;
+		try {
+			const decoded = AbiCoder.defaultAbiCoder().decode([OrderV4_ABI], order.orderBytes);
+			return normalizeOrderData(decoded[0] as OrderV4);
+		} catch (error) {
+			console.warn(`[OrdersTable] Failed to decode orderBytes for ${order.orderHash}:`, error);
+			return undefined;
+		}
+	}
+
+	function resolveAssetAddress(order: ApiOrderSummary, token: string | null): string | null {
+		if (token && orderInvolvesToken(order, token)) return normalizeAddress(token);
+
+		const normalizedInput = normalizeAddress(order.inputToken.address);
+		const normalizedOutput = normalizeAddress(order.outputToken.address);
+		const st0xToken = TOKENS.find((configuredToken) => {
+			if (
+				configuredToken.chainId !== $currentNetwork?.chainId ||
+				configuredToken.category !== 'ST0x'
+			) {
+				return false;
+			}
+			const configuredAddress = normalizeAddress(configuredToken.address);
+			return configuredAddress === normalizedInput || configuredAddress === normalizedOutput;
+		});
+		return st0xToken ? normalizeAddress(st0xToken.address) : normalizedOutput;
+	}
+
+	function apiOrderToClosedDisplayOrder(
+		order: ApiOrderSummary,
+		token: string | null
+	): DisplayOrder | null {
+		const orderData = decodeOrderData(order);
+		const inputIOIndex = findIoIndexByToken(orderData?.validInputs, order.inputToken.address);
+		const outputIOIndex = findIoIndexByToken(orderData?.validOutputs, order.outputToken.address);
+		const inputVault = inputIOIndex >= 0 ? orderData?.validInputs?.[inputIOIndex] : undefined;
+		const outputVault = outputIOIndex >= 0 ? orderData?.validOutputs?.[outputIOIndex] : undefined;
+		const inputVaultId = vaultIdToHex(inputVault?.vaultId);
+		const outputVaultId = vaultIdToHex(outputVault?.vaultId);
+
+		const inputTokenAddress = order.inputToken.address;
+		const outputTokenAddress = order.outputToken.address;
+		const assetAddress = resolveAssetAddress(order, token);
+		const isBuy = Boolean(
+			assetAddress && normalizeAddress(inputTokenAddress) === normalizeAddress(assetAddress)
+		);
+		const displayToken = isBuy ? order.inputToken : order.outputToken;
+		const displayType: Exclude<OrderType, 'dynamic-spread'> =
+			order.orderType === 'dynamic-spread' ? 'custom' : order.orderType;
+
+		const sgOrder = {
+			orderHash: order.orderHash,
+			owner: order.owner,
+			active: order.active,
+			orderbook: { id: order.orderbookId },
+			orderBytes: order.orderBytes
+		} as SgOrder;
+
+		const quote: ProcessedQuote = {
+			orderHash: order.orderHash,
+			maxOutput: '',
+			ratio: '',
+			inputTokenSymbol: order.inputToken.symbol,
+			outputTokenSymbol: order.outputToken.symbol,
+			inputTokenAddress,
+			outputTokenAddress,
+			inputIOIndex: inputIOIndex >= 0 ? inputIOIndex : 0,
+			outputIOIndex: outputIOIndex >= 0 ? outputIOIndex : 0,
+			inputVaultId,
+			outputVaultId,
+			orderData,
+			sgOrder,
+			orderbookId: order.orderbookId,
+			inputTokenDecimals: order.inputToken.decimals,
+			outputTokenDecimals: order.outputToken.decimals,
+			orderType: order.orderType
+		};
+
+		return {
+			type: displayType,
+			orderHash: order.orderHash,
+			timestamp: order.removedAt ?? order.createdAt ?? 0,
+			side: isBuy ? 'Buy' : 'Sell',
+			quote,
+			tokenSymbol: displayToken.symbol,
+			tokenAddress: displayToken.address,
+			inputTokenSymbol: order.inputToken.symbol,
+			outputTokenSymbol: order.outputToken.symbol,
+			price: undefined,
+			isActive: order.active,
+			isFilled: false
+		};
 	}
 
 	// Helper function to create the closed orders query
@@ -101,22 +247,27 @@
 				if (!enabled || !network || !signer) {
 					return [];
 				}
-				const client = await createRaindexClient();
-				const filters: GetOrdersFilters = {
-					owners: [signer as `0x${string}`],
-					active: false
-				};
-				// Only filter by token if provided
-				if (token) {
-					const tokenAddr = token as `0x${string}`;
-					filters.tokens = { inputs: [tokenAddr], outputs: [tokenAddr] };
+				const orders: ApiOrderSummary[] = [];
+				let page = 1;
+				let hasMore = true;
+				while (hasMore && page <= MAX_CLOSED_ORDER_PAGES) {
+					const result = await apiGetOrdersByOwner(signer, {
+						page,
+						pageSize: CLOSED_ORDERS_PAGE_SIZE,
+						state: 'inactive'
+					});
+					orders.push(
+						...result.orders.filter(
+							(order) => orderMatchesNetwork(order, network) && orderInvolvesToken(order, token)
+						)
+					);
+					hasMore = result.pagination.hasMore;
+					page++;
 				}
-				const result = await client.getOrders([network.id], filters, 1);
-				if (result.error) {
-					console.error('[closedOrdersQuery] Error:', result.error);
-					return [];
+				if (hasMore) {
+					console.warn(`[closedOrdersQuery] Hit pagination cap (${MAX_CLOSED_ORDER_PAGES} pages)`);
 				}
-				return result.value?.orders ?? [];
+				return orders;
 			}
 		});
 	}
@@ -155,63 +306,11 @@
 					continue;
 				}
 
-				const sgOrderResult = order.convertToSgOrder();
-				if (sgOrderResult.error || !sgOrderResult.value) {
+				const closedOrder = apiOrderToClosedDisplayOrder(order, tokenAddress);
+				if (!closedOrder) {
 					continue;
 				}
-				const sgOrder = sgOrderResult.value;
-
-				const inputVault = sgOrder.inputs?.[0];
-				const outputVault = sgOrder.outputs?.[0];
-
-				// Determine token symbol and address for display
-				const inputTokenSymbol = inputVault?.token?.symbol ?? '';
-				const outputTokenSymbol = outputVault?.token?.symbol ?? '';
-				const inputTokenAddress = inputVault?.token?.address ?? '';
-				const outputTokenAddress = outputVault?.token?.address ?? '';
-
-				// Determine side and token info based on token position
-				// If order INPUT is the asset, this is a BUY order (order receives the asset)
-				// If order OUTPUT is the asset, this is a SELL order (order gives the asset)
-				const isBuy = tokenAddress
-					? inputVault?.token?.address?.toLowerCase() === tokenAddress.toLowerCase()
-					: false;
-
-				const displayTokenSymbol = isBuy ? inputTokenSymbol : outputTokenSymbol;
-				const displayTokenAddress = isBuy ? inputTokenAddress : outputTokenAddress;
-
-				// Classify the order type using rainlang
-				const orderType = classifyOrderType(order.rainlang) ?? 'custom';
-				const displayType = orderType === 'dynamic-spread' ? 'custom' : orderType;
-
-				result.push({
-					type: displayType,
-					orderHash: order.orderHash,
-					timestamp: sgOrder.timestampAdded ? Number(sgOrder.timestampAdded) : 0,
-					side: isBuy ? 'Buy' : 'Sell',
-					quote: {
-						orderHash: order.orderHash,
-						orderbookId: order.orderbook,
-						inputVaultId: inputVault?.vaultId
-							? `0x${BigInt(inputVault.vaultId).toString(16).padStart(64, '0')}`
-							: undefined,
-						outputVaultId: outputVault?.vaultId
-							? `0x${BigInt(outputVault.vaultId).toString(16).padStart(64, '0')}`
-							: undefined,
-						inputTokenAddress,
-						outputTokenAddress,
-						inputTokenSymbol,
-						outputTokenSymbol,
-						sgOrder
-					} as ProcessedQuote,
-					tokenSymbol: displayTokenSymbol,
-					tokenAddress: displayTokenAddress,
-					inputTokenSymbol,
-					outputTokenSymbol,
-					price: undefined,
-					isActive: false,
-					isFilled: false
-				});
+				result.push(closedOrder);
 			}
 		}
 

--- a/tests/helpers/makerOrders.ts
+++ b/tests/helpers/makerOrders.ts
@@ -101,6 +101,7 @@ export interface DeployedMakerOrder {
 	/** ABI-encoded OrderV4 — the same bytes the subgraph would index as `orderBytes`. */
 	orderBytes: `0x${string}`;
 	owner: `0x${string}`;
+	chainId: number;
 	orderbookAddress: `0x${string}`;
 	inputToken: { address: `0x${string}`; symbol: string; decimals: number };
 	outputToken: { address: `0x${string}`; symbol: string; decimals: number };
@@ -331,6 +332,7 @@ export async function deployMakerLimitOrder(
 		orderHash,
 		orderBytes,
 		owner: account.address,
+		chainId: base.id,
 		orderbookAddress: args.orderbookAddress,
 		inputToken: sdkInputToken,
 		outputToken: sdkOutputToken,

--- a/tests/integration/ui/syntheticOrdersStub.ts
+++ b/tests/integration/ui/syntheticOrdersStub.ts
@@ -42,7 +42,9 @@ function encodeVaultBalanceHex(decimalString: string): string {
 	const parsed = Float.parse(decimalString);
 	if (parsed.error || !parsed.value) {
 		throw new Error(
-			`encodeVaultBalanceHex: Float.parse failed for "${decimalString}": ${parsed.error?.readableMsg ?? 'no value'}`
+			`encodeVaultBalanceHex: Float.parse failed for "${decimalString}": ${
+				parsed.error?.readableMsg ?? 'no value'
+			}`
 		);
 	}
 	return parsed.value.asHex();
@@ -147,9 +149,7 @@ function makerOrderToSgOrder(o: DeployedMakerOrder): SgOrder {
 		},
 		orderbook: { id: orderbookId },
 		ordersAsOutput: [],
-		ordersAsInput: [
-			{ id: o.orderHash.toLowerCase(), orderHash: o.orderHash, active: true }
-		],
+		ordersAsInput: [{ id: o.orderHash.toLowerCase(), orderHash: o.orderHash, active: true }],
 		balanceChanges: []
 	};
 	const outputVault: SgVault = {
@@ -169,9 +169,7 @@ function makerOrderToSgOrder(o: DeployedMakerOrder): SgOrder {
 			decimals: String(o.outputToken.decimals)
 		},
 		orderbook: { id: orderbookId },
-		ordersAsOutput: [
-			{ id: o.orderHash.toLowerCase(), orderHash: o.orderHash, active: true }
-		],
+		ordersAsOutput: [{ id: o.orderHash.toLowerCase(), orderHash: o.orderHash, active: true }],
 		ordersAsInput: [],
 		balanceChanges: []
 	};
@@ -270,6 +268,7 @@ function makerOrderToApiSummary(o: DeployedMakerOrder): ApiOrderSummary {
 	return {
 		orderHash: o.orderHash,
 		owner: o.owner,
+		chainId: o.chainId,
 		orderBytes: o.orderBytes,
 		inputToken: {
 			address: o.inputToken.address,
@@ -284,6 +283,9 @@ function makerOrderToApiSummary(o: DeployedMakerOrder): ApiOrderSummary {
 		outputVaultBalance: o.outputVaultBalance,
 		maxOutput: o.maxOutput,
 		ioRatio: o.ioRatio,
+		orderType: 'limit',
+		active: true,
+		removedAt: null,
 		createdAt: o.timestampAdded,
 		orderbookId: o.orderbookAddress.toLowerCase()
 	};

--- a/tests/lib/api/orders.test.ts
+++ b/tests/lib/api/orders.test.ts
@@ -38,12 +38,16 @@ function orderSummary(overrides: Partial<ApiOrderSummary> = {}): ApiOrderSummary
 	return {
 		orderHash: '0x-order',
 		owner: '0x-owner',
+		chainId: 8453,
 		orderBytes: '',
 		inputToken: { address: paymentToken.address, symbol: paymentToken.symbol, decimals: 6 },
 		outputToken: stockToken,
 		outputVaultBalance: '100',
 		maxOutput: '2.5',
 		ioRatio: '1.2',
+		orderType: 'limit',
+		active: true,
+		removedAt: null,
 		createdAt: 1,
 		orderbookId: '0x-orderbook',
 		...overrides
@@ -71,6 +75,15 @@ describe('fetchAndQuoteTokenOrders', () => {
 
 		expect(quotes).toHaveLength(1);
 		expect(quotes[0].maxOutput).toBe(Float.parse('2.5').value?.asHex());
+	});
+
+	it('uses the REST orderType classification', async () => {
+		mockOrders([orderSummary({ orderType: 'dca' })]);
+
+		const quotes = await fetchAndQuoteTokenOrders(8453, stockToken.address, paymentToken);
+
+		expect(quotes).toHaveLength(1);
+		expect(quotes[0].orderType).toBe('dca');
 	});
 
 	it('drops orders when REST maxOutput is missing', async () => {


### PR DESCRIPTION
## Linear
- Refs RAI-753: https://linear.app/makeitrain/issue/RAI-753/support-inactiveclosed-orders-in-order-list-endpoints

## Dependencies
- Depends on REST API PR: https://github.com/ST0x-Technology/st0x.rest.api/pull/138
- REST PR #138 depends on rain.orderbook PR: https://github.com/rainlanguage/raindex/pull/2688
- Stacked on website PR: https://github.com/SARKEX/st0x/pull/201

## Summary
- Consume REST `state=inactive` owner order summaries for the Closed orders toggle.
- Remove the table direct Raindex SDK inactive-order fetch/classification path.
- Require REST `chainId` on `ApiOrderSummary` and filter closed owner results to the selected network.
- Derive closed-order withdraw IO indexes and vault ids by matching REST input/output token addresses to decoded `orderBytes`, instead of assuming index 0.
- Map REST `active`, `removedAt`, `orderType`, and decoded `orderBytes` into closed order rows for trade/dashboard views.

## Local verification
- `npm run test -- run tests/lib/api/orders.test.ts tests/lib/api/st0x-proxy.test.ts tests/lib/queries/tokens.test.ts`
- `bunx svelte-check --no-tsconfig --ignore "tests"`
- `bun run check` (blocked by existing missing `@playwright/test` type-resolution errors under `tests/integration/ui`)
- `SESSION_SECRET=local-build-secret-local-build-secret BASE_RPC_URL=https://base-rpc.publicnode.com bun run build` (SSR/client bundles build; final Vercel adapter step rejects local Node v24.5.0, requires Node 18/20/22)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to filter orders by state (active, inactive, or all).
  * Orders now display additional metadata including order type and chain information.

* **Bug Fixes**
  * Improved closed order retrieval and display in the orders table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->