### PR TITLE
refactor(tokens): source ST0x catalog from REST API

### DIFF
--- a/src/lib/config/tokenMigration.ts
+++ b/src/lib/config/tokenMigration.ts
@@ -4,10 +4,10 @@
  * This file contains the mapping of old (legacy) tokens to their new wrapped equivalents.
  * The site now trades wrapped tStock tokens (wt[ticker]), so all tokens are named "Wrapped [tStock name]".
  *
- * NOTE: All address data is derived from TOKENS in tokens.ts (single source of truth)
+ * NOTE: All address data is derived from the API-backed runtime token catalog.
  */
 
-import { TOKENS, getTokenByLegacyAddress } from './tokens';
+import { getTokenByLegacyAddress, onTokenCatalogChange, type CategorizedToken } from './tokens';
 
 export interface TokenMigrationMapping {
 	oldToken: {
@@ -51,7 +51,7 @@ export const SWAP_ORDER_HASHES: Record<string, string> = {
  * Derive old/legacy symbol from token
  * Uses legacySymbol if explicitly set (e.g., tSPLG -> wtSPYM), otherwise derives from wrapped symbol
  */
-function getLegacySymbol(token: (typeof TOKENS)[0]): string {
+function getLegacySymbol(token: CategorizedToken): string {
 	if (token.legacySymbol) {
 		return token.legacySymbol;
 	}
@@ -73,28 +73,9 @@ function getLegacyName(wrappedName: string): string {
 }
 
 /**
- * Complete token migration mappings - derived from TOKENS (single source of truth)
+ * Complete token migration mappings, rebuilt when the remote catalog changes.
  */
-export const TOKEN_MIGRATION_MAPPINGS: TokenMigrationMapping[] = TOKENS.filter(
-	(t) => t.legacyAddress && t.category === 'ST0x'
-).map((t) => {
-	const legacySymbol = getLegacySymbol(t);
-	return {
-		oldToken: {
-			address: t.legacyAddress!,
-			symbol: legacySymbol,
-			name: getLegacyName(t.name),
-			decimals: t.decimals
-		},
-		newToken: {
-			address: t.address,
-			symbol: t.symbol,
-			name: t.name,
-			decimals: t.decimals
-		},
-		swapOrderHash: SWAP_ORDER_HASHES[legacySymbol] ?? ''
-	};
-});
+export const TOKEN_MIGRATION_MAPPINGS: TokenMigrationMapping[] = [];
 
 // Create lookup maps for efficient access
 const oldTokenAddressSet = new Set(
@@ -114,6 +95,45 @@ const newTokenAddressSet = new Set(
 const mappingByNewAddress = new Map(
 	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.newToken.address.toLowerCase(), m])
 );
+
+onTokenCatalogChange((tokens) => {
+	const mappings = tokens
+		.filter((token) => token.legacyAddress && token.category === 'ST0x')
+		.map((token) => {
+			const legacySymbol = getLegacySymbol(token);
+			return {
+				oldToken: {
+					address: token.legacyAddress!,
+					symbol: legacySymbol,
+					name: getLegacyName(token.name),
+					decimals: token.decimals
+				},
+				newToken: {
+					address: token.address,
+					symbol: token.symbol,
+					name: token.name,
+					decimals: token.decimals
+				},
+				swapOrderHash: SWAP_ORDER_HASHES[legacySymbol] ?? ''
+			};
+		});
+
+	TOKEN_MIGRATION_MAPPINGS.splice(0, TOKEN_MIGRATION_MAPPINGS.length, ...mappings);
+	oldTokenAddressSet.clear();
+	mappingByOldAddress.clear();
+	mappingByOldSymbol.clear();
+	newTokenAddressSet.clear();
+	mappingByNewAddress.clear();
+	for (const mapping of mappings) {
+		const oldAddress = mapping.oldToken.address.toLowerCase();
+		const newAddress = mapping.newToken.address.toLowerCase();
+		oldTokenAddressSet.add(oldAddress);
+		mappingByOldAddress.set(oldAddress, mapping);
+		mappingByOldSymbol.set(mapping.oldToken.symbol, mapping);
+		newTokenAddressSet.add(newAddress);
+		mappingByNewAddress.set(newAddress, mapping);
+	}
+});
 
 /**
  * Check if an address is an old (legacy) token that needs migration

--- a/src/lib/config/tokenWrapping.ts
+++ b/src/lib/config/tokenWrapping.ts
@@ -8,10 +8,14 @@
  * Old/Legacy tStock --[Swap]--> Wrapped tStock (wt) <--[Wrap/Unwrap]--> Unwrapped tStock (t)
  *    (existing)              (ERC4626 vault)                      (underlying)
  *
- * NOTE: All address data is derived from TOKENS in tokens.ts (single source of truth)
+ * NOTE: All address data is derived from the API-backed runtime token catalog.
  */
 
-import { TOKENS, getTokenByWrappedAddress, getTokenByUnwrappedAddress } from './tokens';
+import {
+	getTokenByWrappedAddress,
+	getTokenByUnwrappedAddress,
+	onTokenCatalogChange
+} from './tokens';
 
 export interface TokenWrappingMapping {
 	/** The ERC4626 vault token (wrapped tStock) - this IS the vault contract */
@@ -51,43 +55,21 @@ function getUnwrappedName(wrappedName: string): string {
 }
 
 /**
- * Complete token wrapping mappings - derived from TOKENS (single source of truth)
+ * Complete token wrapping mappings, rebuilt when the remote catalog changes.
  */
-export const TOKEN_WRAPPING_MAPPINGS: TokenWrappingMapping[] = TOKENS.filter(
-	(t) => t.unwrappedAddress && t.category === 'ST0x'
-).map((t) => ({
-	wrappedToken: {
-		address: t.address,
-		symbol: t.symbol,
-		name: t.name,
-		decimals: t.decimals
-	},
-	unwrappedToken: {
-		address: t.unwrappedAddress!,
-		symbol: getUnwrappedSymbol(t.symbol),
-		name: getUnwrappedName(t.name),
-		decimals: t.decimals
-	}
-}));
+export const TOKEN_WRAPPING_MAPPINGS: TokenWrappingMapping[] = [];
 
 /**
  * Underlying token addresses for each wrapped token (derived from TOKENS)
  * These are the underlying assets of the ERC4626 vaults
  */
-export const UNDERLYING_TOKEN_ADDRESSES: Record<string, string> = Object.fromEntries(
-	TOKENS.filter((t) => t.unwrappedAddress).map((t) => [
-		getUnwrappedSymbol(t.symbol),
-		t.unwrappedAddress!
-	])
-);
+export const UNDERLYING_TOKEN_ADDRESSES: Record<string, string> = {};
 
 /**
  * Wrapped token addresses (ERC4626 vaults) - derived from TOKENS
  * These are the vault contracts that hold the underlying tokens
  */
-export const WRAPPED_TOKEN_ADDRESSES: Record<string, string> = Object.fromEntries(
-	TOKENS.filter((t) => t.category === 'ST0x').map((t) => [t.symbol, t.address])
-);
+export const WRAPPED_TOKEN_ADDRESSES: Record<string, string> = {};
 
 // Create lookup maps for efficient access
 const mappingByWrappedAddress = new Map(
@@ -101,6 +83,44 @@ const mappingByUnwrappedAddress = new Map(
 const unwrappedAddressSet = new Set(
 	TOKEN_WRAPPING_MAPPINGS.map((m) => m.unwrappedToken.address.toLowerCase())
 );
+
+onTokenCatalogChange((tokens) => {
+	const mappings: TokenWrappingMapping[] = tokens
+		.filter((token) => token.unwrappedAddress && token.category === 'ST0x')
+		.map((token) => ({
+			wrappedToken: {
+				address: token.address,
+				symbol: token.symbol,
+				name: token.name,
+				decimals: token.decimals
+			},
+			unwrappedToken: {
+				address: token.unwrappedAddress!,
+				symbol: getUnwrappedSymbol(token.symbol),
+				name: getUnwrappedName(token.name),
+				decimals: token.decimals
+			}
+		}));
+
+	TOKEN_WRAPPING_MAPPINGS.splice(0, TOKEN_WRAPPING_MAPPINGS.length, ...mappings);
+	mappingByWrappedAddress.clear();
+	mappingByUnwrappedAddress.clear();
+	unwrappedAddressSet.clear();
+	for (const mapping of mappings) {
+		mappingByWrappedAddress.set(mapping.wrappedToken.address.toLowerCase(), mapping);
+		mappingByUnwrappedAddress.set(mapping.unwrappedToken.address.toLowerCase(), mapping);
+		unwrappedAddressSet.add(mapping.unwrappedToken.address.toLowerCase());
+	}
+
+	for (const key of Object.keys(UNDERLYING_TOKEN_ADDRESSES)) delete UNDERLYING_TOKEN_ADDRESSES[key];
+	for (const key of Object.keys(WRAPPED_TOKEN_ADDRESSES)) delete WRAPPED_TOKEN_ADDRESSES[key];
+	for (const token of tokens) {
+		if (token.unwrappedAddress) {
+			UNDERLYING_TOKEN_ADDRESSES[getUnwrappedSymbol(token.symbol)] = token.unwrappedAddress;
+		}
+		if (token.category === 'ST0x') WRAPPED_TOKEN_ADDRESSES[token.symbol] = token.address;
+	}
+});
 
 /**
  * Get the wrapping mapping for a wrapped token by its address (vault address)

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -49,371 +49,47 @@ export interface CategorizedToken extends PythToken {
 	legacyAddress?: string; // Old token for migration (optional)
 	legacySymbol?: string; // Old symbol if different (e.g., tSPLG -> wtSPYM)
 	previousSymbols?: string[]; // Historical symbol names for blob storage lookups
-	// Temporary hardcoded price fallback for tokens whose Pyth feed is unavailable.
-	// Used by the snapshot pipeline when priceFeedId is empty. Remove once a real feed is wired up.
+	receiptAddress?: string;
+	isin?: string;
+	// Registry-provided fallback for tokens whose Pyth feed is unavailable.
+	// Used by the snapshot pipeline when priceFeedId is empty.
 	fallbackPrice?: number;
 }
 
-export const TOKENS: CategorizedToken[] = [
-	{
-		chainId: base.id,
-		address: '0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7',
-		unwrappedAddress: '0x7271a3c91bb6070ed09333b84a815949d4f16d14',
-		legacyAddress: '0x69fca9f7fad46a7eef3acef5beac9df5b7eca73b',
-		symbol: 'wtNVDA',
-		decimals: 18,
-		name: 'Wrapped NVIDIA Corporation ST0x',
-		logoUrl: '/images/NVDA.png',
-		priceFeedId: '0xb1073854ed24cbc755dc527418f52b7d271f6cc967bbf8d8129112b18860a593',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:NVDA',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x997baE3EC193a249596d3708C3fAB7C501Bb8a53',
-		unwrappedAddress: '0x466cb2e46fa1afc0ab5e22274b34d0391db18efd',
-		legacyAddress: '0x8d8c315db61f60dcc3c66cdb48ca87fc643e35ea',
-		symbol: 'wtAMZN',
-		decimals: 18,
-		name: 'Wrapped Amazon.com Inc ST0x',
-		logoUrl: '/images/AMZN.png',
-		priceFeedId: '0xb5d0e0fa58a1f8b81498ae670ce93c872d14434b72c364885d4fa1b257cbb07a',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AMZN',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x219A8d384a10BF19b9f24cB5cC53F79Dd0e5A03D',
-		unwrappedAddress: '0x4e169cd2ab4f82640a8c65c68fed55863866fdb0',
-		legacyAddress: '0x470b06815a2e286df8c38c9c73280e0760088623',
-		symbol: 'wtTSLA',
-		decimals: 18,
-		name: 'Wrapped Tesla Inc ST0x',
-		logoUrl: '/images/TSLA.png',
-		priceFeedId: '0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:TSLA',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xFF05E1bD696900dc6A52CA35Ca61Bb1024eDa8e2',
-		unwrappedAddress: '0x013b782f402d61aa1004cca95b9f5bb402c9d5fe',
-		legacyAddress: '0xff647ad8c4b065bd746911bb9ea1a33c38c63604',
-		symbol: 'wtMSTR',
-		decimals: 18,
-		name: 'Wrapped MicroStrategy Incorporated ST0x',
-		logoUrl: '/images/MSTR.png',
-		priceFeedId: '0xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:MSTR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x1E46d7eFef64A833AFB1CD49299a7AD5B439f4d8',
-		unwrappedAddress: '0x9a507314ea2a6c5686c0d07bfecb764dcf324dff',
-		legacyAddress: '0xd0a90b7c9ae5facbe09ca4c576a3795eda53b397',
-		symbol: 'wtIAU',
-		decimals: 18,
-		name: 'Wrapped iShares Gold Trust ST0x',
-		logoUrl: '/images/ishares.png',
-		priceFeedId: '0xf703fbded84f7da4bd9ff4661b5d1ffefa8a9c90b7fa12f247edc8251efac914',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:IAU',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x5cDa0E1CA4ce2af96315f7F8963C85399c172204',
-		unwrappedAddress: '0x626757e6f50675d17fcad312e82f989ae7a23d38',
-		legacyAddress: '0xb616f8b391d1adc118fd7e4063526d5530d49b10',
-		symbol: 'wtCOIN',
-		decimals: 18,
-		name: 'Wrapped Coinbase Global Inc ST0x',
-		logoUrl: '/images/COIN.png',
-		priceFeedId: '0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:COIN',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x31C2C14134e6E3B7ef9478297F199331133Fc2d8',
-		unwrappedAddress: '0x8fdf41116f755771bfe0747d5f8c3711d5debfbb',
-		legacyAddress: '0x2289249984f1fa2ce86c4e8867e7eb819ea7df95',
-		legacySymbol: 'tSPYM', // Symbol changed from SPLG to SPYM
-		previousSymbols: ['wtSPLG', 'tSPLG'], // Historical blob storage names
-		symbol: 'wtSPYM',
-		decimals: 18,
-		name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-		logoUrl: '/images/state_street.png',
-		priceFeedId: '',
-		// priceFeedId removed — Pyth no longer supports this feed ID.
-		// Using a hardcoded fallback until a replacement feed is wired up.
-		fallbackPrice: 82.5,
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SPYM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	// wtSTOX token temporarily disabled
-	// {
-	// 	chainId: base.id,
-	// 	address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
-	// 	unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
-	// 	legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
-	// 	// legacySymbol: 'tSTOX',
-	// 	symbol: 'wtSTOX',
-	// 	decimals: 18,
-	// 	name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-	// 	logoUrl: '/images/state_street.png',
-	// 	priceFeedId: '0x54e2e127c93950de5a710100fd1cd387aba1ec8920850efdb05da5fee57d2e32',
-	// 	category: 'ST0x',
-	// 	tradingViewSymbol: 'AMEX:SPLG',
-	// 	tradingViewMarket: 'america',
-	// 	limitOrders: []
-	// },
-	{
-		chainId: base.id,
-		address: '0xEB7F3E4093C9d68253b6104FbbfF561F3eC0442F',
-		unwrappedAddress: '0x58ce5024b89b4f73c27814c0f0abbea331c99be8',
-		legacyAddress: '0x826a85de1f7b70f4c7450c0f882a6db06000ed80',
-		symbol: 'wtSIVR',
-		decimals: 18,
-		name: 'Wrapped abrdn Physical Silver Shares ETF ST0x',
-		logoUrl: '/images/abrdn.png',
-		priceFeedId: '0x0a5ee42b0f7287a777926d08bc185a6a60f42f40a9b63d78d85d4a03ee2e3737',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SIVR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x8AFba81DEc38DE0A18E2Df5E1967a7493651eebf',
-		unwrappedAddress: '0x38eb797892ed71da69bdc27a456a7c83ff813b52',
-		legacyAddress: '0x43422a9d11a6640ef0d5f65292ef8adf87cf8522',
-		symbol: 'wtCRCL',
-		decimals: 18,
-		name: 'Wrapped Circle Internet Group Inc ST0x',
-		logoUrl: '/images/CRCL.png',
-		priceFeedId: '0x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:CRCL',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x2512EC661f0bA089c275EA105E31bAD6FcFcf319',
-		unwrappedAddress: '0xfbde45df60249203b12148452fc77c3b5f811eb2',
-		legacyAddress: '0xf8fdfd6a686346d34b3143fc23072aa45c9e8386',
-		symbol: 'wtBMNR',
-		decimals: 18,
-		name: 'Wrapped Bitmine Immersion Technologies, Inc ST0x',
-		logoUrl: '/images/BMNR.png',
-		priceFeedId: '0x54e2e127c93950de5a710100fd1cd387aba1ec8920850efdb05da5fee57d2e32',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:BMNR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x82f5BAEE1076334357a34A19E04f7c282D51cE47',
-		unwrappedAddress: '0x1f17523b147ccc2a2328c0f014f6d49c479ea063',
-		legacyAddress: '0x6192539a2036c786aba3ca6a2222ff7a0f9c287e',
-		symbol: 'wtPPLT',
-		decimals: 18,
-		name: 'Wrapped abrdn Physical Platinum Shares ETF ST0x',
-		logoUrl: '/images/abrdn.png',
-		priceFeedId: '0x782410278b6c8aa2d437812281526012808404aa14c243f73fb9939eeb88d430',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:PPLT',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x823FF7Bbde2869aAe73A6CD53e7f614442836757',
-		unwrappedAddress: '0x09ee803ba675052e10a54bfc8e18c0f67793056b',
-		symbol: 'wtQQQM',
-		decimals: 18,
-		name: 'Wrapped Invesco NASDAQ 100 ETF ST0x',
-		logoUrl: '/images/invesco.png',
-		priceFeedId: '0x433b196b3b026f46f76b5e901c84c575a7280dcba0f4272edefe0529b599ad64',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:QQQM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x23ec6886b49D7ab123E9ee8e474D2fa7AB6Cbc2d',
-		unwrappedAddress: '0x0acfea6833c4a3f41bf2fbd736aa9eea547d90ee',
-		symbol: 'wtVWO',
-		decimals: 18,
-		name: 'Wrapped Vanguard Emerging Markets Stock Index Fund ST0x',
-		logoUrl: '/images/vanguard.png',
-		priceFeedId: '0x2f91d775954c0c828d4563448d253cf09df218b620825242775d878d1d5956c7',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:VWO',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x9FfF48B4535AF3765Ac9E1b164720EDc01DF8EE7',
-		unwrappedAddress: '0x323804af6f3bb463d688b854667c6870a0fc06ad',
-		symbol: 'wtARKK',
-		decimals: 18,
-		name: 'Wrapped ARK Innovation ETF ST0x',
-		logoUrl: '/images/ARKK.png',
-		priceFeedId: '0xb2fe0af6c828efefda3ffda664f919825a535aa28a0f19fc238945c7aff540b1',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:ARKK',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		// wtSGOV — iShares 0-3 Month Treasury Bond ETF. Added via st0x.registry
-		// PR #22 (ST0x-Technology/st0x.registry). This is the first ST0x wrapper
-		// expected to develop a non-1:1 wrap ratio over time (T-bill yield
-		// accrues into the vault, increasing assetsPerShare). Pyth feed wiring
-		// is upstream in rain.pyth PR #20.
-		chainId: base.id,
-		address: '0x78c31580c97101694C70022c83D570150c11e935',
-		unwrappedAddress: '0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612',
-		symbol: 'wtSGOV',
-		decimals: 18,
-		name: 'Wrapped iShares 0-3 Month Treasury Bond ETF ST0x',
-		logoUrl: '/images/ishares.png',
-		priceFeedId: '0x8d6a29bb5ed522931d711bb12c4bbf92af986936e52af582032913b5ffcbf4d5',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:SGOV',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		// wtSPCX — Space Exploration Technologies Corp (SpaceX). Deployed on Base
-		// 2026-06-10 ahead of the 2026-06-12 Nasdaq IPO (ticker SPCX, ISIN
-		// US84615Q1031). Newly listed, so Pyth has no feed yet — using a hardcoded
-		// fallbackPrice at the $135 IPO price until a real feed is wired up
-		// (mirrors the wtSPYM pattern above).
-		chainId: base.id,
-		address: '0x19F89aaEf8a93f38A974beca9776f09aB844887F',
-		unwrappedAddress: '0xc585AeB8B76c5F5e4215470A7625258e86ED7746',
-		symbol: 'wtSPCX',
-		decimals: 18,
-		name: 'Wrapped Space Exploration Technologies Corp. ST0x',
-		logoUrl: '/images/SPCX.svg',
-		priceFeedId: '',
-		fallbackPrice: 135,
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:SPCX',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x3aF952888Cd89DAD3e8AF67cf4b7E740B36829C3',
-		unwrappedAddress: '0x9a5D3cAeC90b0332b18C0B93fEF42F3F8C918289',
-		symbol: 'wtCEG',
-		decimals: 18,
-		name: 'Wrapped Constellation Energy Corporation ST0x',
-		logoUrl: '/images/CEG.png',
-		priceFeedId: '0xa541bc5c4b69961442e45e9198c7cce151ff9c2a1003f620c6d4a9785c77a4d9',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:CEG',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x1A91Df4a970EBaB1bB4AF32Eb6d10509028eE4b8',
-		unwrappedAddress: '0x96DE077262609298CD891E4Ab21bd34837dE33aB',
-		symbol: 'wtDRAM',
-		decimals: 18,
-		name: 'Wrapped Roundhill Memory ETF ST0x',
-		logoUrl: '/images/roundhill.png',
-		priceFeedId: '',
-		// priceFeedId removed — Pyth no longer supports this feed ID.
-		// Using a hardcoded fallback until a replacement feed is wired up.
-		fallbackPrice: 50,
-		category: 'ST0x',
-		tradingViewSymbol: 'CBOE:DRAM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x71C66449d2528E23514A9c197BFD55Ae9DB3B714',
-		unwrappedAddress: '0x7001e2974F775f0Fd73a3D2e5914e591f3EC3fBB',
-		symbol: 'wtTSM',
-		decimals: 18,
-		name: 'Wrapped Taiwan Semiconductor Manufacturing Company ST0x',
-		logoUrl: '/images/TSM.png',
-		priceFeedId: '0xe722560a66e4ab00522ef20a38fa2ba5d1b41f1c5404723ed895d202a7af7cc4',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:TSM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x8200c6d9AB9E02A25D7F2099244C476d99a085ef',
-		unwrappedAddress: '0x722Cb373f1871A176fb5DC3953046f2EAE22F619',
-		symbol: 'wtASML',
-		decimals: 18,
-		name: 'Wrapped ASML Holding N.V. ST0x',
-		logoUrl: '/images/ASML.png',
-		priceFeedId: '0x1a6e324589a0e355919fb1c0389edc3fdf4c46034626bd82aad4e47714cfa94f',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:ASML',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9',
-		unwrappedAddress: '0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c',
-		symbol: 'wtSKHY',
-		decimals: 18,
-		name: 'Wrapped SK hynix Inc. ADR ST0x',
-		logoUrl: '/images/SKHY.png',
-		priceFeedId: '',
-		// Pyth does not yet publish an SKHY feed. Use the $149 IPO price until one is available.
-		fallbackPrice: 149,
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:SKHY',
-		tradingViewMarket: 'america',
-		limitOrders: []
+/**
+ * Runtime ST0x token catalog hydrated from the REST API.
+ *
+ * The array identity is stable so existing consumers can keep references while
+ * remote registry updates replace its contents in place.
+ */
+export const TOKENS: CategorizedToken[] = [];
+export const TOKEN_SYMBOLS: string[] = [];
+export const TOKEN_WRAPPED_ADDRESS_SET = new Set<string>();
+export const PREVIOUS_SYMBOLS_BY_TOKEN = new Map<string, string[]>();
+
+type TokenCatalogListener = (tokens: readonly CategorizedToken[]) => void;
+const tokenCatalogListeners = new Set<TokenCatalogListener>();
+
+export function replaceTokenCatalog(tokens: readonly CategorizedToken[]): void {
+	TOKENS.splice(0, TOKENS.length, ...tokens);
+	TOKEN_SYMBOLS.splice(0, TOKEN_SYMBOLS.length, ...tokens.map((token) => token.symbol));
+	TOKEN_WRAPPED_ADDRESS_SET.clear();
+	PREVIOUS_SYMBOLS_BY_TOKEN.clear();
+	for (const token of tokens) {
+		TOKEN_WRAPPED_ADDRESS_SET.add(token.address.toLowerCase());
+		if (token.previousSymbols?.length) {
+			PREVIOUS_SYMBOLS_BY_TOKEN.set(token.symbol, token.previousSymbols);
+		}
 	}
-	// {
-	// 	chainId: base.id,
-	// 	address: '0xF4f8c66085910d583c01f3b4e44Bf731D4e2c565',
-	// 	unwrappedAddress: '0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b',
-	// 	// No legacy address - wtRKLB is a new token
-	// 	symbol: 'wtRKLB',
-	// 	decimals: 18,
-	// 	name: 'Wrapped Rocket Lab USA Inc ST0x',
-	// 	logoUrl: '/images/RKLB.png',
-	// 	priceFeedId: '0x40589e289317e4fbd997b1a267606e20a1cc7c3e4689f9e5a5992957917816c8',
-	// 	category: 'ST0x',
-	// 	tradingViewSymbol: 'NASDAQ:RKLB',
-	// 	tradingViewMarket: 'america',
-	// 	limitOrders: []
-	// }
-];
+	rebuildTokenLookups();
+	for (const listener of tokenCatalogListeners) listener(TOKENS);
+}
+
+export function onTokenCatalogChange(listener: TokenCatalogListener): () => void {
+	tokenCatalogListeners.add(listener);
+	listener(TOKENS);
+	return () => tokenCatalogListeners.delete(listener);
+}
 
 export const CRYPTO_TOKENS: CategorizedToken[] = [
 	{
@@ -495,16 +171,25 @@ export function getAllTokensByNetwork(chainId: number): CategorizedToken[] {
 	return [...getTokensByNetwork(chainId), ...getCryptoTokensByNetwork(chainId)];
 }
 
-// Address lookup maps (built once at module load)
-const tokenByWrappedAddress = new Map(TOKENS.map((t) => [t.address.toLowerCase(), t]));
+const tokenByWrappedAddress = new Map<string, CategorizedToken>();
+const tokenByUnwrappedAddress = new Map<string, CategorizedToken>();
+const tokenByLegacyAddress = new Map<string, CategorizedToken>();
 
-const tokenByUnwrappedAddress = new Map(
-	TOKENS.filter((t) => t.unwrappedAddress).map((t) => [t.unwrappedAddress!.toLowerCase(), t])
-);
+function rebuildTokenLookups(): void {
+	tokenByWrappedAddress.clear();
+	tokenByUnwrappedAddress.clear();
+	tokenByLegacyAddress.clear();
 
-const tokenByLegacyAddress = new Map(
-	TOKENS.filter((t) => t.legacyAddress).map((t) => [t.legacyAddress!.toLowerCase(), t])
-);
+	for (const token of TOKENS) {
+		tokenByWrappedAddress.set(token.address.toLowerCase(), token);
+		if (token.unwrappedAddress) {
+			tokenByUnwrappedAddress.set(token.unwrappedAddress.toLowerCase(), token);
+		}
+		if (token.legacyAddress) {
+			tokenByLegacyAddress.set(token.legacyAddress.toLowerCase(), token);
+		}
+	}
+}
 
 export function getTokenByWrappedAddress(address: string): CategorizedToken | null {
 	return tokenByWrappedAddress.get(address.toLowerCase()) ?? null;

--- a/src/lib/queries/tokens.ts
+++ b/src/lib/queries/tokens.ts
@@ -1,13 +1,17 @@
 import { browser } from '$app/environment';
 import { createQuery } from '@tanstack/svelte-query';
 import { apiGetTokens, type ApiToken } from '$lib/api/st0xApi';
-import type { CategorizedToken, TokenCategory } from '$lib/config/tokens';
+import { replaceTokenCatalog, type CategorizedToken, type TokenCategory } from '$lib/config/tokens';
 
 type ApiTokenExtensions = {
 	category?: unknown;
 	unwrappedAddress?: unknown;
 	legacyAddress?: unknown;
 	legacySymbol?: unknown;
+	previousSymbols?: unknown;
+	receiptAddress?: unknown;
+	priceFeedId?: unknown;
+	fallbackPrice?: unknown;
 	tradingViewSymbol?: unknown;
 	tradingViewMarket?: unknown;
 };
@@ -18,6 +22,15 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function asString(value: unknown): string | undefined {
 	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return undefined;
+	return value;
 }
 
 function getApiChainId(token: ApiToken): number | null {
@@ -58,13 +71,17 @@ function normalizeApiToken(token: ApiToken): CategorizedToken | null {
 		decimals: token.decimals,
 		name: token.name ?? token.label ?? token.symbol,
 		logoUrl: asString(token['logo-uri']),
-		priceFeedId: '',
+		priceFeedId: asString(extensions.priceFeedId) ?? '',
+		fallbackPrice: asNumber(extensions.fallbackPrice),
 		category,
 		tradingViewSymbol: asString(extensions.tradingViewSymbol),
 		tradingViewMarket: asString(extensions.tradingViewMarket),
 		unwrappedAddress: asString(extensions.unwrappedAddress),
 		legacyAddress: asString(extensions.legacyAddress),
 		legacySymbol: asString(extensions.legacySymbol),
+		previousSymbols: asStringArray(extensions.previousSymbols),
+		receiptAddress: asString(extensions.receiptAddress),
+		isin: asString(token.isin) ?? asString(asRecord(token.extensions)?.isin),
 		limitOrders: []
 	};
 }
@@ -73,14 +90,18 @@ export function normalizeApiTokensForNetwork(
 	apiTokens: ApiToken[],
 	chainId: number
 ): CategorizedToken[] {
+	return normalizeApiTokens(apiTokens).filter((token) => token.chainId === chainId);
+}
+
+export function normalizeApiTokens(apiTokens: ApiToken[]): CategorizedToken[] {
 	const seen = new Set<string>();
 	const result: CategorizedToken[] = [];
 
 	for (const apiToken of apiTokens) {
 		const normalized = normalizeApiToken(apiToken);
-		if (!normalized || normalized.chainId !== chainId) continue;
+		if (!normalized) continue;
 
-		const addressKey = normalized.address.toLowerCase();
+		const addressKey = `${normalized.chainId}:${normalized.address.toLowerCase()}`;
 		if (seen.has(addressKey)) continue;
 		seen.add(addressKey);
 		result.push(normalized);
@@ -115,6 +136,10 @@ export function createApiTokensQuery(chainId: number | null | undefined) {
 		retry: 2,
 		refetchOnMount: 'always',
 		refetchOnWindowFocus: true,
-		queryFn: async () => normalizeApiTokensForNetwork(await apiGetTokens(), chainId as number)
+		queryFn: async () => {
+			const tokens = normalizeApiTokensForNetwork(await apiGetTokens(), chainId as number);
+			replaceTokenCatalog(tokens.filter((token) => token.category === 'ST0x'));
+			return tokens;
+		}
 	});
 }

--- a/src/lib/server/snapshots/generator.test.ts
+++ b/src/lib/server/snapshots/generator.test.ts
@@ -47,6 +47,10 @@ vi.mock('$lib/server/kv', () => ({
 	getRewardsExcludedWalletsSet: vi.fn(async () => new Set<string>())
 }));
 
+vi.mock('$lib/server/tokenCatalog', () => ({
+	ensureServerTokenCatalog: vi.fn(async () => undefined)
+}));
+
 vi.mock('./scraper', () => ({
 	fetchAllTransfers: vi.fn(async () => []),
 	ALL_TOKEN_ADDRESSES: []

--- a/src/lib/server/snapshots/generator.ts
+++ b/src/lib/server/snapshots/generator.ts
@@ -11,6 +11,7 @@ import { networks } from '$lib/config/networks';
 import { TOKENS, getTokenAddressVariants, getTokenByAnyAddress } from '$lib/config/tokens';
 import { recordRpcAttempt, reportChainExhausted } from '$lib/server/rpcMetrics';
 import { withRetry } from '$lib/utils/retry';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
 const RPC_URLS = [networks[0].rpcUrl, ...networks[0].fallbackRpcUrls];
 
@@ -190,6 +191,7 @@ export async function generateTokenSnapshot(
 	tokenAddress: string,
 	blockNumber: number
 ): Promise<BlockSnapshot> {
+	await ensureServerTokenCatalog();
 	const normalizedToken = tokenAddress.toLowerCase();
 
 	// Find the parent token config to get all address variants
@@ -236,6 +238,7 @@ export async function generateTokenSnapshot(
  * wrapped, unwrapped, and legacy addresses.
  */
 export async function generateAllTokenSnapshots(blockNumber: number): Promise<BlockSnapshot[]> {
+	await ensureServerTokenCatalog();
 	// Get block timestamp first (needed for Pyth price lookup)
 	const timestamp = await getBlockTimestamp(blockNumber);
 

--- a/src/lib/server/snapshots/pyth.ts
+++ b/src/lib/server/snapshots/pyth.ts
@@ -211,7 +211,8 @@ export async function fetchPythPricesAtTimestamp(
 		}
 
 		for (const { address, token } of fallbackTokenAddresses) {
-			const price = monitorPrice ?? token.fallbackPrice!;
+			const price =
+				token.symbol === 'wtSPYM' ? monitorPrice ?? token.fallbackPrice! : token.fallbackPrice!;
 			results.set(address.toLowerCase(), {
 				tokenAddress: address.toLowerCase(),
 				tokenSymbol: token.symbol,

--- a/src/lib/server/snapshots/scraper.test.ts
+++ b/src/lib/server/snapshots/scraper.test.ts
@@ -38,8 +38,11 @@ vi.mock('$lib/config/networks', () => ({
 }));
 
 vi.mock('$lib/config/tokens', () => ({
-	TOKENS: [{ address: '0xVAULT' }],
-	getAllTokenAddressesFlat: () => ['0xvault']
+	getTokenAddressVariants: (token: { address: string }) => [token.address.toLowerCase()],
+	onTokenCatalogChange: (listener: (tokens: { address: string }[]) => void) => {
+		listener([{ address: '0xVAULT' }]);
+		return () => undefined;
+	}
 }));
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {

--- a/src/lib/server/snapshots/scraper.ts
+++ b/src/lib/server/snapshots/scraper.ts
@@ -2,7 +2,7 @@
 // Modeled after albion.rewards/src/processor.ts
 
 import { networks } from '$lib/config/networks';
-import { TOKENS, getAllTokenAddressesFlat } from '$lib/config/tokens';
+import { getTokenAddressVariants, onTokenCatalogChange } from '$lib/config/tokens';
 import type { Transfer, SubgraphTransfer, SubgraphWrappedTokenTransfer } from './types';
 
 const BATCH_SIZE = 1000;
@@ -12,10 +12,23 @@ const SFT_SUBGRAPH_URL = networks[0].subgraph_url;
 const SFT_SUBGRAPH_URLS_LEGACY = networks[0].subgraph_urls_legacy ?? [];
 
 // Get all token addresses from config (lowercase)
-export const TOKEN_ADDRESSES = TOKENS.map((t) => t.address.toLowerCase());
+export const TOKEN_ADDRESSES: string[] = [];
 
 // All token addresses including unwrapped and legacy (for expanded snapshots)
-export const ALL_TOKEN_ADDRESSES = getAllTokenAddressesFlat();
+export const ALL_TOKEN_ADDRESSES: string[] = [];
+
+onTokenCatalogChange((tokens) => {
+	TOKEN_ADDRESSES.splice(
+		0,
+		TOKEN_ADDRESSES.length,
+		...tokens.map((token) => token.address.toLowerCase())
+	);
+	ALL_TOKEN_ADDRESSES.splice(
+		0,
+		ALL_TOKEN_ADDRESSES.length,
+		...tokens.flatMap((token) => getTokenAddressVariants(token))
+	);
+});
 
 /**
  * Fetch transfers from a specific SFT subgraph up to a specific block

--- a/src/lib/server/snapshots/vaults.ts
+++ b/src/lib/server/snapshots/vaults.ts
@@ -2,7 +2,7 @@
 // Used to attribute orderbook holdings to vault owners
 
 import { networks } from '$lib/config/networks';
-import { TOKENS } from '$lib/config/tokens';
+import { onTokenCatalogChange } from '$lib/config/tokens';
 import { parseFloatHex } from '$lib/utils/tokenMath';
 
 const BATCH_SIZE = 1000;
@@ -14,7 +14,15 @@ const ORDERBOOK_SUBGRAPH_URLS = [
 ].filter(Boolean);
 
 // Get token addresses for filtering
-const TOKEN_ADDRESSES = TOKENS.map((t) => t.address.toLowerCase());
+const TOKEN_ADDRESSES: string[] = [];
+
+onTokenCatalogChange((tokens) => {
+	TOKEN_ADDRESSES.splice(
+		0,
+		TOKEN_ADDRESSES.length,
+		...tokens.map((token) => token.address.toLowerCase())
+	);
+});
 
 interface SubgraphVault {
 	id: string;

--- a/src/lib/server/tokenCatalog.ts
+++ b/src/lib/server/tokenCatalog.ts
@@ -1,0 +1,70 @@
+import { env } from '$env/dynamic/private';
+import type { ApiToken } from '$lib/api/st0xApi';
+import { replaceTokenCatalog, type CategorizedToken } from '$lib/config/tokens';
+import { normalizeApiTokens } from '$lib/queries/tokens';
+
+const CACHE_TTL_MS = 60_000;
+
+let cachedTokens: CategorizedToken[] = [];
+let cacheExpiresAt = 0;
+let inFlight: Promise<CategorizedToken[]> | null = null;
+
+function getApiConfig(): { url: string; authorization: string } {
+	const url = env.ST0X_API_URL?.replace(/\/+$/, '');
+	const key = env.ST0X_API_KEY;
+	const secret = env.ST0X_API_SECRET;
+	if (!url || !key || !secret) {
+		throw new Error('ST0X REST API token catalog is not configured');
+	}
+
+	return {
+		url,
+		authorization: `Basic ${btoa(`${key}:${secret}`)}`
+	};
+}
+
+async function fetchTokenCatalog(): Promise<CategorizedToken[]> {
+	const config = getApiConfig();
+	const response = await fetch(`${config.url}/v1/tokens`, {
+		headers: {
+			Accept: 'application/json',
+			Authorization: config.authorization
+		}
+	});
+
+	if (!response.ok) {
+		throw new Error(`Token catalog request failed with HTTP ${response.status}`);
+	}
+
+	const tokens = normalizeApiTokens((await response.json()) as ApiToken[]);
+	const st0xTokens = tokens.filter((token) => token.category === 'ST0x');
+	if (st0xTokens.length === 0) {
+		throw new Error('Token catalog response did not contain any ST0x tokens');
+	}
+
+	replaceTokenCatalog(st0xTokens);
+	cachedTokens = tokens;
+	cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+	return tokens;
+}
+
+export async function getServerTokenCatalog(): Promise<CategorizedToken[]> {
+	if (cachedTokens.length > 0 && Date.now() < cacheExpiresAt) return cachedTokens;
+	if (!inFlight) {
+		inFlight = fetchTokenCatalog()
+			.catch((error) => {
+				if (cachedTokens.length === 0) throw error;
+				console.warn('[token-catalog] Refresh failed; serving stale catalog:', error);
+				cacheExpiresAt = Date.now() + 10_000;
+				return cachedTokens;
+			})
+			.finally(() => {
+				inFlight = null;
+			});
+	}
+	return inFlight;
+}
+
+export async function ensureServerTokenCatalog(): Promise<void> {
+	await getServerTokenCatalog();
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,6 @@
+import type { LayoutServerLoad } from './$types';
+import { getServerTokenCatalog } from '$lib/server/tokenCatalog';
+
+export const load: LayoutServerLoad = async () => ({
+	tokenCatalog: await getServerTokenCatalog()
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,21 @@
 	import { queryClient } from '$lib/clients/queryClient';
 	import { page } from '$app/stores';
 	import { env as publicEnv } from '$env/dynamic/public';
+	import { replaceTokenCatalog, type CategorizedToken } from '$lib/config/tokens';
+
+	export let data: { tokenCatalog?: CategorizedToken[] };
+
+	function hydrateTokenCatalog(tokens: CategorizedToken[]): void {
+		replaceTokenCatalog(tokens.filter((token) => token.category === 'ST0x'));
+		for (const chainId of new Set(tokens.map((token) => token.chainId))) {
+			queryClient.setQueryData(
+				['st0xApiTokens', chainId],
+				tokens.filter((token) => token.chainId === chainId)
+			);
+		}
+	}
+
+	$: hydrateTokenCatalog(data.tokenCatalog ?? []);
 
 	// Site-wide SEO defaults. Pages override the title via their own <svelte:head>
 	// (Svelte keeps the last <title>), or by returning `title`/`description` from a

--- a/src/routes/api/admin/nansen/+server.ts
+++ b/src/routes/api/admin/nansen/+server.ts
@@ -6,14 +6,15 @@ import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/adminAuth';
 import { listAccessCodes, getWalletsByCode } from '$lib/server/accessCodes';
 import { networks } from '$lib/config/networks';
-import { TOKENS, getPaymentTokensForNetwork } from '$lib/config/tokens';
+import { TOKEN_WRAPPED_ADDRESS_SET, getPaymentTokensForNetwork } from '$lib/config/tokens';
 import { toDecimal, isPaymentToken } from '$lib/utils/tokenMath';
 import { getWalletTiers, type NansenTier } from '$lib/server/nansenTiers';
 import { cacheGet, cacheSet, CACHE_TTL } from '$lib/server/cache';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
 const paymentTokens = getPaymentTokensForNetwork(8453);
 const usdc = paymentTokens[0];
-const validTokenAddresses = new Set(TOKENS.map((t) => t.address.toLowerCase()));
+const validTokenAddresses = TOKEN_WRAPPED_ADDRESS_SET;
 
 interface Trade {
 	id: string;
@@ -203,6 +204,7 @@ function processTrades(
 export const GET: RequestHandler = async ({ cookies, request }) => {
 	const guardResponse = await requireAdmin(request, cookies, 'admin-nansen');
 	if (guardResponse) return guardResponse;
+	await ensureServerTokenCatalog();
 
 	try {
 		// STEP 1: Get Nansen wallets FIRST (fast KV lookup)

--- a/src/routes/api/admin/referrals/statement/+server.ts
+++ b/src/routes/api/admin/referrals/statement/+server.ts
@@ -5,15 +5,14 @@ import { requireAdmin } from '$lib/server/adminAuth';
 import { kvGet, KV_KEYS, type SnapshotBlockRecord } from '$lib/server/kv';
 import { getWalletsByCode } from '$lib/server/accessCodes';
 import { list } from '@vercel/blob';
-import { TOKENS } from '$lib/config/tokens';
+import { PREVIOUS_SYMBOLS_BY_TOKEN, TOKEN_SYMBOLS } from '$lib/config/tokens';
 import type { BlockSnapshot } from '$lib/server/snapshots/types';
 import { env } from '$env/dynamic/private';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
 const POINTS_PER_DOLLAR = 100;
-const tokenSymbols = TOKENS.map((t) => t.symbol);
-const previousSymbolsByToken = new Map<string, string[]>(
-	TOKENS.filter((t) => t.previousSymbols?.length).map((t) => [t.symbol, t.previousSymbols!])
-);
+const tokenSymbols = TOKEN_SYMBOLS;
+const previousSymbolsByToken = PREVIOUS_SYMBOLS_BY_TOKEN;
 
 async function fetchSnapshot(
 	tokenSymbol: string,
@@ -72,6 +71,7 @@ interface SnapshotData {
 export const GET: RequestHandler = async ({ url, cookies, request }) => {
 	const guardResponse = await requireAdmin(request, cookies, 'admin-referrals-statement');
 	if (guardResponse) return guardResponse;
+	await ensureServerTokenCatalog();
 
 	const code = url.searchParams.get('code');
 	const month = url.searchParams.get('month');

--- a/src/routes/api/admin/swap-snapshot/+server.ts
+++ b/src/routes/api/admin/swap-snapshot/+server.ts
@@ -3,6 +3,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/adminAuth';
 import { SWAP_ORDER_HASHES, TOKEN_MIGRATION_MAPPINGS } from '$lib/config/tokenMigration';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 import { networks } from '$lib/config/networks';
 import { ORDERBOOK_ADDRESS, SYSTEM_EXCLUDED_ADDRESSES } from '$lib/config/snapshots';
 import { getTeamWalletsSet } from '$lib/server/kv';
@@ -316,6 +317,7 @@ async function fetchLegacyHolders(legacyAddresses: string[]): Promise<LegacyBala
 export const GET: RequestHandler = async ({ cookies, request }) => {
 	const guardResponse = await requireAdmin(request, cookies, 'admin-swap-snapshot');
 	if (guardResponse) return guardResponse;
+	await ensureServerTokenCatalog();
 
 	try {
 		// Get all swap order hashes

--- a/src/routes/api/admin/tvl/+server.ts
+++ b/src/routes/api/admin/tvl/+server.ts
@@ -13,15 +13,14 @@ import {
 } from '$lib/server/kv';
 import { list } from '@vercel/blob';
 import type { BlockSnapshot } from '$lib/server/snapshots/types';
-import { TOKENS } from '$lib/config/tokens';
+import { PREVIOUS_SYMBOLS_BY_TOKEN, TOKEN_SYMBOLS } from '$lib/config/tokens';
 import { env } from '$env/dynamic/private';
 import { requireAdmin } from '$lib/server/adminAuth';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
 // Build token symbol map with fallback names for renamed tokens
-const tokenSymbols = TOKENS.map((t) => t.symbol);
-const previousSymbolsByToken = new Map<string, string[]>(
-	TOKENS.filter((t) => t.previousSymbols?.length).map((t) => [t.symbol, t.previousSymbols!])
-);
+const tokenSymbols = TOKEN_SYMBOLS;
+const previousSymbolsByToken = PREVIOUS_SYMBOLS_BY_TOKEN;
 
 interface WalletTvlEntry {
 	address: string;
@@ -374,6 +373,7 @@ async function calculateSimpleTvlAtBlock(
 export const GET: RequestHandler = async ({ url, cookies, request }) => {
 	const guardResponse = await requireAdmin(request, cookies, 'admin-tvl');
 	if (guardResponse) return guardResponse;
+	await ensureServerTokenCatalog();
 
 	try {
 		const limitParam = url.searchParams.get('limit');

--- a/src/routes/api/admin/wallet/statement/+server.ts
+++ b/src/routes/api/admin/wallet/statement/+server.ts
@@ -4,15 +4,14 @@ import type { RequestHandler } from './$types';
 import { requireAdmin } from '$lib/server/adminAuth';
 import { kvGet, KV_KEYS, type SnapshotBlockRecord } from '$lib/server/kv';
 import { list } from '@vercel/blob';
-import { TOKENS } from '$lib/config/tokens';
+import { PREVIOUS_SYMBOLS_BY_TOKEN, TOKEN_SYMBOLS } from '$lib/config/tokens';
 import type { BlockSnapshot } from '$lib/server/snapshots/types';
 import { env } from '$env/dynamic/private';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
 const POINTS_PER_DOLLAR = 100;
-const tokenSymbols = TOKENS.map((t) => t.symbol);
-const previousSymbolsByToken = new Map<string, string[]>(
-	TOKENS.filter((t) => t.previousSymbols?.length).map((t) => [t.symbol, t.previousSymbols!])
-);
+const tokenSymbols = TOKEN_SYMBOLS;
+const previousSymbolsByToken = PREVIOUS_SYMBOLS_BY_TOKEN;
 
 async function fetchSnapshot(
 	tokenSymbol: string,
@@ -64,6 +63,7 @@ interface SnapshotData {
 export const GET: RequestHandler = async ({ url, cookies, request }) => {
 	const guardResponse = await requireAdmin(request, cookies, 'admin-wallet-statement');
 	if (guardResponse) return guardResponse;
+	await ensureServerTokenCatalog();
 
 	const wallet = url.searchParams.get('wallet');
 	const month = url.searchParams.get('month');

--- a/src/routes/api/public/trade-activity/+server.ts
+++ b/src/routes/api/public/trade-activity/+server.ts
@@ -12,6 +12,7 @@ import { withConditionalCache, CACHE_KEYS, CACHE_TTL } from '$lib/server/cache';
 import { networks, TOKENS, CRYPTO_TOKENS } from '$lib/config/network';
 import type { Network } from '$lib/config/network';
 import { normalizeAddress } from '$lib/utils/tokenMath';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 import { bucketTimestamp, TRADE_WINDOW_BUCKET_SECONDS } from '$lib/utils/timeWindow';
 import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
 import type { ApiTradeByAddress, ApiTradesByAddressResponse } from '$lib/api/st0xApi';
@@ -298,6 +299,7 @@ async function computeTradeActivity(): Promise<PublicTradeActivityResponse> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
+	await ensureServerTokenCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 

--- a/src/routes/api/public/tvl/+server.ts
+++ b/src/routes/api/public/tvl/+server.ts
@@ -6,13 +6,12 @@ import { withConditionalCache, CACHE_KEYS, CACHE_TTL } from '$lib/server/cache';
 import { kvGet, KV_KEYS, type SnapshotBlockRecord } from '$lib/server/kv';
 import { list } from '@vercel/blob';
 import type { BlockSnapshot } from '$lib/server/snapshots/types';
-import { TOKENS } from '$lib/config/tokens';
+import { PREVIOUS_SYMBOLS_BY_TOKEN, TOKEN_SYMBOLS } from '$lib/config/tokens';
 import { env } from '$env/dynamic/private';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
-const tokenSymbols = TOKENS.map((t) => t.symbol);
-const previousSymbolsByToken = new Map<string, string[]>(
-	TOKENS.filter((t) => t.previousSymbols?.length).map((t) => [t.symbol, t.previousSymbols!])
-);
+const tokenSymbols = TOKEN_SYMBOLS;
+const previousSymbolsByToken = PREVIOUS_SYMBOLS_BY_TOKEN;
 
 interface PublicTvlResponse {
 	success: boolean;
@@ -99,6 +98,7 @@ async function computeAggregateTvl(): Promise<PublicTvlResponse> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
+	await ensureServerTokenCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 

--- a/src/routes/api/snapshots/get/+server.ts
+++ b/src/routes/api/snapshots/get/+server.ts
@@ -3,42 +3,47 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { list } from '@vercel/blob';
 import { env } from '$env/dynamic/private';
-import { TOKENS } from '$lib/config/tokens';
+import { TOKENS, onTokenCatalogChange } from '$lib/config/tokens';
 import { TOKEN_MIGRATION_MAPPINGS } from '$lib/config/tokenMigration';
+import { ensureServerTokenCatalog } from '$lib/server/tokenCatalog';
 
-const LEGACY_BY_WRAPPED = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.newToken.symbol.toLowerCase(), m.oldToken.symbol])
-);
-const WRAPPED_BY_LEGACY = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.oldToken.symbol.toLowerCase(), m.newToken.symbol])
-);
-const LEGACY_SYMBOLS = new Set([
-	...TOKEN_MIGRATION_MAPPINGS.map((m) => m.oldToken.symbol.toLowerCase()),
-	...TOKENS.flatMap((t) => t.previousSymbols ?? []).map((s) => s.toLowerCase())
-]);
+const LEGACY_BY_WRAPPED = new Map<string, string>();
+const WRAPPED_BY_LEGACY = new Map<string, string>();
+const LEGACY_SYMBOLS = new Set<string>();
 
 // Build a map from current/legacy symbols to their historical (previous) symbols
 // e.g., 'wtspym' -> ['wtSPLG', 'tSPLG']
 const PREVIOUS_SYMBOLS_BY_CURRENT = new Map<string, string[]>();
-for (const t of TOKENS) {
-	if (t.previousSymbols?.length) {
-		PREVIOUS_SYMBOLS_BY_CURRENT.set(t.symbol.toLowerCase(), t.previousSymbols);
-		// Also map the legacy symbol to previous symbols
-		if (t.legacySymbol) {
-			PREVIOUS_SYMBOLS_BY_CURRENT.set(t.legacySymbol.toLowerCase(), t.previousSymbols);
-		}
-	}
-}
 
 // Reverse map: previous symbol -> canonical (current wrapped) symbol
 const CANONICAL_BY_PREVIOUS = new Map<string, string>();
-for (const t of TOKENS) {
-	if (t.previousSymbols?.length) {
-		for (const prev of t.previousSymbols) {
-			CANONICAL_BY_PREVIOUS.set(prev.toLowerCase(), t.symbol);
+
+onTokenCatalogChange((tokens) => {
+	LEGACY_BY_WRAPPED.clear();
+	WRAPPED_BY_LEGACY.clear();
+	LEGACY_SYMBOLS.clear();
+	PREVIOUS_SYMBOLS_BY_CURRENT.clear();
+	CANONICAL_BY_PREVIOUS.clear();
+
+	for (const mapping of TOKEN_MIGRATION_MAPPINGS) {
+		LEGACY_BY_WRAPPED.set(mapping.newToken.symbol.toLowerCase(), mapping.oldToken.symbol);
+		WRAPPED_BY_LEGACY.set(mapping.oldToken.symbol.toLowerCase(), mapping.newToken.symbol);
+		LEGACY_SYMBOLS.add(mapping.oldToken.symbol.toLowerCase());
+	}
+
+	for (const token of tokens) {
+		for (const previousSymbol of token.previousSymbols ?? []) {
+			LEGACY_SYMBOLS.add(previousSymbol.toLowerCase());
+			CANONICAL_BY_PREVIOUS.set(previousSymbol.toLowerCase(), token.symbol);
+		}
+		if (token.previousSymbols?.length) {
+			PREVIOUS_SYMBOLS_BY_CURRENT.set(token.symbol.toLowerCase(), token.previousSymbols);
+			if (token.legacySymbol) {
+				PREVIOUS_SYMBOLS_BY_CURRENT.set(token.legacySymbol.toLowerCase(), token.previousSymbols);
+			}
 		}
 	}
-}
+});
 
 function uniqueSymbols(symbols: string[]): string[] {
 	const seen = new Set<string>();
@@ -92,6 +97,7 @@ function getAllSnapshotTokenSymbols(): string[] {
 }
 
 export const GET: RequestHandler = async ({ url }) => {
+	await ensureServerTokenCatalog();
 	// Check if Blob token is available (required for Vercel Blob storage)
 	if (!env.BLOB_READ_WRITE_TOKEN) {
 		return json(

--- a/tests/fixtures/st0xTokenCatalog.ts
+++ b/tests/fixtures/st0xTokenCatalog.ts
@@ -1,0 +1,17 @@
+import type { CategorizedToken } from '../../src/lib/config/tokens';
+
+const symbols = ['IAU', 'NVDA', 'AMZN', 'TSLA', 'MSTR', 'COIN', 'SPYM'];
+
+export const TEST_ST0X_TOKENS: CategorizedToken[] = symbols.map((symbol, index) => ({
+	chainId: 8453,
+	address: `0x${String(index + 1).padStart(40, '0')}`,
+	unwrappedAddress: `0x${String(index + 101).padStart(40, '0')}`,
+	symbol: `wt${symbol}`,
+	decimals: 18,
+	name: `Wrapped ${symbol} ST0x`,
+	logoUrl: `https://example.com/${symbol}.png`,
+	priceFeedId: `0x${String(index + 1).padStart(64, '0')}`,
+	category: 'ST0x',
+	tradingViewSymbol: `NASDAQ:${symbol}`,
+	tradingViewMarket: 'america'
+}));

--- a/tests/lib/config/tokenCatalog.test.ts
+++ b/tests/lib/config/tokenCatalog.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	PREVIOUS_SYMBOLS_BY_TOKEN,
+	TOKEN_SYMBOLS,
+	TOKENS,
+	getTokenByAnyAddress,
+	replaceTokenCatalog,
+	type CategorizedToken
+} from '../../../src/lib/config/tokens';
+import { TOKEN_MIGRATION_MAPPINGS } from '../../../src/lib/config/tokenMigration';
+import { TOKEN_WRAPPING_MAPPINGS } from '../../../src/lib/config/tokenWrapping';
+
+function token(overrides: Partial<CategorizedToken> = {}): CategorizedToken {
+	return {
+		chainId: 8453,
+		address: '0x0000000000000000000000000000000000000001',
+		unwrappedAddress: '0x0000000000000000000000000000000000000002',
+		legacyAddress: '0x0000000000000000000000000000000000000003',
+		symbol: 'wtTEST',
+		legacySymbol: 'tTEST',
+		previousSymbols: ['wtOLD'],
+		decimals: 18,
+		name: 'Wrapped Test ST0x',
+		priceFeedId: '0xfeed',
+		category: 'ST0x',
+		...overrides
+	};
+}
+
+describe('runtime token catalog', () => {
+	afterEach(() => replaceTokenCatalog([]));
+
+	it('rebuilds lookups, wrapping mappings, and migration mappings in place', () => {
+		replaceTokenCatalog([token()]);
+
+		expect(TOKENS.map((item) => item.symbol)).toEqual(['wtTEST']);
+		expect(TOKEN_SYMBOLS).toEqual(['wtTEST']);
+		expect(PREVIOUS_SYMBOLS_BY_TOKEN.get('wtTEST')).toEqual(['wtOLD']);
+		expect(getTokenByAnyAddress('0x0000000000000000000000000000000000000002')?.symbol).toBe(
+			'wtTEST'
+		);
+		expect(TOKEN_WRAPPING_MAPPINGS).toHaveLength(1);
+		expect(TOKEN_MIGRATION_MAPPINGS).toHaveLength(1);
+
+		replaceTokenCatalog([
+			token({
+				address: '0x0000000000000000000000000000000000000004',
+				unwrappedAddress: '0x0000000000000000000000000000000000000005',
+				legacyAddress: undefined,
+				symbol: 'wtNEXT',
+				previousSymbols: undefined
+			})
+		]);
+
+		expect(getTokenByAnyAddress('0x0000000000000000000000000000000000000001')).toBeNull();
+		expect(TOKEN_WRAPPING_MAPPINGS[0]?.wrappedToken.symbol).toBe('wtNEXT');
+		expect(TOKEN_MIGRATION_MAPPINGS).toHaveLength(0);
+	});
+});

--- a/tests/lib/network.test.ts
+++ b/tests/lib/network.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect } from 'vitest';
+import { replaceTokenCatalog } from '$lib/config/tokens';
+import { TEST_ST0X_TOKENS } from '../fixtures/st0xTokenCatalog';
 import {
 	getNetworkById,
 	getNetworkByChainId,
@@ -15,6 +17,8 @@ import {
 	TOKENS,
 	CRYPTO_TOKENS
 } from '$lib/config/network';
+
+replaceTokenCatalog(TEST_ST0X_TOKENS);
 
 describe('network', () => {
 	describe('getNetworkById', () => {

--- a/tests/lib/queries/tokens.test.ts
+++ b/tests/lib/queries/tokens.test.ts
@@ -76,6 +76,33 @@ describe('normalizeApiTokensForNetwork', () => {
 		expect(tokens[0].legacyAddress).toBeUndefined();
 	});
 
+	it('normalizes remote pricing and historical metadata', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({
+					symbol: 'wtSPYM',
+					isin: 'US78464A8541',
+					extensions: {
+						category: 'ST0x',
+						priceFeedId: '0xfeed',
+						fallbackPrice: 82.5,
+						previousSymbols: ['wtSPLG', 'tSPLG'],
+						receiptAddress: '0x0000000000000000000000000000000000000002'
+					}
+				})
+			],
+			8453
+		);
+
+		expect(tokens[0]).toMatchObject({
+			priceFeedId: '0xfeed',
+			fallbackPrice: 82.5,
+			previousSymbols: ['wtSPLG', 'tSPLG'],
+			receiptAddress: '0x0000000000000000000000000000000000000002',
+			isin: 'US78464A8541'
+		});
+	});
+
 	it('deduplicates API tokens by address', () => {
 		const tokens = normalizeApiTokensForNetwork(
 			[

--- a/tests/lib/server/snapshots/pyth.test.ts
+++ b/tests/lib/server/snapshots/pyth.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fallbackTokens = new Map([
+	[
+		'0xspym',
+		{
+			address: '0xspym',
+			symbol: 'wtSPYM',
+			priceFeedId: '',
+			fallbackPrice: 82.5
+		}
+	],
+	[
+		'0xdram',
+		{
+			address: '0xdram',
+			symbol: 'wtDRAM',
+			priceFeedId: '',
+			fallbackPrice: 50
+		}
+	]
+]);
+
+vi.mock('$lib/config/tokens', () => ({
+	getTokenByAnyAddress: (address: string) => fallbackTokens.get(address.toLowerCase()) ?? null
+}));
+
+vi.mock('$lib/server/snapshots/marketHours', () => ({
+	getPriceTimestamp: (timestamp: number) => timestamp
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+	env: { LIQUIDITY_MONITOR_URL: 'https://liquidity-monitor.example' }
+}));
+
+describe('fetchPythPricesAtTimestamp fallback pricing', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ price: 99 }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					})
+			)
+		);
+	});
+
+	it('uses the SPYM monitor only for SPYM and preserves other token fallbacks', async () => {
+		const { fetchPythPricesAtTimestamp } = await import(
+			'../../../../src/lib/server/snapshots/pyth'
+		);
+		const result = await fetchPythPricesAtTimestamp(1_700_000_000, ['0xspym', '0xdram']);
+
+		expect(result.prices.get('0xspym')?.price).toBe(99);
+		expect(result.prices.get('0xdram')?.price).toBe(50);
+	});
+});

--- a/tests/lib/transactionStore.test.ts
+++ b/tests/lib/transactionStore.test.ts
@@ -5,8 +5,10 @@ import { readContract, sendTransaction, waitForTransactionReceipt, estimateGas }
 import {
 	TOKENS,
 	DEFAULT_PAYMENT_TOKENS,
-	getDefaultPaymentTokenForNetwork
+	getDefaultPaymentTokenForNetwork,
+	replaceTokenCatalog
 } from '$lib/config/network';
+import { TEST_ST0X_TOKENS } from '../fixtures/st0xTokenCatalog';
 import { rainlangConfirmationModal, currentNetwork, reviewStrategyOnDeploy } from '$lib/stores';
 
 const STOXs = TOKENS;
@@ -204,6 +206,7 @@ describe('transactionStore tests', () => {
 	let mockGetAddOrdersForTransaction: ReturnType<typeof vi.fn>;
 
 	beforeEach(async () => {
+		replaceTokenCatalog(TEST_ST0X_TOKENS);
 		vi.clearAllMocks();
 		transactionStore.reset();
 


### PR DESCRIPTION
## Chained PRs

- Parent: #220
- Registry dependency: ST0x-Technology/st0x.registry#33, stacked on ST0x-Technology/st0x.registry#21
- Deploy the enriched registry artifact to the REST API before deploying this PR.

## Motivation

The webapp discovers supported tokens through `/v1/tokens`, but pricing, wrapping, migration, snapshot, and reporting code still depends on a duplicated hardcoded ST0x `TOKENS` catalog. Every token launch therefore requires both a registry change and a webapp release.

## Solution

- Remove all hardcoded ST0x token entries from the webapp.
- Normalize registry-provided Pyth feed IDs, fallback prices, historical symbols, receipt addresses, and ISINs from `/v1/tokens`.
- Load and cache the token catalog server-side, hydrate it into the root layout, and seed the client query cache.
- Keep a stable runtime catalog identity while rebuilding address lookups, wrapping mappings, migration mappings, snapshot address lists, TVL symbols, and reporting maps whenever remote data refreshes.
- Ensure token-dependent server operations load the API catalog before use and serve the last successful catalog if a refresh temporarily fails.
- Restrict the liquidity-monitor SPYM price to wtSPYM so other fallback-priced tokens retain their own registry values.
- Replace production-token test assumptions with explicit API-shaped fixtures.

After this migration, adding an ST0x token requires a registry update and API registry reload, but no webapp token-list edit.

## Checks

- [x] `npm run check` — 0 errors and 0 warnings
- [x] `npm run lint-check`
- [x] `npm run format-check`
- [x] `nix develop -c npm test -- --run` — 72 files passed; 784 tests passed, 1 skipped
- [x] Production build completed in the repository's Nix Node environment
- [x] `git diff --check`
