### PR TITLE
RAI-754 use REST token proofs endpoint

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -7,6 +7,7 @@
 
 import { browser } from '$app/environment';
 import { fetchJson } from '$lib/clients/http';
+import type { MetaV1S } from '$lib/types/OffchainAssetReceiptVault';
 
 // ============================================================================
 // Shared Types (match Rust API camelCase serialization)
@@ -143,6 +144,32 @@ export interface ApiTradesBatchResponse {
 }
 
 // ============================================================================
+// Token Proof Types
+// ============================================================================
+
+export interface ApiTokenProofSchema {
+	id: string;
+	information: string;
+	timestamp: number;
+}
+
+export interface ApiTokenProofReceipt {
+	id: string;
+	receiptId: string;
+	txHash: string;
+	type: 'deposit' | 'withdraw';
+	information: string;
+	timestamp: number;
+}
+
+export interface ApiTokenProofsResponse {
+	address: string;
+	metadata: MetaV1S[];
+	schemas: ApiTokenProofSchema[];
+	receipts: ApiTokenProofReceipt[];
+}
+
+// ============================================================================
 // API Client
 // ============================================================================
 
@@ -196,6 +223,14 @@ export async function apiGetOrdersByToken(
 export async function apiGetTokens(): Promise<ApiToken[]> {
 	assertBrowser('apiGetTokens');
 	return fetchJson<ApiToken[]>(apiUrl('/v1/tokens'));
+}
+
+/**
+ * Fetch raw proof/attestation metadata for a tokenized asset.
+ */
+export async function apiGetTokenProofs(address: string): Promise<ApiTokenProofsResponse> {
+	assertBrowser('apiGetTokenProofs');
+	return fetchJson<ApiTokenProofsResponse>(apiUrl(`/v1/tokens/${address}/proofs`));
 }
 
 /**

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,6 +1,7 @@
 import { derived, writable, type Readable } from 'svelte/store';
 import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
 import type { MetaV1S } from '$lib/types/OffchainAssetReceiptVault';
+import type { ApiTokenProofsResponse } from '$lib/api/st0xApi';
 import type { Network } from '$lib/config/network';
 import { networks } from '$lib/config/network';
 import type { OracleQuote } from '$lib/queries/oracleQuotes';
@@ -27,6 +28,7 @@ function createNetworkQueryStore<T>(
 }
 
 export const sftMetadata = writable<MetaV1S[] | null>(null);
+export const tokenProofs = writable<ApiTokenProofsResponse | null>(null);
 export const currentNetwork = writable<Network>(networks[0]); // Base is default
 
 // Re-export wrongNetwork from authStore to maintain backward compatibility

--- a/src/lib/utils/schemas.ts
+++ b/src/lib/utils/schemas.ts
@@ -1,11 +1,18 @@
 import { MAGIC_NUMBERS } from '$lib/config/constants';
 import { cborDecode, bytesToMeta } from '$lib/utils/helpers';
-import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
+import type {
+	OffchainAssetReceiptVault,
+	ReceiptVaultInformation
+} from '$lib/types/OffchainAssetReceiptVault';
 
-export const addSchemaToReceipts = (vault: OffchainAssetReceiptVault) => {
+type RawReceiptVaultInformation = Pick<ReceiptVaultInformation, 'id' | 'information'> & {
+	timestamp: string | number;
+};
+
+export const addSchemaToReceiptVaultInformations = (
+	receiptVaultInformations: RawReceiptVaultInformation[]
+) => {
 	const tempSchema: { displayName: string; hash: string }[] = [];
-
-	const receiptVaultInformations = vault.receiptVaultInformations;
 
 	if (receiptVaultInformations.length) {
 		for (const data of receiptVaultInformations) {
@@ -31,3 +38,6 @@ export const addSchemaToReceipts = (vault: OffchainAssetReceiptVault) => {
 	}
 	return tempSchema;
 };
+
+export const addSchemaToReceipts = (vault: OffchainAssetReceiptVault) =>
+	addSchemaToReceiptVaultInformations(vault.receiptVaultInformations);

--- a/src/routes/(main)/trade/[id]/proofs/+layout.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/+layout.svelte
@@ -1,39 +1,65 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { getSftMetadata, getSftById } from '$lib/api/subgraph';
+	import { apiGetTokenProofs } from '$lib/api/st0xApi';
 	import { page } from '$app/stores';
-	import { sftMetadata, currentNetwork, sfts, currentToken } from '$lib/stores';
+	import { sftMetadata, tokenProofs, currentNetwork, sfts, currentToken } from '$lib/stores';
+	import { getTokenByAnyAddress } from '$lib/config/tokens';
 	import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
 
 	const { id } = $page.params;
 
 	$: query = createQuery({
-		queryKey: ['getSftMetadata', id, $currentNetwork?.id],
-		enabled: !!$currentNetwork?.metadata_subgraph_url,
-		queryFn: () => getSftMetadata(id, $currentNetwork.metadata_subgraph_url as string)
+		queryKey: ['getTokenProofs', id, $currentNetwork?.id],
+		enabled: Boolean(browser && id),
+		queryFn: () => apiGetTokenProofs(id)
 	});
 
 	$: if ($query && $query.data) {
-		sftMetadata.set($query.data);
+		tokenProofs.set($query.data);
+		sftMetadata.set($query.data.metadata);
+	} else if ($query?.error) {
+		tokenProofs.set(null);
+		sftMetadata.set(null);
 	}
 
-	// Fetch full vault by id when not in sfts (e.g. direct navigation to /trade/[id]/proofs)
-	$: vaultQuery = createQuery({
-		queryKey: ['getSftById', id, $currentNetwork?.id],
-		enabled: !!$currentNetwork && !!id,
-		queryFn: () => getSftById(id, $currentNetwork!)
-	});
-
-	// Set currentToken: prefer vault from sfts (instant), else use vault from getSftById
+	// Set currentToken: prefer cached vault details for display name, then fall back to token config.
 	$: if (id) {
+		const wrappedAddress = $query?.data?.address?.toLowerCase();
 		const foundInSfts = $sfts?.find(
-			(v: OffchainAssetReceiptVault) => v.id === id || v.address?.toLowerCase() === id.toLowerCase()
+			(v: OffchainAssetReceiptVault) =>
+				v.id === id ||
+				v.address?.toLowerCase() === id.toLowerCase() ||
+				(wrappedAddress && v.address?.toLowerCase() === wrappedAddress)
 		);
 		if (foundInSfts) {
 			currentToken.set(foundInSfts);
-		} else if ($vaultQuery?.data) {
-			currentToken.set($vaultQuery.data);
+		} else if ($query?.data) {
+			const token = getTokenByAnyAddress(id) ?? getTokenByAnyAddress($query.data.address);
+			currentToken.set({
+				id: $query.data.address,
+				totalShares: '0',
+				address: $query.data.address as `0x${string}`,
+				deployer: '',
+				admin: '',
+				name: token?.name ?? token?.symbol ?? $query.data.address,
+				symbol: token?.symbol ?? '',
+				deployTimestamp: '',
+				receiptContractAddress: '',
+				tokenHolders: [],
+				receiptVaultInformations: $query.data.schemas.map((schema) => ({
+					id: schema.id,
+					information: schema.information,
+					timestamp: String(schema.timestamp),
+					caller: { address: '' },
+					transaction: { blockNumber: '' }
+				})),
+				withdraws: [],
+				deposits: [],
+				shareTransfers: [],
+				chainId: $currentNetwork?.chainId
+			});
 		}
 	}
 </script>

--- a/src/routes/(main)/trade/[id]/proofs/+page.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/+page.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
 	import type { Schema } from '$lib/types/SchemaQueryResponse';
-	import { currentToken } from '$lib/stores';
-	import { addSchemaToReceipts } from '$lib/utils/schemas';
+	import { currentToken, tokenProofs } from '$lib/stores';
+	import { addSchemaToReceiptVaultInformations } from '$lib/utils/schemas';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import ViewMetadata from './ViewMetadata.svelte';
 	import Section from '$lib/components/ui/Section.svelte';
 
 	let schemas: Schema[] = [];
-	$: if ($currentToken) {
-		// @ts-expect-error - addSchemaToReceipts return shape is compatible with Schema[] for ViewMetadata
-		schemas = addSchemaToReceipts($currentToken);
+	$: if ($tokenProofs) {
+		// @ts-expect-error - schema decoder return shape is compatible with Schema[] for ViewMetadata
+		schemas = addSchemaToReceiptVaultInformations($tokenProofs.schemas);
+	} else {
+		schemas = [];
 	}
 </script>
 

--- a/src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte
@@ -24,12 +24,12 @@
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let mappedMetaV1: any[] = [];
 
-	$: if (vault && $sftMetadata) {
-		if ($sftMetadata?.length > 0) {
-			mappedMetaV1 = $sftMetadata.slice(0, 1).map((metaV1) => {
-				return getReceiptSchema(metaV1);
-			});
-		}
+	$: if (vault && $sftMetadata?.length) {
+		mappedMetaV1 = $sftMetadata.slice(0, 1).map((metaV1) => {
+			return getReceiptSchema(metaV1);
+		});
+	} else {
+		mappedMetaV1 = [];
 	}
 </script>
 

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -30,6 +30,11 @@ function getAuthHeader(): string {
 const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
 	{ method: 'GET', pattern: /^v1\/tokens$/ },
+	{
+		method: 'GET',
+		pattern: /^v1\/tokens\/[^/]+\/proofs$/,
+		cache: 'public, s-maxage=60, stale-while-revalidate=300'
+	},
 	// Shared endpoints — same response for all users, cache at Vercel edge
 	{
 		method: 'GET',


### PR DESCRIPTION
## Linear
- Refs RAI-754: https://linear.app/makeitrain/issue/RAI-754/add-token-proofsattestation-metadata-endpoint

## Dependencies
- Stacked on website PR: https://github.com/SARKEX/st0x/pull/203
- Depends on REST API PR: https://github.com/ST0x-Technology/st0x.rest.api/pull/139

## Summary
- Consume the REST `GET /v1/tokens/{address}/proofs` endpoint from the trade proofs page.
- Add the token proofs API client types and proxy allow-list entry.
- Move proofs schema derivation to the REST response instead of direct SFT subgraph data.
- Preserve token display metadata by resolving cached vaults first, then falling back to configured token metadata from the REST proof address.
- Clear derived metadata when proof metadata is empty or unavailable to avoid stale display state.

## Local verification
- `npx eslint src/lib/api/st0xApi.ts 'src/routes/api/st0x/[...path]/+server.ts' src/lib/stores/index.ts src/lib/utils/schemas.ts 'src/routes/(main)/trade/[id]/proofs/+layout.svelte' 'src/routes/(main)/trade/[id]/proofs/+page.svelte' 'src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte'`
- `npx prettier --check src/lib/api/st0xApi.ts 'src/routes/api/st0x/[...path]/+server.ts' src/lib/stores/index.ts src/lib/utils/schemas.ts 'src/routes/(main)/trade/[id]/proofs/+layout.svelte' 'src/routes/(main)/trade/[id]/proofs/+page.svelte' 'src/routes/(main)/trade/[id]/proofs/ViewMetadata.svelte'`
- `npx svelte-check --no-tsconfig --ignore tests --threshold error`
- `git diff --check`
- `npm run check` is still blocked by existing missing `@playwright/test` type-resolution errors under `tests/integration/ui`.
- `npm run lint-check` is still blocked by existing unrelated lint errors under `src/lib/components/orders`.
