### PR TITLE
fix(prices): surface configured fallback token prices

### DIFF
--- a/src/lib/api/pyth.ts
+++ b/src/lib/api/pyth.ts
@@ -28,6 +28,7 @@ type PricePoint = {
 
 type TokenWithMarket = PythToken & {
 	tradingViewSymbol?: string;
+	fallbackPrice?: number;
 };
 
 const logReference = (tag: string, payload?: unknown) => {
@@ -142,21 +143,24 @@ export async function getPythQuotes(
 	tokens: TokenWithMarket[],
 	network?: Network
 ): Promise<TradingViewQuote[]> {
-	const tokensWithFeed = tokens.filter((token) => token.priceFeedId);
-	if (!tokensWithFeed.length) return [];
+	const tokensWithPriceSource = tokens.filter(
+		(token) => token.priceFeedId || typeof token.fallbackPrice === 'number'
+	);
+	if (!tokensWithPriceSource.length) return [];
 
 	const snapshots = await (network
-		? resolveNetworkSnapshots(tokensWithFeed, network.id)
-		: getOracleSnapshots(tokensWithFeed));
+		? resolveNetworkSnapshots(tokensWithPriceSource, network.id)
+		: getOracleSnapshots(tokensWithPriceSource));
 	logReference('pyth-prices-fetched', { count: snapshots.length });
 
 	const snapshotMap = new Map(
 		snapshots.map((snapshot) => [normaliseFeedId(snapshot.feedId), snapshot])
 	);
 
-	const results = tokensWithFeed.map((token) => {
-		const feedId = normaliseFeedId(token.priceFeedId);
-		const latest = snapshotMap.get(feedId);
+	const results = tokensWithPriceSource.map((token) => {
+		const feedId = token.priceFeedId ? normaliseFeedId(token.priceFeedId) : '';
+		const latest = feedId ? snapshotMap.get(feedId) : undefined;
+		const fallbackPrice = typeof token.fallbackPrice === 'number' ? token.fallbackPrice : null;
 		if (latest?.publishTime === null) {
 			logReference('latest-missing-publish-time', { feedId, latestPrice: latest?.price });
 		}
@@ -165,7 +169,7 @@ export async function getPythQuotes(
 		}
 		return {
 			symbol: token.tradingViewSymbol ?? token.symbol ?? null,
-			close: latest?.price ?? null,
+			close: latest?.price ?? fallbackPrice,
 			open: null,
 			high: null,
 			low: null,
@@ -193,23 +197,38 @@ export interface OracleSnapshot {
 
 export async function getOracleSnapshots(tokens: TokenWithMarket[]): Promise<OracleSnapshot[]> {
 	const tokensWithFeed = tokens.filter((token) => token.priceFeedId);
-	if (!tokensWithFeed.length) return [];
-
 	const feedIds = tokensWithFeed.map((token) => token.priceFeedId);
-	const latestPrices = await fetchLatestBatch(feedIds);
+	const latestPrices = feedIds.length
+		? await fetchLatestBatch(feedIds)
+		: new Map<string, PricePoint>();
 
-	return tokensWithFeed.map((token) => {
+	return tokens.flatMap((token) => {
+		if (!token.priceFeedId && typeof token.fallbackPrice === 'number') {
+			return [
+				{
+					feedId: '',
+					price: token.fallbackPrice,
+					confidence: 0,
+					publishTime: null,
+					token
+				}
+			];
+		}
+		if (!token.priceFeedId) return [];
+
 		const feedId = normaliseFeedId(token.priceFeedId);
 		const latest =
 			latestPrices.get(feedId) ??
 			({ price: null, confidence: null, publishTime: null } satisfies PricePoint);
-		return {
-			feedId,
-			price: latest.price,
-			confidence: latest.confidence,
-			publishTime: latest.publishTime,
-			token
-		};
+		return [
+			{
+				feedId,
+				price: latest.price,
+				confidence: latest.confidence,
+				publishTime: latest.publishTime,
+				token
+			}
+		];
 	});
 }
 

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -306,9 +306,8 @@ export const TOKENS: CategorizedToken[] = [
 	{
 		// wtSPCX — Space Exploration Technologies Corp (SpaceX). Deployed on Base
 		// 2026-06-10 ahead of the 2026-06-12 Nasdaq IPO (ticker SPCX, ISIN
-		// US84615Q1031). Newly listed, so Pyth has no feed yet — using a hardcoded
-		// fallbackPrice at the $135 IPO price until a real feed is wired up
-		// (mirrors the wtSPYM pattern above).
+		// US84615Q1031). Pyth has no feed yet, so use TradingView's latest close
+		// observed on 2026-07-13 until a real feed is wired up.
 		chainId: base.id,
 		address: '0x19F89aaEf8a93f38A974beca9776f09aB844887F',
 		unwrappedAddress: '0xc585AeB8B76c5F5e4215470A7625258e86ED7746',
@@ -317,7 +316,7 @@ export const TOKENS: CategorizedToken[] = [
 		name: 'Wrapped Space Exploration Technologies Corp. ST0x',
 		logoUrl: '/images/SPCX.svg',
 		priceFeedId: '',
-		fallbackPrice: 135,
+		fallbackPrice: 145.3,
 		category: 'ST0x',
 		tradingViewSymbol: 'NASDAQ:SPCX',
 		tradingViewMarket: 'america',
@@ -346,9 +345,9 @@ export const TOKENS: CategorizedToken[] = [
 		name: 'Wrapped Roundhill Memory ETF ST0x',
 		logoUrl: '/images/roundhill.png',
 		priceFeedId: '',
-		// priceFeedId removed — Pyth no longer supports this feed ID.
-		// Using a hardcoded fallback until a replacement feed is wired up.
-		fallbackPrice: 50,
+		// Pyth does not publish a DRAM feed. Use TradingView's latest close observed
+		// on 2026-07-13 until a replacement feed is wired up.
+		fallbackPrice: 63.04,
 		category: 'ST0x',
 		tradingViewSymbol: 'CBOE:DRAM',
 		tradingViewMarket: 'america',

--- a/src/lib/queries/oracleQuotes.ts
+++ b/src/lib/queries/oracleQuotes.ts
@@ -12,10 +12,14 @@ export interface OracleQuote {
 	publishTime: number | null;
 }
 
-export function tokensWithPriceFeed(network: Network | null) {
+export function tokensWithPriceSource(network: Network | null) {
 	if (!network) return [];
 	const all = [...TOKENS, ...CRYPTO_TOKENS];
-	return all.filter((token) => token.chainId === network.chainId && token.priceFeedId);
+	return all.filter(
+		(token) =>
+			token.chainId === network.chainId &&
+			(token.priceFeedId || typeof token.fallbackPrice === 'number')
+	);
 }
 
 /** Fetch SPYM price from the liquidity-monitor proxy endpoint. */
@@ -40,7 +44,7 @@ export function createOracleQuotesQuery(network: Network | null) {
 		refetchInterval: 15_000,
 		queryFn: async () => {
 			if (!network) return {};
-			const tokens = tokensWithPriceFeed(network);
+			const tokens = tokensWithPriceSource(network);
 			const [snapshots, spymPrice] = await Promise.all([
 				tokens.length ? getNetworkOracleSnapshots(tokens, network) : ([] as OracleSnapshot[]),
 				fetchSpymPrice()

--- a/src/lib/queries/priceFeeds.ts
+++ b/src/lib/queries/priceFeeds.ts
@@ -4,7 +4,15 @@ import type { Network } from '$lib/config/network';
 import { TOKENS } from '$lib/config/network';
 import { getPythQuotes } from '$lib/api/pyth';
 import type { TradingViewQuote } from '$lib/api/tradingview';
-import { tokensWithPriceFeed } from '$lib/queries/oracleQuotes';
+import { tokensWithPriceSource } from '$lib/queries/oracleQuotes';
+
+export function replaceQuoteBySymbol(
+	quotes: TradingViewQuote[],
+	replacement: TradingViewQuote | null
+): TradingViewQuote[] {
+	if (!replacement) return quotes;
+	return [...quotes.filter((quote) => quote.symbol !== replacement.symbol), replacement];
+}
 
 /** Fetch SPYM price from the liquidity-monitor proxy (no Pyth feed available). */
 async function fetchSpymQuote(network: Network): Promise<TradingViewQuote | null> {
@@ -45,11 +53,10 @@ export function createPriceFeedsQuery(network: Network | null) {
 		queryFn: async () => {
 			const net = network as Network;
 			const [pythQuotes, spymQuote] = await Promise.all([
-				getPythQuotes(tokensWithPriceFeed(network), net),
+				getPythQuotes(tokensWithPriceSource(network), net),
 				fetchSpymQuote(net)
 			]);
-			if (spymQuote) pythQuotes.push(spymQuote);
-			return pythQuotes;
+			return replaceQuoteBySymbol(pythQuotes, spymQuote);
 		}
 	});
 }

--- a/tests/lib/api/pyth.test.ts
+++ b/tests/lib/api/pyth.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getOracleSnapshots, getPythQuotes } from '$lib/api/pyth';
+import type { CategorizedToken } from '$lib/config/tokens';
+
+const fallbackToken: CategorizedToken = {
+	chainId: 8453,
+	address: '0x0000000000000000000000000000000000000001',
+	symbol: 'wtFALLBACK',
+	decimals: 18,
+	name: 'Wrapped Fallback Asset',
+	priceFeedId: '',
+	fallbackPrice: 42.5,
+	category: 'ST0x',
+	tradingViewSymbol: 'NASDAQ:FALLBACK'
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('Pyth fallback prices', () => {
+	it('returns configured fallback quotes without calling Hermes', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+		const quotes = await getPythQuotes([fallbackToken]);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(quotes).toEqual([
+			expect.objectContaining({
+				symbol: 'NASDAQ:FALLBACK',
+				close: 42.5
+			})
+		]);
+	});
+
+	it('exposes fallback prices through oracle snapshots', async () => {
+		const snapshots = await getOracleSnapshots([fallbackToken]);
+
+		expect(snapshots).toEqual([
+			expect.objectContaining({
+				feedId: '',
+				price: 42.5,
+				confidence: 0,
+				publishTime: null,
+				token: fallbackToken
+			})
+		]);
+	});
+});

--- a/tests/lib/queries/priceFeeds.test.ts
+++ b/tests/lib/queries/priceFeeds.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { TradingViewQuote } from '$lib/api/tradingview';
+import { replaceQuoteBySymbol } from '$lib/queries/priceFeeds';
+import { tokensWithPriceSource } from '$lib/queries/oracleQuotes';
+import { networks } from '$lib/config/network';
+
+function quote(symbol: string, close: number): TradingViewQuote {
+	return {
+		symbol,
+		close,
+		open: null,
+		high: null,
+		low: null,
+		volume: null,
+		change: null,
+		changeAbs: null,
+		changePercent: null,
+		week52High: null,
+		week52Low: null,
+		marketCap: null,
+		prevClose: null
+	};
+}
+
+describe('price feed sources', () => {
+	it('includes Pyth and fallback-backed Base tokens', () => {
+		const base = networks.find((network) => network.chainId === 8453) ?? null;
+		const symbols = tokensWithPriceSource(base).map((token) => token.symbol);
+
+		expect(symbols).toEqual(
+			expect.arrayContaining(['wtCEG', 'wtTSM', 'wtASML', 'wtDRAM', 'wtSKHY', 'wtSPCX'])
+		);
+	});
+
+	it('replaces the SPYM fallback with the live monitor quote', () => {
+		const quotes = replaceQuoteBySymbol(
+			[quote('NASDAQ:NVDA', 200), quote('AMEX:SPYM', 82.5)],
+			quote('AMEX:SPYM', 88.6)
+		);
+
+		expect(quotes).toEqual([quote('NASDAQ:NVDA', 200), quote('AMEX:SPYM', 88.6)]);
+	});
+
+	it('keeps the fallback when the live monitor quote is unavailable', () => {
+		const quotes = [quote('AMEX:SPYM', 82.5)];
+
+		expect(replaceQuoteBySymbol(quotes, null)).toBe(quotes);
+	});
+});

--- a/tests/lib/queries/priceFeeds.test.ts
+++ b/tests/lib/queries/priceFeeds.test.ts
@@ -32,6 +32,17 @@ describe('price feed sources', () => {
 		);
 	});
 
+	it('uses the refreshed configured fallback prices', () => {
+		const base = networks.find((network) => network.chainId === 8453) ?? null;
+		const fallbackPrices = Object.fromEntries(
+			tokensWithPriceSource(base)
+				.filter((token) => ['wtDRAM', 'wtSKHY', 'wtSPCX'].includes(token.symbol))
+				.map((token) => [token.symbol, token.fallbackPrice])
+		);
+
+		expect(fallbackPrices).toEqual({ wtDRAM: 63.04, wtSKHY: 149, wtSPCX: 145.3 });
+	});
+
 	it('replaces the SPYM fallback with the live monitor quote', () => {
 		const quotes = replaceQuoteBySymbol(
 			[quote('NASDAQ:NVDA', 200), quote('AMEX:SPYM', 82.5)],


### PR DESCRIPTION
## Summary

- Include tokens with a configured `fallbackPrice` in the shared client price-source pipeline.
- Return fallback values through both TradingView-style quotes and address-keyed oracle snapshots, fixing `N/A` for wtDRAM, wtSKHY, and wtSPCX.
- Refresh the non-Pyth fallbacks from the latest market data available in TradingView: wtDRAM `$63.04`, wtSPCX `$145.30`; keep wtSKHY at its `$149.00` configured value because TradingView does not currently expose a quote for it.
- Replace the SPYM fallback quote with the live liquidity-monitor quote when available, while retaining the fallback when the monitor is unavailable.
- Add regression coverage for fallback-only tokens, exact configured values, Base price-source selection, and SPYM precedence.

## Verification

- `npm test -- --run` — 72 test files passed; 787 tests passed, 1 skipped
- `npm run lint`
- `npm run format-check`
- `git diff --check`
- Browser plugin against the local PR branch — rendered wtDRAM `$63.04`, wtSPCX `$145.30`, and wtSKHY `$149.00` without `N/A`

## Known limitation

- `npm run check` was attempted, but this checkout has a stale local dependency tree: latest main references `@playwright/test`, while that package is absent from the installed `node_modules`. The resulting diagnostics are confined to existing Playwright integration fixtures; the changed files produced no Svelte diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configured fallback prices when live price-feed data is unavailable.
  * Oracle snapshots now include tokens with fallback prices.
  * Price-feed selection now includes tokens with either live feeds or fallback prices.

* **Bug Fixes**
  * Prevented duplicate quotes by replacing existing quotes with updated monitor data when available.
  * Preserved fallback quotes when live monitor data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
