### PR TITLE
Use REST API for wrap ratios

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -170,6 +170,50 @@ export interface ApiTokenProofsResponse {
 }
 
 // ============================================================================
+// Wrap Ratio Types
+// ============================================================================
+
+export interface ApiWrapRatio {
+	shareAddress: string;
+	assetAddress: string;
+	assetsPerShare: string;
+	blockNumber: number;
+	blockTimestamp: number;
+	capturedAt: string;
+}
+
+export interface ApiWrapRatioError {
+	shareAddress: string;
+	message: string;
+}
+
+export interface ApiWrapRatiosResponse {
+	data: ApiWrapRatio[];
+	errors: ApiWrapRatioError[];
+}
+
+export interface ApiWrapRatioHistoryEvent {
+	type: 'snapshot';
+	blockNumber: number;
+	blockTimestamp: number;
+	assetsPerShare: string;
+	capturedAt: string;
+}
+
+export interface ApiWrapRatioHistoryResponse {
+	shareAddress: string;
+	assetAddress: string;
+	events: ApiWrapRatioHistoryEvent[];
+	pagination: {
+		page: number;
+		pageSize: number;
+		totalEvents: number;
+		totalPages: number;
+		hasMore: boolean;
+	};
+}
+
+// ============================================================================
 // API Client
 // ============================================================================
 
@@ -231,6 +275,38 @@ export async function apiGetTokens(): Promise<ApiToken[]> {
 export async function apiGetTokenProofs(address: string): Promise<ApiTokenProofsResponse> {
 	assertBrowser('apiGetTokenProofs');
 	return fetchJson<ApiTokenProofsResponse>(apiUrl(`/v1/tokens/${address}/proofs`));
+}
+
+/**
+ * Fetch current wrap ratios for supported wrapped tokens.
+ */
+export async function apiGetWrapRatios(): Promise<ApiWrapRatiosResponse> {
+	assertBrowser('apiGetWrapRatios');
+	return fetchJson<ApiWrapRatiosResponse>(apiUrl('/v1/tokens/wrap-ratio'));
+}
+
+/**
+ * Fetch current wrap ratio for a single wrapped token.
+ */
+export async function apiGetWrapRatio(wrappedTokenAddress: string): Promise<ApiWrapRatio> {
+	assertBrowser('apiGetWrapRatio');
+	return fetchJson<ApiWrapRatio>(apiUrl(`/v1/tokens/wrap-ratio/${wrappedTokenAddress}`));
+}
+
+/**
+ * Fetch snapshot history for a wrapped token's wrap ratio.
+ */
+export async function apiGetWrapRatioHistory(
+	wrappedTokenAddress: string,
+	options?: { page?: number; pageSize?: number }
+): Promise<ApiWrapRatioHistoryResponse> {
+	assertBrowser('apiGetWrapRatioHistory');
+	return fetchJson<ApiWrapRatioHistoryResponse>(
+		apiUrl(`/v1/tokens/wrap-ratio/${wrappedTokenAddress}/history`, {
+			page: options?.page,
+			pageSize: options?.pageSize
+		})
+	);
 }
 
 /**

--- a/src/lib/components/wrap/RatioHistoryTab.svelte
+++ b/src/lib/components/wrap/RatioHistoryTab.svelte
@@ -1,47 +1,36 @@
 <script lang="ts">
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
-	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
 	import { createExchangeRateHistoryQuery } from '$lib/queries/exchangeRates';
 	import RatioStepChart from './RatioStepChart.svelte';
 
 	/**
-	 * "Ratio History" tab inside Token Details. Off the critical buy/sell path —
-	 * this is a deep-dive surface that proves the ratio is auditable: every
-	 * change has an on-chain event with a tx link.
-	 *
-	 * Snapshots show the rate at a block; donations are the events that move it
-	 * (issuer rebases, in-kind distributions, etc.).
+	 * "Ratio History" tab inside Token Details. The REST API returns sampled
+	 * wrap-ratio snapshots, and the UI derives movement between samples.
 	 */
 	export let wrappedTokenAddress: string;
 	export let wrappedSymbol: string;
 	export let assetSymbol: string;
 	export let currentRatio: number;
 	export let onLearnMore: (() => void) | undefined = undefined;
-	/** Optional explorer href builder for tx hashes (chain-specific). */
-	export let txHrefBuilder: ((txHash: string) => string) | undefined = undefined;
 
 	$: query = createExchangeRateHistoryQuery(wrappedTokenAddress, { pageSize: 100 });
 
-	// Snapshots are bookkeeping points the indexer writes whenever it samples
-	// the vault — they don't change the ratio, just record it, so they're noise
-	// in the user-facing timeline. We keep only the events that actually moved
-	// the ratio (donations / issuer rebases) plus a synthetic "deployed at 1:1"
-	// anchor so the list always shows where the wrapper started.
 	$: rawEvents = $query.data?.events ?? [];
-	$: events = rawEvents.filter((e) => e.type === 'donation');
-	// Reverse for the list display (most-recent first) without mutating the
-	// ascending order the chart needs.
+	$: events = [...rawEvents].sort((a, b) => {
+		if (a.blockTimestamp !== b.blockTimestamp) return a.blockTimestamp - b.blockTimestamp;
+		return a.blockNumber - b.blockNumber;
+	});
 	$: eventsDesc = [...events].reverse();
 
 	function fmtRatio(v: number | null | undefined): string {
-		if (v == null || !Number.isFinite(v)) return '—';
+		if (v == null || !Number.isFinite(v)) return '-';
 		return Number.isInteger(v)
 			? String(v)
 			: v.toLocaleString('en-US', { maximumFractionDigits: 4 });
 	}
 
 	function ratioOfEvent(ev: (typeof events)[number]): number | null {
-		const v = ev.newAssetsPerShare == null ? NaN : Number(ev.newAssetsPerShare);
+		const v = Number(ev.assetsPerShare);
 		return Number.isFinite(v) ? v : null;
 	}
 
@@ -59,11 +48,6 @@
 		if (days < 365) return `${Math.round(days / 30)}mo ago`;
 		return `${(days / 365).toFixed(1)}y ago`;
 	}
