### PR TITLE
fix(seo): list canonical /docs/introduction in sitemap

### DIFF
--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -8,9 +8,11 @@ import type { RequestHandler } from './$types';
 // Sitemap URL returning 404.
 const SITE = 'https://www.st0x.io';
 
-// Public, indexable routes that exist on this branch. App/auth-gated routes
-// (/dashboard, /trade, /strategies, /platform-metrics) are intentionally excluded.
-const ROUTES = ['/', '/faqs', '/docs', '/terms', '/privacy-policy'];
+// Public, indexable routes. App/auth-gated routes (/dashboard, /trade,
+// /strategies, /platform-metrics) are intentionally excluded. Use canonical
+// destinations only — `/docs` 307-redirects to `/docs/introduction`, so list
+// the latter to avoid advertising a redirecting URL.
+const ROUTES = ['/', '/faqs', '/docs/introduction', '/terms', '/privacy-policy'];
 
 export const GET: RequestHandler = () => {
 	const urls = ROUTES.map(


### PR DESCRIPTION
Tiny follow-up to #213. `/docs` 307-redirects to `/docs/introduction`; the sitemap now lists the canonical 200 URL instead of the redirecting one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sitemap to ensure only canonical, non-redirecting routes are advertised to search engines, improving site indexing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->