### PR TITLE
fix(seo): add site-wide title & meta description defaults

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,22 @@
 	import '../app.css';
 	import { QueryClientProvider } from '@tanstack/svelte-query';
 	import { queryClient } from '$lib/clients/queryClient';
+	import { page } from '$app/stores';
 	import { env as publicEnv } from '$env/dynamic/public';
+
+	// Site-wide SEO defaults. Pages override the title via their own <svelte:head>
+	// (Svelte keeps the last <title>), or by returning `title`/`description` from a
+	// load function. Without these, crawlers fall back to scraping visible body text
+	// (e.g. the footer risk warning).
+	const SITE_URL = 'https://www.st0x.io';
+	const DEFAULT_TITLE = 'ST0x — Trade & Earn on DeFi-Native Tokenized Assets';
+	const DEFAULT_DESCRIPTION =
+		'ST0x brings real-world assets on-chain as DeFi-first tokens. Trade tokenized stocks, ETFs & commodities 24/7, then earn yield with fully composable, on-chain assets.';
+	const OG_IMAGE = `${SITE_URL}/apple-touch-icon.png`;
+
+	$: metaTitle = ($page.data?.title as string | undefined) ?? DEFAULT_TITLE;
+	$: metaDescription = ($page.data?.description as string | undefined) ?? DEFAULT_DESCRIPTION;
+	$: canonicalUrl = `${SITE_URL}${$page.url.pathname}`;
 	import { onMount } from 'svelte';
 	import { injectAnalytics } from '@vercel/analytics/sveltekit';
 	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
@@ -124,6 +139,27 @@
 		};
 	});
 </script>
+
+<svelte:head>
+	<title>{metaTitle}</title>
+	<meta name="description" content={metaDescription} />
+	<link rel="canonical" href={canonicalUrl} />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="website" />
+	<meta property="og:site_name" content="ST0x" />
+	<meta property="og:url" content={canonicalUrl} />
+	<meta property="og:title" content={metaTitle} />
+	<meta property="og:description" content={metaDescription} />
+	<meta property="og:image" content={OG_IMAGE} />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:site" content="@st0x_io" />
+	<meta name="twitter:title" content={metaTitle} />
+	<meta name="twitter:description" content={metaDescription} />
+	<meta name="twitter:image" content={OG_IMAGE} />
+</svelte:head>
 
 <QueryClientProvider client={queryClient}>
 	<!-- Dynamic SDK wrapper (invisible, handles auth state) -->

--- a/src/routes/api-docs/+page.svelte
+++ b/src/routes/api-docs/+page.svelte
@@ -1,11 +1,3 @@
-<svelte:head>
-	<title>API Documentation | st0x</title>
-	<meta
-		name="description"
-		content="st0x Public API documentation for rewards, RocketBoost, and wallet data."
-	/>
-</svelte:head>
-
 <div class="api-docs-wrapper">
 	<iframe src="/scalar.html" title="API Documentation" class="api-docs-iframe"></iframe>
 </div>

--- a/src/routes/api-docs/+page.ts
+++ b/src/routes/api-docs/+page.ts
@@ -1,0 +1,7 @@
+// SEO metadata for this route. The root layout reads `title`/`description` from
+// `$page.data` and renders them as the single source of title + meta description,
+// avoiding duplicate tags from an inline <svelte:head>.
+export const load = () => ({
+	title: 'API Documentation | st0x',
+	description: 'st0x Public API documentation for rewards, RocketBoost, and wallet data.'
+});


### PR DESCRIPTION
## Problem
The homepage set no `<title>` or meta description, so Google scraped visible body text and used the **footer risk warning** as the search snippet (see screenshot in the originating request).

## Fix
- Add SEO defaults (title, description, canonical, Open Graph, Twitter) in the root `+layout.svelte`, driven by `$page.data` with constant fallbacks. Canonical is **per-page** via `$page.url.pathname`.
- Remove the now-redundant inline `<svelte:head>` from the homepage (the layout default *is* the homepage copy).
- Move `/api-docs` metadata into a `load` (`+page.ts`) so it overrides via `$page.data` instead of an inline `<meta name="description">`, which would have duplicated against the layout default (Svelte **accumulates** head meta; only `<title>` overwrites).

**Title:** ST0x — Trade & Earn on DeFi-Native Tokenized Assets
**Description:** ST0x brings real-world assets on-chain as DeFi-first tokens. Trade tokenized stocks, ETFs & commodities 24/7, then earn yield with fully composable, on-chain assets.

## Verification
Ran the dev server and curled SSR HTML — single `<title>` + single `<meta name="description">` on every route, per-page canonicals:

| Route | title | description | canonical |
|---|---|---|---|
| `/` | 1 (default) | 1 (default) | `/` |
| `/faqs` | 1 (default) | 1 (default) | `/faqs` |
| `/api-docs` | 1 (own) | 1 (own) | `/api-docs` |
| 404 | 1 (own) | 1 (default) | ✓ |

`svelte-check`, `eslint`, and `prettier --check` all pass. `trade/[id]` is `ssr=false` (client-only, not SEO-indexed) — unchanged.

## Follow-ups (not in this PR)
- OG image is a placeholder (`apple-touch-icon.png`); add a proper 1200×630 `static/og-image.png`.
- After deploy, request re-indexing in Google Search Console (snippet updates on next crawl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented site-wide SEO metadata management with dynamic page titles and descriptions
  * Added Open Graph and Twitter card tags for improved social media sharing
  * Configured canonical URLs for better search engine indexing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->