-
-	function truncTx(hash: string): string {
-		if (!hash || hash.length < 12) return hash;
-		return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
-	}
 </script>
 
 <div>
@@ -71,8 +55,8 @@
 		<div>
 			<h3 class="font-semibold text-white">Wrap Ratio History</h3>
 			<p class="mt-0.5 text-xs text-gray-400 sm:text-sm">
-				Starts at <span class="font-mono">1 : 1</span>. Each rebase below adds more {assetSymbol} per
-				{wrappedSymbol} — usually a dividend or split from the underlying.
+				Starts at <span class="font-mono">1 : 1</span>. Each snapshot records how much
+				{assetSymbol} backs 1 {wrappedSymbol} when the API samples the vault.
 				{#if onLearnMore}
 					<button
 						type="button"
@@ -98,23 +82,20 @@
 	{:else if $query.isError}
 		<div class="rounded-lg border border-red-400/20 bg-red-400/[0.05] p-3 text-sm text-red-300">
 			Failed to load ratio history.
-			{#if $query.error instanceof Error}
-				<span class="ml-1 text-red-200/80">({$query.error.message})</span>
-			{/if}
 		</div>
 	{:else if events.length === 0}
 		<RatioStepChart events={[]} {wrappedSymbol} {assetSymbol} />
 		<div
 			class="mt-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-4 text-sm text-gray-400"
 		>
-			No rebases yet — the wrap ratio has been 1 : 1 since deployment.
+			No historical snapshots yet. The current sampled ratio is shown above.
 		</div>
 	{:else}
 		<RatioStepChart {events} {wrappedSymbol} {assetSymbol} />
 
-		<h4 class="mb-2 mt-4 text-xs font-semibold uppercase tracking-wide text-gray-400">Events</h4>
+		<h4 class="mb-2 mt-4 text-xs font-semibold uppercase tracking-wide text-gray-400">Snapshots</h4>
 		<ol class="relative space-y-0">
-			{#each eventsDesc as ev, idx (ev.blockNumber)}
+			{#each eventsDesc as ev, idx (`${ev.blockNumber}-${ev.capturedAt}`)}
 				{@const isLatest = idx === 0}
 				{@const newRate = ratioOfEvent(ev)}
 				{@const prev = eventsDesc[idx + 1] != null ? ratioOfEvent(eventsDesc[idx + 1]) : 1}
@@ -136,12 +117,12 @@
 					<div class="border-b border-white/5 py-3">
 						<div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
 							<div class="flex items-baseline gap-2">
-								<span class="text-sm font-medium text-gray-100">Rebase</span>
+								<span class="text-sm font-medium text-gray-100">Snapshot</span>
 								{#if isLatest}
 									<span
 										class="inline-flex items-center rounded-full border border-yellow-400/35 bg-yellow-400/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-yellow-200"
 									>
-										current
+										latest
 									</span>
 								{/if}
 							</div>
@@ -168,34 +149,16 @@
 									{direction === 'up' ? '+' : ''}{pct.toFixed(2)}%
 								</span>
 							{/if}
-							{#if ev.type === 'donation'}
-								{#if txHrefBuilder}
-									<a
-										href={txHrefBuilder(ev.txHash)}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="inline-flex items-center gap-1 font-mono text-[11px] text-blue-300 hover:text-blue-200 hover:underline"
-									>
-										{truncTx(ev.txHash)}
-										<IconExternalLink width="10" height="10" />
-									</a>
-								{:else}
-									<span class="font-mono text-[11px] text-gray-500">{truncTx(ev.txHash)}</span>
-								{/if}
-							{/if}
 						</div>
-						{#if ev.type === 'donation'}
-							<p class="mt-1.5 text-xs leading-relaxed text-gray-400">
-								+<span class="font-mono tabular-nums text-gray-300">{ev.assetAmount}</span>
-								{assetSymbol} added to the vault.
-							</p>
-						{/if}
+						<p class="mt-1.5 text-xs leading-relaxed text-gray-400">
+							Captured at block <span class="font-mono tabular-nums text-gray-300"
+								>{ev.blockNumber}</span
+							>.
+						</p>
 					</div>
 				</li>
 			{/each}
 
-			<!-- Synthetic parity anchor — the wrapper starts 1:1 by construction; we
-			     show it as the oldest item so the timeline doesn't begin in the air. -->
 			<li class="relative pl-6 pr-1">
 				<span
 					class="absolute left-0 top-2 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-white/15 bg-white/5"

--- a/src/lib/components/wrap/RatioStepChart.svelte
+++ b/src/lib/components/wrap/RatioStepChart.svelte
@@ -3,8 +3,8 @@
 
 	/**
 	 * Step chart of the wrap ratio (assetsPerShare) over time. Each input event
-	 * is a snapshot or donation point; the line steps up/down at each event and
-	 * extends flat to "now" at the right edge.
+	 * is a sampled snapshot; the line steps up/down at each event and extends
+	 * flat to "now" at the right edge.
 	 *
 	 * Events are expected sorted ascending by blockTimestamp.
 	 */
@@ -13,16 +13,11 @@
 	export let assetSymbol: string;
 
 	function rateOf(ev: ExchangeRateEvent): number | null {
-		if (ev.type === 'snapshot') {
-			const v = Number(ev.assetsPerShare);
-			return Number.isFinite(v) ? v : null;
-		}
-		const v = ev.newAssetsPerShare == null ? NaN : Number(ev.newAssetsPerShare);
+		const v = Number(ev.assetsPerShare);
 		return Number.isFinite(v) ? v : null;
 	}
 
-	// Drop events with no readable rate (the API may return null on donations
-	// it couldn't price; they'll self-heal on the next read).
+	// Drop events with no readable rate; they'll self-heal on the next sample.
 	$: pts = events
 		.map((e) => ({ ev: e, rate: rateOf(e) }))
 		.filter((p): p is { ev: ExchangeRateEvent; rate: number } => p.rate != null);
@@ -36,8 +31,8 @@
 	$: innerW = w - padL - padR;
 	$: innerH = h - padT - padB;
 
-	// The wrap ratio is bounded below by 1.0 (vault assets ≥ shares minted by
-	// construction — issuer donations only add, never remove). Anchoring the
+	// The wrap ratio is bounded below by 1.0 (vault assets >= shares minted by
+	// construction). Anchoring the
 	// y-axis at 0 wastes 99% of the plot area on impossible values; the
 	// previous fixed `0..yMax` axis made a 1 → 1.0027 step look flat. We
 	// instead frame the axis tightly around the actual data with a small

--- a/src/lib/queries/exchangeRates.ts
+++ b/src/lib/queries/exchangeRates.ts
@@ -1,24 +1,24 @@
 /**
  * Wrap-ratio (exchange-rate) data source.
  *
- * Reads from a hardcoded JSON fixture (`$lib/config/wrapRatioFixture.json`)
- * instead of an upstream API. The /v1/tokens/exchange-rates(/history)
- * endpoint isn't live yet; when it ships, swap the loader implementations
- * and the rest of the UI (chip, denom toggle, Ratio History tab) keeps
- * working unchanged because the shapes match the planned API contract.
- *
- * Only wtSGOV has a non-1:1 rate today (1.002700626096609112 — verified
- * on Base via `cast call wtSGOV.convertToAssets(1e18)` at block 46604184).
- * Every other wrapper implicitly resolves to 1.0 via the safe default in
- * `resolveRatio`.
+ * The REST API returns wrap-ratio rows with share/asset addresses. The website
+ * composes display metadata from /v1/tokens so existing UI surfaces can keep
+ * working with token refs instead of doing local chain/indexer reads.
  */
-import { createQuery } from '@tanstack/svelte-query';
 import { browser } from '$app/environment';
-import fixture from '$lib/config/wrapRatioFixture.json';
+import {
+	apiGetTokens,
+	apiGetWrapRatioHistory,
+	apiGetWrapRatios,
+	type ApiWrapRatio,
+	type ApiWrapRatioHistoryResponse,
+	type ApiWrapRatiosResponse
+} from '$lib/api/st0xApi';
+import type { CategorizedToken } from '$lib/config/tokens';
+import { findApiTokenByAnyAddress, normalizeApiTokensForNetwork } from '$lib/queries/tokens';
+import { createQuery } from '@tanstack/svelte-query';
 
-// ============================================================================
-// Types — kept identical in shape to what the API contract will return.
-// ============================================================================
+const BASE_CHAIN_ID = 8453;
 
 export interface TokenRef {
 	address: string;
@@ -29,47 +29,27 @@ export interface TokenRef {
 export interface ExchangeRate {
 	share: TokenRef;
 	asset: TokenRef;
-	assetsPerShare: string; // decimal string — e.g. "1.0", "1.002700626096609112"
+	assetsPerShare: string;
 	blockNumber: number;
 	blockTimestamp: number;
-	capturedAt: string; // "YYYY-MM-DD HH:MM:SS"
+	capturedAt: string;
 }
 
-export type ExchangeRateEventType = 'snapshot' | 'donation';
-
-export interface ExchangeRateEventBase {
-	type: ExchangeRateEventType;
-	blockNumber: number;
-	blockTimestamp: number;
-}
-
-export interface ExchangeRateSnapshot extends ExchangeRateEventBase {
+export interface ExchangeRateSnapshot {
 	type: 'snapshot';
+	blockNumber: number;
+	blockTimestamp: number;
 	assetsPerShare: string;
 	capturedAt: string;
 }
 
-export interface ExchangeRateDonation extends ExchangeRateEventBase {
-	type: 'donation';
-	txHash: string;
-	donor: string;
-	assetAmount: string;
-	newAssetsPerShare: string | null;
-}
-
-export type ExchangeRateEvent = ExchangeRateSnapshot | ExchangeRateDonation;
+export type ExchangeRateEvent = ExchangeRateSnapshot;
 
 export interface ExchangeRateHistoryResponse {
 	share: TokenRef;
 	asset: TokenRef;
 	events: ExchangeRateEvent[];
-	pagination: {
-		page: number;
-		pageSize: number;
-		totalEvents: number;
-		totalPages: number;
-		hasMore: boolean;
-	};
+	pagination: ApiWrapRatioHistoryResponse['pagination'];
 }
 
 export interface ExchangeRateLookup {
@@ -81,36 +61,94 @@ export interface ExchangeRateLookup {
 	all: ExchangeRate[];
 }
 
-// ============================================================================
-// Fixture loader
-// ============================================================================
-
-interface WrapRatioFixture {
-	rates: ExchangeRate[];
-	history: Record<string, Omit<ExchangeRateHistoryResponse, 'pagination'>>;
+function toKey(address: string | null | undefined): string {
+	return address?.toLowerCase() ?? '';
 }
 
-const FIXTURE = fixture as unknown as WrapRatioFixture;
+function tokenToRef(token: CategorizedToken | null | undefined, fallbackAddress: string): TokenRef {
+	return {
+		address: token?.address ?? fallbackAddress,
+		symbol: token?.symbol ?? '',
+		decimals: token?.decimals ?? 18
+	};
+}
 
-function buildLookup(rates: ExchangeRate[]): ExchangeRateLookup {
+function unwrapSymbol(symbol: string): string {
+	if (!symbol) return '';
+	return symbol.startsWith('wt') ? `t${symbol.slice(2)}` : symbol.replace(/^w/, '');
+}
+
+function exactTokenByAddress(tokens: CategorizedToken[], address: string): CategorizedToken | null {
+	const key = toKey(address);
+	return tokens.find((token) => toKey(token.address) === key) ?? null;
+}
+
+function buildTokenRefs(
+	tokens: CategorizedToken[],
+	shareAddress: string,
+	assetAddress: string
+): { share: TokenRef; asset: TokenRef } {
+	const shareToken =
+		exactTokenByAddress(tokens, shareAddress) ?? findApiTokenByAnyAddress(tokens, shareAddress);
+	const exactAssetToken = exactTokenByAddress(tokens, assetAddress);
+	const share = tokenToRef(shareToken, shareAddress);
+	const asset = exactAssetToken
+		? tokenToRef(exactAssetToken, assetAddress)
+		: {
+				address: assetAddress,
+				symbol: unwrapSymbol(share.symbol),
+				decimals: share.decimals
+			};
+	return { share, asset };
+}
+
+export function buildLookup(rates: ExchangeRate[]): ExchangeRateLookup {
 	const byShareAddress: Record<string, ExchangeRate> = {};
 	const byAssetAddress: Record<string, ExchangeRate> = {};
 	for (const rate of rates) {
-		const share = rate.share.address?.toLowerCase();
-		const asset = rate.asset.address?.toLowerCase();
+		const share = toKey(rate.share.address);
+		const asset = toKey(rate.asset.address);
 		if (share) byShareAddress[share] = rate;
 		if (asset) byAssetAddress[asset] = rate;
 	}
 	return { byShareAddress, byAssetAddress, all: rates };
 }
 
-const LOOKUP: ExchangeRateLookup = buildLookup(FIXTURE.rates);
+export function mapApiWrapRatio(row: ApiWrapRatio, tokens: CategorizedToken[]): ExchangeRate {
+	const { share, asset } = buildTokenRefs(tokens, row.shareAddress, row.assetAddress);
+	return {
+		share,
+		asset,
+		assetsPerShare: row.assetsPerShare,
+		blockNumber: row.blockNumber,
+		blockTimestamp: row.blockTimestamp,
+		capturedAt: row.capturedAt
+	};
+}
+
+export function mapApiWrapRatioHistory(
+	response: ApiWrapRatioHistoryResponse,
+	tokens: CategorizedToken[]
+): ExchangeRateHistoryResponse {
+	const { share, asset } = buildTokenRefs(tokens, response.shareAddress, response.assetAddress);
+	return {
+		share,
+		asset,
+		events: response.events.map((event) => ({
+			type: 'snapshot',
+			blockNumber: event.blockNumber,
+			blockTimestamp: event.blockTimestamp,
+			assetsPerShare: event.assetsPerShare,
+			capturedAt: event.capturedAt
+		})),
+		pagination: response.pagination
+	};
+}
 
 /**
  * Returns the wrap ratio (number of underlying t* per 1 wt*) for a given
  * token address — accepts either the share (wt*) or asset (t*) address.
- * Returns 1 when the lookup is missing the entry (safe default — parity
- * wrappers stay 1:1).
+ * Returns 1 when the lookup is missing the entry.
  */
 export function resolveRatio(
 	lookup: ExchangeRateLookup | null | undefined,
@@ -124,62 +162,53 @@ export function resolveRatio(
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 }
 
-/**
- * TanStack-shaped query so existing consumers (`$exchangeRatesQuery.data`)
- * keep working when the live API replaces the fixture. The queryFn is
- * synchronous-with-Promise-wrap — there's no network call.
- */
-export function createExchangeRatesQuery() {
+function warnWrapRatioErrors(response: ApiWrapRatiosResponse): void {
+	if (response.errors?.length) {
+		console.warn('[wrap-ratio] REST API returned partial errors', response.errors);
+	}
+}
+
+export function createExchangeRatesQuery(chainId: number = BASE_CHAIN_ID) {
 	return createQuery<ExchangeRateLookup>({
-		queryKey: ['exchangeRates'],
+		queryKey: ['exchangeRates', chainId],
 		enabled: browser,
-		staleTime: Infinity,
-		queryFn: async () => LOOKUP
+		staleTime: 60_000,
+		refetchOnWindowFocus: true,
+		queryFn: async () => {
+			const [apiTokens, wrapRatios] = await Promise.all([apiGetTokens(), apiGetWrapRatios()]);
+			warnWrapRatioErrors(wrapRatios);
+			const tokens = normalizeApiTokensForNetwork(apiTokens, chainId);
+			return buildLookup(wrapRatios.data.map((row) => mapApiWrapRatio(row, tokens)));
+		}
 	});
 }
 
 export function createExchangeRateHistoryQuery(
 	wrappedTokenAddress: string | null | undefined,
-	options?: { page?: number; pageSize?: number }
+	options?: { page?: number; pageSize?: number },
+	chainId: number = BASE_CHAIN_ID
 ) {
 	return createQuery<ExchangeRateHistoryResponse>({
 		queryKey: [
 			'exchangeRateHistory',
+			chainId,
 			wrappedTokenAddress?.toLowerCase() ?? null,
 			options?.page ?? 1,
 			options?.pageSize ?? 50
 		],
 		enabled: browser && Boolean(wrappedTokenAddress),
-		staleTime: Infinity,
+		staleTime: 60_000,
+		retry: false,
 		queryFn: async () => {
 			if (!wrappedTokenAddress) {
 				throw new Error('wrappedTokenAddress is required');
 			}
-			const entry = FIXTURE.history[wrappedTokenAddress.toLowerCase()];
-			if (!entry) {
-				return {
-					share: { address: wrappedTokenAddress, symbol: '', decimals: 18 },
-					asset: { address: '', symbol: '', decimals: 18 },
-					events: [],
-					pagination: {
-						page: 1,
-						pageSize: options?.pageSize ?? 50,
-						totalEvents: 0,
-						totalPages: 0,
-						hasMore: false
-					}
-				};
-			}
-			return {
-				...entry,
-				pagination: {
-					page: 1,
-					pageSize: options?.pageSize ?? 50,
-					totalEvents: entry.events.length,
-					totalPages: 1,
-					hasMore: false
-				}
-			};
+			const [apiTokens, history] = await Promise.all([
+				apiGetTokens(),
+				apiGetWrapRatioHistory(wrappedTokenAddress, options)
+			]);
+			const tokens = normalizeApiTokensForNetwork(apiTokens, chainId);
+			return mapApiWrapRatioHistory(history, tokens);
 		}
 	});
 }

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -1738,7 +1738,6 @@
 							assetSymbol={(currentPythToken?.symbol ?? currentToken.symbol).replace(/^wt/, 't')}
 							{currentRatio}
 							onLearnMore={openWrapExplainer}
-							txHrefBuilder={(tx) => `${$currentNetwork.blockExplorer}/tx/${tx}`}
 						/>
 					{:else if activeTokenTab === 'supply'}
 						<div>

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -32,6 +32,21 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 	{ method: 'GET', pattern: /^v1\/tokens$/ },
 	{
 		method: 'GET',
+		pattern: /^v1\/tokens\/wrap-ratio$/,
+		cache: 'public, s-maxage=60, stale-while-revalidate=300'
+	},
+	{
+		method: 'GET',
+		pattern: /^v1\/tokens\/wrap-ratio\/[^/]+$/,
+		cache: 'public, s-maxage=60, stale-while-revalidate=300'
+	},
+	{
+		method: 'GET',
+		pattern: /^v1\/tokens\/wrap-ratio\/[^/]+\/history$/,
+		cache: 'public, s-maxage=60, stale-while-revalidate=300'
+	},
+	{
+		method: 'GET',
 		pattern: /^v1\/tokens\/[^/]+\/proofs$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},

--- a/tests/integration/ui/wrapRatio.spec.ts
+++ b/tests/integration/ui/wrapRatio.spec.ts
@@ -3,12 +3,8 @@
 // Ratio History tab).
 //
 // Target token: **wtSGOV** (iShares 0-3 Month T-Bill ETF). SGOV's wrap
-// ratio is 1.002700626096609112 today (verified on Base via
-// `cast call wtSGOV.convertToAssets(1e18)` at block 46604184). The value
-// plus a single historical dividend distribution event are pinned in
-// `src/lib/config/wrapRatioFixture.json`; the UI reads from that file
-// directly (no API call), so this spec doesn't need to mock the rates
-// endpoint anymore.
+// ratio is stubbed from the REST API response shape so the test covers the
+// production data path without depending on staging data.
 //
 // Why SGOV: SGOV isn't in the SFT subgraph yet, so `getSftById` returns
 // null quickly — `singleTokenQuery` resolves fast, the page falls back to
@@ -22,15 +18,94 @@ import { test, expect } from './fixtures';
 const WT_SGOV_ADDRESS = '0x78c31580c97101694C70022c83D570150c11e935';
 const T_SGOV_ADDRESS = '0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612';
 
-// Mirrors the value pinned in `src/lib/config/wrapRatioFixture.json`. The
-// UI renders ratios with `toLocaleString('en-US', { maximumFractionDigits: 4 })`,
-// so 1.002700626096609112 displays as "1.0027".
+// The UI renders ratios with
+// `toLocaleString('en-US', { maximumFractionDigits: 4 })`.
 const RATIO_DISPLAY = '1.0027';
 
-test.describe('Wrap ratio UX — non-1:1 wtSGOV (hardcoded fixture)', () => {
-	test('chip, explainer, ratio history, denom toggle render with the SGOV fixture', async ({
+test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
+	test('chip, explainer, ratio history, denom toggle render with REST wrap-ratio data', async ({
 		page
 	}) => {
+		await page.route(/\/api\/st0x\/v1\/tokens/, async (route) => {
+			const url = new URL(route.request().url());
+			const pathname = url.pathname.toLowerCase();
+			if (url.pathname === '/api/st0x/v1/tokens') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify([
+						{
+							address: WT_SGOV_ADDRESS,
+							symbol: 'wtSGOV',
+							decimals: 18,
+							name: 'Wrapped iShares 0-3 Month Treasury Bond ETF ST0x',
+							network: { chainId: 8453 },
+							extensions: {
+								category: 'ST0x',
+								unwrappedAddress: T_SGOV_ADDRESS
+							}
+						}
+					])
+				});
+				return;
+			}
+			if (pathname === `/api/st0x/v1/tokens/wrap-ratio/${WT_SGOV_ADDRESS.toLowerCase()}/history`) {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						shareAddress: WT_SGOV_ADDRESS,
+						assetAddress: T_SGOV_ADDRESS,
+						events: [
+							{
+								type: 'snapshot',
+								blockNumber: 46604184,
+								blockTimestamp: 1748430000,
+								assetsPerShare: '1.0',
+								capturedAt: '1748430000'
+							},
+							{
+								type: 'snapshot',
+								blockNumber: 46604185,
+								blockTimestamp: 1748433600,
+								assetsPerShare: '1.002700626096609112',
+								capturedAt: '1748433600'
+							}
+						],
+						pagination: {
+							page: 1,
+							pageSize: 100,
+							totalEvents: 2,
+							totalPages: 1,
+							hasMore: false
+						}
+					})
+				});
+				return;
+			}
+			if (url.pathname === '/api/st0x/v1/tokens/wrap-ratio') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						data: [
+							{
+								shareAddress: WT_SGOV_ADDRESS,
+								assetAddress: T_SGOV_ADDRESS,
+								assetsPerShare: '1.002700626096609112',
+								blockNumber: 46604185,
+								blockTimestamp: 1748433600,
+								capturedAt: '1748433600'
+							}
+						],
+						errors: []
+					})
+				});
+				return;
+			}
+			await route.fallback();
+		});
+
 		// Stub the SFT subgraph for the SGOV singleTokenQuery so it resolves fast
 		// and deterministically. SGOV's Goldsky entry is sparse / cold so the
 		// upstream request can rate-limit or hit the fixtures.ts retry loop
@@ -88,7 +163,11 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (hardcoded fixture)', () => {
 		// Dismiss the "No USDC found" announcement banner so its dismiss-X button
 		// doesn't accidentally absorb the click flow if Playwright targets the
 		// wrong stacking layer.
-		await page.locator('button[aria-label="Dismiss"]').first().click({ trial: true }).catch(() => {});
+		await page
+			.locator('button[aria-label="Dismiss"]')
+			.first()
+			.click({ trial: true })
+			.catch(() => {});
 
 		const trigger = page.locator('[data-testid="wrap-explainer-trigger"]').first();
 		await expect(trigger).toBeVisible();
@@ -119,11 +198,9 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (hardcoded fixture)', () => {
 		// The contract tab is the default tab in Token Details. The yellow card
 		// at the top has the ratio + "Unwrap in Dashboard" CTA.
 		await expect(page.getByText('Wrap Ratio').first()).toBeVisible();
-		await expect(
-			page.getByRole('link', { name: /Unwrap in Dashboard/i }).first()
-		).toBeVisible();
+		await expect(page.getByRole('link', { name: /Unwrap in Dashboard/i }).first()).toBeVisible();
 
-		// ───────── 4. Ratio History tab — timeline + events ─────────
+		// ───────── 4. Ratio History tab - timeline + snapshots ─────────
 		// Tab click sometimes drops on the floor if hasRatio briefly flips while
 		// the page is still hydrating (it's reactive over the same currentRatio
 		// that drives the tab strip). Retry until the panel content appears.
@@ -133,15 +210,12 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (hardcoded fixture)', () => {
 			await ratioTab.click();
 			await expect(page.getByText('Wrap Ratio History')).toBeVisible({ timeout: 1_500 });
 		}).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
-		// The fixture has one donation event between two bookkeeping snapshots.
-		// We filter snapshots out of the user-facing list, so only the "Rebase"
-		// item plus the synthetic "Deployed" anchor should render. The "current"
-		// pill should mark the rebase (most-recent real event).
-		await expect(page.getByText(/^Rebase$/).first()).toBeVisible();
+		// REST history returns sampled snapshots only. The most recent snapshot
+		// gets the "latest" pill, followed by the synthetic deployment anchor.
+		await expect(page.getByText(/^Snapshot$/).first()).toBeVisible();
 		await expect(page.getByText(/^Deployed$/).first()).toBeVisible();
-		await expect(page.getByText('current').first()).toBeVisible();
-		// And we shouldn't render any "Snapshot" rows anymore — they were noise.
-		await expect(page.getByText(/^Snapshot$/i)).toHaveCount(0);
+		await expect(page.getByText('latest').first()).toBeVisible();
+		await expect(page.getByText(/^Rebase$/i)).toHaveCount(0);
 
 		// ───────── 5. DenomToggle in the On-chain Market header ─────────
 		const sharesBtn = page.getByRole('tab', { name: 'Shares (tSGOV)' });
@@ -192,14 +266,20 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (hardcoded fixture)', () => {
 			// pre-fix code failed: header changed but cells stayed in wt.
 			await expect(ordersPanel.locator('tbody').getByText(/wtSGOV/i)).toHaveCount(0);
 			await expect(
-				ordersPanel.locator('tbody').getByText(/(?<!w)tSGOV/i).first()
+				ordersPanel
+					.locator('tbody')
+					.getByText(/(?<!w)tSGOV/i)
+					.first()
 			).toBeVisible();
 
 			// And toggling back to wrapped flips them all back.
 			await tokensBtn.click();
 			await expect(tokensBtn).toHaveAttribute('aria-selected', 'true');
 			await expect(
-				ordersPanel.locator('tbody').getByText(/wtSGOV/i).first()
+				ordersPanel
+					.locator('tbody')
+					.getByText(/wtSGOV/i)
+					.first()
 			).toBeVisible({ timeout: 5_000 });
 		}
 	});

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -100,13 +100,59 @@ describe('/api/st0x proxy', () => {
 		);
 	});
 
-	it('keeps wrap-ratio endpoints blocked until their API PRs land', async () => {
-		const fetchMock = vi.fn();
+	it('allows cached wrap-ratio endpoints', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ data: [], errors: [] }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
 		vi.stubGlobal('fetch', fetchMock);
 
 		const response = await GET(proxyEvent('GET', 'v1/tokens/wrap-ratio'));
 
-		expect(response.status).toBe(404);
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBe(
+			'public, s-maxage=60, stale-while-revalidate=300'
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/tokens/wrap-ratio?page=1',
+			expect.objectContaining({ method: 'GET' })
+		);
+	});
+
+	it('allows cached wrap-ratio history endpoints', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					shareAddress: '0xShare',
+					assetAddress: '0xAsset',
+					events: [],
+					pagination: {
+						page: 1,
+						pageSize: 20,
+						totalEvents: 0,
+						totalPages: 0,
+						hasMore: false
+					}
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(proxyEvent('GET', 'v1/tokens/wrap-ratio/0xShare/history'));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBe(
+			'public, s-maxage=60, stale-while-revalidate=300'
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/tokens/wrap-ratio/0xShare/history?page=1',
+			expect.objectContaining({ method: 'GET' })
+		);
 	});
 });

--- a/tests/lib/queries/exchangeRates.test.ts
+++ b/tests/lib/queries/exchangeRates.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildLookup,
+	mapApiWrapRatio,
+	mapApiWrapRatioHistory,
+	resolveRatio
+} from '$lib/queries/exchangeRates';
+import type { CategorizedToken } from '$lib/config/tokens';
+
+const tokens: CategorizedToken[] = [
+	{
+		chainId: 8453,
+		address: '0xShare',
+		symbol: 'wtSGOV',
+		decimals: 18,
+		name: 'Wrapped Test SGOV',
+		priceFeedId: '',
+		category: 'ST0x',
+		unwrappedAddress: '0xAsset',
+		limitOrders: []
+	}
+];
+
+describe('exchangeRates REST adapters', () => {
+	it('composes token refs from token metadata and resolves by share or asset address', () => {
+		const rate = mapApiWrapRatio(
+			{
+				shareAddress: '0xShare',
+				assetAddress: '0xAsset',
+				assetsPerShare: '1.0027',
+				blockNumber: 123,
+				blockTimestamp: 456,
+				capturedAt: '456'
+			},
+			tokens
+		);
+		const lookup = buildLookup([rate]);
+
+		expect(rate.share).toEqual({ address: '0xShare', symbol: 'wtSGOV', decimals: 18 });
+		expect(rate.asset).toEqual({ address: '0xAsset', symbol: 'tSGOV', decimals: 18 });
+		expect(resolveRatio(lookup, '0xShare')).toBe(1.0027);
+		expect(resolveRatio(lookup, '0xAsset')).toBe(1.0027);
+		expect(resolveRatio(lookup, '0xMissing')).toBe(1);
+	});
+
+	it('maps snapshot history events', () => {
+		const history = mapApiWrapRatioHistory(
+			{
+				shareAddress: '0xShare',
+				assetAddress: '0xAsset',
+				events: [
+					{
+						type: 'snapshot',
+						blockNumber: 123,
+						blockTimestamp: 456,
+						assetsPerShare: '1.0027',
+						capturedAt: '456'
+					}
+				],
+				pagination: {
+					page: 1,
+					pageSize: 20,
+					totalEvents: 1,
+					totalPages: 1,
+					hasMore: false
+				}
+			},
+			tokens
+		);
+
+		expect(history.events).toEqual([
+			{
+				type: 'snapshot',
+				blockNumber: 123,
+				blockTimestamp: 456,
+				assetsPerShare: '1.0027',
+				capturedAt: '456'
+			}
+		]);
+		expect(history.asset.symbol).toBe('tSGOV');
+	});
+});


### PR DESCRIPTION
## Chained PRs

Depends on #206.

## Motivation

Wrap-ratio data was still coming from the local website fixture while the REST API now exposes current ratios and snapshot history.

## Solution

- Add typed REST client methods for current wrap ratios and snapshot history.
- Allow the wrap-ratio REST routes through the st0x proxy with short shared caching.
- Replace the fixture-backed exchange-rate query with REST data composed with /v1/tokens metadata.
- Update the Ratio History tab to render snapshot history instead of donation/rebase events.
- Fail fast and show a clean error state when the history endpoint returns an error.
- Update wrap-ratio tests to stub and assert the REST response shapes.

## Checks

- bunx vitest run tests/lib/api/st0x-proxy.test.ts tests/lib/queries/exchangeRates.test.ts
- bunx eslint src/lib/api/st0xApi.ts src/lib/queries/exchangeRates.ts src/lib/components/wrap/RatioHistoryTab.svelte src/lib/components/wrap/RatioStepChart.svelte 'src/routes/(main)/trade/[id]/+page.svelte' 'src/routes/api/st0x/[...path]/+server.ts'
- bunx svelte-check --no-tsconfig --ignore "tests,node_modules,.svelte-kit,build" --threshold error
- Browser smoke test on local staging-backed dev server at http://127.0.0.1:5185/trade/0x78c31580c97101694C70022c83D570150c11e935

## Local Browser Result

- wtSGOV current ratio loads from REST and renders as 1 wtSGOV = 1.0027 tSGOV in the header chip, denom toggle context, and contract card.
- Ratio History tab opens after collapsing the left asset sidebar.
- Staging history endpoint now returns snapshots; the UI renders the step chart, snapshot list, latest pill, block numbers, and deployed anchor.

Notes: full bun run check is currently blocked by missing @playwright/test types in tests/integration/ui; production build compiles but adapter finalization is blocked locally by Node v24.5.0 not being supported by @sveltejs/adapter-vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added wrap ratio snapshot history with pagination via API endpoints for improved data access

* **Refactor**
  * Exchange rate queries now source from REST API for real-time data instead of fixtures
  * Wrap ratio history display updated: shows snapshots instead of rebases with block capture details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->