### PR TITLE
chore(subgraph): bump SFT Base subgraph 1.0.10 → 1.0.12

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -103,7 +103,7 @@
 - Crypto reference tokens (CRYPTO_TOKENS) on Arbitrum + Base: WBTC, WETH, ARB, USDC
 
 **Subgraphs (Goldsky):**
-- SFT subgraph (Base): `https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.10/gn`
+- SFT subgraph (Base): `https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.12/gn`
 - Metadata subgraph (Base): `https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn`
 - Orderbook v4 subgraph (Base, active): `https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn`
 - Orderbook v4 subgraph (Base, inactive/historical): `…/ob4-base/2025-10-11-a62b/gn`

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -63,7 +63,7 @@ export const networks: Network[] = [
 		],
 		icon: 'ethereum',
 		subgraph_url:
-			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.10/gn',
+			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.12/gn',
 		metadata_subgraph_url:
 			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn',
 		orderbook_subgraph_url:


### PR DESCRIPTION
## Summary

- Bump the Base SFT subgraph URL from `sft-base/1.0.10` to `sft-base/1.0.12` in `src/lib/config/networks.ts`.
- Update `.planning/codebase/INTEGRATIONS.md` to reflect the new version.

## Why

1.0.12 is an **additive, backward-compatible** schema change. No fields were removed; it adds aggregate fields (`depositVolume`, `withdrawVolume`, `tokenHolderCount`, `shareTransferCount`, `assetsPerShare`, `sharesPerAsset`, `exchangeRateBlock`, `exchangeRateTimestamp`).

## Verification

Validated against the live 1.0.12 subgraph:

- Root query types identical between 1.0.10 and 1.0.12.
- `OffchainAssetReceiptVault` fields: 35 → 43, **zero removals**.
- Existing `getSfts` / `getSftById` full nested query (`src/lib/api/subgraph.ts`) runs with no GraphQL errors.
- Snapshot scraper queries (`sharesTransfers`, `wrappedTokenTransfers`) run with no GraphQL errors.
- `tests/lib/network.test.ts` and `src/lib/server/snapshots/scraper.test.ts` pass.

## Test plan

- [ ] CI green (test / test-integration / test-e2e)
- [ ] Landing + trade pages load token/vault data on preview
- [ ] Snapshot admin flows unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Base network data source to use the latest subgraph endpoint, improving data freshness and reliability.
* **Documentation**
  * Kept the integration reference in sync with the updated endpoint version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->