### PR TITLE
feat(observability): trace critical frontend trade failures

### DIFF
--- a/src/lib/components/RainlangConfirmationModal.svelte
+++ b/src/lib/components/RainlangConfirmationModal.svelte
@@ -9,7 +9,7 @@
 
 	export let show: boolean = false;
 	export let rainlangCode: string = '';
-	export let onDeploy: () => void;
+	export let onDeploy: () => void | Promise<void>;
 	export let onCancel: () => void;
 
 	let codeElement: HTMLElement | null = null;

--- a/src/lib/components/orders/DcaOrder.svelte
+++ b/src/lib/components/orders/DcaOrder.svelte
@@ -191,7 +191,7 @@
 		}
 		if (!($isAuthenticated && $walletRegistered)) return;
 
-		await withTradeId(async () => {
+		await withTradeId(async (tradeId) => {
 			try {
 				trackTradeEvent('trade_button_clicked', {
 					order_type: 'dca',
@@ -217,7 +217,7 @@
 				// Ask (selling): Accumulate the settlement token over time by selling the asset
 				const inputTok = orderType === 'Bid' ? selectedInputToken : selectedOutputToken;
 				const outputTok = orderType === 'Bid' ? selectedOutputToken : selectedInputToken;
-				transactionStore.handleDcaDeploy(
+				await transactionStore.handleDcaDeploy(
 					{
 						outputToken: outputTok,
 						inputToken: inputTok,
@@ -236,16 +236,12 @@
 					},
 					{
 						order_type: 'dca',
-						// User-perspective symbols (CLAUDE.md §"Order Semantics"):
-						// Buy: asset = the token the user accumulates (selectedInputToken),
-						//      payment = the token they spend (selectedOutputToken).
-						// Sell: inverted — asset = selectedOutputToken,
-						//      payment = selectedInputToken (we sell asset for payment over time).
-						asset_symbol:
-							(orderSide === 'Buy' ? selectedInputToken?.symbol : selectedOutputToken?.symbol) ??
-							'',
-						payment_symbol:
-							(orderSide === 'Buy' ? selectedOutputToken?.symbol : selectedInputToken?.symbol) ?? ''
+						order_side: orderSide.toLowerCase() as 'buy' | 'sell',
+						trade_id: tradeId,
+						// User-perspective symbols stay stable across Buy and Sell. Only the
+						// maker-perspective input/output deployment arguments invert by side.
+						asset_symbol: selectedInputToken?.symbol ?? '',
+						payment_symbol: selectedOutputToken?.symbol ?? ''
 					}
 				);
 

--- a/src/lib/components/orders/LimitOrder.svelte
+++ b/src/lib/components/orders/LimitOrder.svelte
@@ -34,6 +34,13 @@
 	});
 
 	onDestroy(() => {
+		// The price-warning flow keeps the Sentry trade id active while the modal is
+		// open. Navigating away bypasses both modal actions, so release it here too.
+		if (pendingTradeId) {
+			clearTradeId();
+			pendingTradeId = null;
+		}
+
 		// Track abandonment if user had entered values but didn't complete trade
 		if (!tradeSubmittedSuccessfully && selectedAmount > 0n) {
 			trackTradeEvent('trade_panel_abandoned', {
@@ -237,7 +244,7 @@
 		}
 
 		// Mint AFTER guards, BEFORE try (Pitfall 2 / T-2-E discipline).
-		mintTradeId();
+		const tradeId = mintTradeId();
 		// `cleared` flag: when the modal-warning path defers deploy to proceedWithDeploy,
 		// proceedWithDeploy owns the clear (the trade_id stays alive across the modal).
 		// Otherwise this handler clears in finally below.
@@ -301,6 +308,7 @@
 			// Check if price warning is needed
 			if (checkPriceWarning()) {
 				pendingDeployData = deployData;
+				pendingTradeId = tradeId;
 				showPriceWarning = true;
 				// Defer trade_id clearing to proceedWithDeploy (warning-acknowledged path)
 				// or cancelDeploy. Same trade_id spans the modal lifecycle.
@@ -314,8 +322,10 @@
 					price: selectedInitialRatio,
 					amount: formatUnits(selectedAmount, assetToken.decimals)
 				});
-				transactionStore.handleLimitDeploy(deployData, {
+				await transactionStore.handleLimitDeploy(deployData, {
 					order_type: 'limit',
+					order_side: orderSide.toLowerCase() as 'buy' | 'sell',
+					trade_id: tradeId,
 					asset_symbol: assetToken?.symbol ?? '',
 					payment_symbol: settlementToken?.symbol ?? ''
 				});
@@ -346,6 +356,7 @@
 		depositAmount: bigint;
 		inputVaultId: Hex | undefined;
 	} | null = null;
+	let pendingTradeId: string | null = null;
 
 	// Check if limit price is significantly off market price
 	const checkPriceWarning = (): boolean => {
@@ -373,8 +384,8 @@
 		return false;
 	};
 
-	const proceedWithDeploy = () => {
-		if (!pendingDeployData) return;
+	const proceedWithDeploy = async () => {
+		if (!pendingDeployData || !pendingTradeId) return;
 		try {
 			tradeSubmittedSuccessfully = true;
 			trackTradeEvent('limit_order_deployed', {
@@ -384,11 +395,22 @@
 				price: selectedInitialRatio,
 				amount: assetToken ? formatUnits(selectedAmount, assetToken.decimals) : '0'
 			});
-			transactionStore.handleLimitDeploy(pendingDeployData, {
+			await transactionStore.handleLimitDeploy(pendingDeployData, {
 				order_type: 'limit',
+				order_side: orderSide.toLowerCase() as 'buy' | 'sell',
+				trade_id: pendingTradeId,
 				asset_symbol: assetToken?.symbol ?? '',
 				payment_symbol: settlementToken?.symbol ?? ''
 			});
+		} catch (error) {
+			trackTradeEvent('trade_failed', {
+				order_type: 'limit',
+				order_side: orderSide.toLowerCase() as 'buy' | 'sell',
+				asset_symbol: assetToken?.symbol,
+				error_class: classifyError(error),
+				error_message: error instanceof Error ? error.message : String(error)
+			});
+			throw error;
 		} finally {
 			// Pitfall 2 (T-2-E): trade_id was minted in handleDeploy and deferred
 			// across the modal — clear here on the warning-acknowledged path.
@@ -396,6 +418,7 @@
 			showPriceWarning = false;
 			userAcknowledgesWarning = false;
 			pendingDeployData = null;
+			pendingTradeId = null;
 		}
 	};
 
@@ -405,6 +428,7 @@
 		showPriceWarning = false;
 		userAcknowledgesWarning = false;
 		pendingDeployData = null;
+		pendingTradeId = null;
 	};
 
 	// Calculate total cost

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -27,6 +27,12 @@
 	import { isOutsideMarketHours } from '$lib/utils/marketHours';
 	import { trackTradeEvent, type ErrorClass } from '$lib/services/observability/tradeEvents';
 	import { classifyError } from '$lib/services/observability/classifyError';
+	import {
+		addTradeFlowBreadcrumb,
+		captureTradeFlowError,
+		inferWalletFailureStage,
+		type TradeFlowStage
+	} from '$lib/services/observability/tradeFlow';
 	import { withTradeId } from '$lib/services/observability/tradeId';
 	import { onMount } from 'svelte';
 
@@ -894,8 +900,20 @@
 
 		// Mint after early-return guards so unauthenticated/idle clicks do not
 		// pollute the funnel; withTradeId clears in finally (T-2-E mitigation).
-		await withTradeId(async () => {
+		await withTradeId(async (tradeId) => {
+			let activeStage: TradeFlowStage = 'quote';
+			const flowContext = (stage: TradeFlowStage, operation: string) => ({
+				stage,
+				operation,
+				orderType: 'market' as const,
+				orderSide: orderSide.toLowerCase() as 'buy' | 'sell',
+				tradeId,
+				chainId: $currentNetwork?.id,
+				assetSymbol: assetToken?.symbol,
+				paymentSymbol: paymentToken?.symbol
+			});
 			try {
+				addTradeFlowBreadcrumb(flowContext('quote', 'select_executable_quotes'), 'started');
 				trackTradeEvent('trade_button_clicked', {
 					order_type: 'market',
 					order_side: orderSide.toLowerCase() as 'buy' | 'sell',
@@ -912,10 +930,18 @@
 				});
 				// Validate token configuration
 				if (!paymentToken || typeof paymentToken.decimals !== 'number') {
+					captureTradeFlowError(
+						new Error('Payment token configuration is incomplete'),
+						flowContext('quote', 'validate_token_config')
+					);
 					orderPreparationError = 'Token configuration error. Please refresh the page.';
 					return;
 				}
 				if (!assetToken || typeof assetToken.decimals !== 'number') {
+					captureTradeFlowError(
+						new Error('Asset token configuration is incomplete'),
+						flowContext('quote', 'validate_token_config')
+					);
 					orderPreparationError = 'Token configuration error. Please refresh the page.';
 					return;
 				}
@@ -924,9 +950,22 @@
 				const lastUpdated = $orderbookQuotesQuery?.dataUpdatedAt ?? 0;
 				const isStaleQuotes = !lastUpdated || Date.now() - lastUpdated > ORDERBOOK_MAX_STALENESS_MS;
 				if (isStaleQuotes) {
-					await $orderbookQuotesQuery?.refetch?.();
+					const refreshResult = await $orderbookQuotesQuery?.refetch?.();
+					if (refreshResult?.isError) {
+						captureTradeFlowError(
+							refreshResult.error ?? new Error('Orderbook quote refresh failed'),
+							flowContext('quote', 'refresh_quotes')
+						);
+						priceError = true;
+						priceErrorReason = 'error';
+						return;
+					}
 					await fetchMarketPrice();
 					if (priceError) {
+						captureTradeFlowError(
+							new Error(`Quote refresh failed: ${priceErrorReason ?? 'unknown'}`),
+							flowContext('quote', 'refresh_quotes')
+						);
 						return;
 					}
 				}
@@ -934,10 +973,15 @@
 				// Get filtered quotes with price guard
 				const filteredQuotes = getQuotesWithPriceGuard();
 				if (filteredQuotes.length === 0) {
+					captureTradeFlowError(
+						new Error('No executable quotes passed the price guard'),
+						flowContext('quote', 'select_executable_quotes')
+					);
 					priceError = true;
 					priceErrorReason = 'no_quotes';
 					return;
 				}
+				addTradeFlowBreadcrumb(flowContext('quote', 'select_executable_quotes'), 'completed');
 
 				// OBS-07 funnel step: post-walk, pre-execute. Once we have at least one
 				// price-guard-passing quote we count `quote_received` as fired.
@@ -957,6 +1001,7 @@
 				// Execute market order using shared service.
 				// `broadcast` and `confirmed` step events are emitted from
 				// `marketOrderExecution.ts` at SDK callback boundaries (Task 1b).
+				activeStage = 'calldata';
 				const result = await executeMarketOrder({
 					orderSide,
 					amount: selectedAmount,
@@ -1007,6 +1052,12 @@
 				}
 			} catch (error) {
 				console.error('Market order error:', error);
+				// executeMarketOrder owns quote/calldata failures internally. A rejection
+				// escaping after preparation is at the wallet boundary, so distinguish a
+				// signing rejection from a submission/transport failure.
+				const failureStage =
+					activeStage === 'calldata' ? inferWalletFailureStage(error) : activeStage;
+				captureTradeFlowError(error, flowContext(failureStage, 'submit_market_order'));
 				orderPreparationError = error instanceof Error ? error.message : 'Unknown error occurred';
 				trackTradeEvent('trade_failed', {
 					order_type: 'market',

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -49,6 +49,8 @@ import {
 	type TakeOrderFailureReason
 } from '$lib/services/observability/captureTakeOrderFailure';
 import { trackTradeEvent, type ErrorClass } from '$lib/services/observability/tradeEvents';
+import { addTradeFlowBreadcrumb } from '$lib/services/observability/tradeFlow';
+import { getCurrentTradeId } from '$lib/services/observability/tradeId';
 import {
 	getMakerInputIOIndex,
 	getMakerOutputIOIndex,
@@ -226,6 +228,18 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		request_id: null,
 		timestamp: new Date().toISOString()
 	};
+	const flowContext = (stage: 'quote' | 'calldata' | 'submission', operation: string) => ({
+		stage,
+		operation,
+		orderType: 'market' as const,
+		orderSide: orderSide.toLowerCase() as 'buy' | 'sell',
+		tradeId: getCurrentTradeId(),
+		chainId: network.id,
+		assetSymbol: assetToken.symbol,
+		paymentSymbol: paymentToken.symbol
+	});
+	addTradeFlowBreadcrumb(flowContext('quote', 'build_market_route'), 'started');
+	let activeStage: 'quote' | 'calldata' | 'submission' = 'quote';
 
 	// Single-seam dispatcher: every failure-return path routes through this so the
 	// transcript-builder pattern stays correct under future edits. Phase 1 fence:
@@ -234,9 +248,10 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 	const failWith = (
 		reason: TakeOrderFailureReason,
 		errOrMessage: unknown,
-		userFacingError: string
+		userFacingError: string,
+		stageOverride?: 'quote' | 'calldata' | 'submission'
 	): MarketOrderResult => {
-		captureTakeOrderFailure(errOrMessage, transcript, reason);
+		captureTakeOrderFailure(errOrMessage, transcript, reason, stageOverride ?? activeStage);
 		return { success: false, error: userFacingError, errorClass: errorClassForReason(reason) };
 	};
 
@@ -396,7 +411,8 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			return failWith(
 				'unhydrated_fills',
 				new Error('firstQuote missing orderData/sgOrder after hydration'),
-				'Unable to prepare aggregated order route. Please refresh and retry.'
+				'Unable to prepare aggregated order route. Please refresh and retry.',
+				'calldata'
 			);
 		}
 
@@ -563,6 +579,9 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			amount: formatUnits(amount, amountDecimals),
 			priceCap: priceCapStrForSdk
 		};
+		addTradeFlowBreadcrumb(flowContext('quote', 'build_market_route'), 'completed');
+		activeStage = 'calldata';
+		addTradeFlowBreadcrumb(flowContext('calldata', 'prepare_take_order'), 'started');
 		console.log('[executeMarketOrder] TakeOrdersRequest', {
 			mode: takeRequest.mode,
 			amount: takeRequest.amount,
@@ -618,6 +637,9 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			orderFillAmounts,
 			orderFillDecimals
 		};
+		addTradeFlowBreadcrumb(flowContext('calldata', 'prepare_take_order'), 'completed');
+		activeStage = 'submission';
+		addTradeFlowBreadcrumb(flowContext('submission', 'take_market_order'), 'started');
 		const approvalSymbol = isBuy ? paymentToken.symbol : assetToken.symbol;
 		const aggregatedHandled = await handleAggregatedTakeOrdersCalldata(
 			takeRequest,
@@ -669,6 +691,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		}
 		const { status, error: txError } = get(transactionStoreInternal);
 		if (status === TransactionStatus.SUCCESS) {
+			addTradeFlowBreadcrumb(flowContext('submission', 'take_market_order'), 'completed');
 			// OBS-07 (Plan 02-03 Task 1b): SDK callback boundary collapse.
 			// `handleAggregatedTakeOrdersCalldata` / `handleOracleOrders` already block
 			// through wallet-sign → on-chain dispatch → receipt confirmation by the

--- a/src/lib/services/observability/captureTakeOrderFailure.ts
+++ b/src/lib/services/observability/captureTakeOrderFailure.ts
@@ -26,6 +26,8 @@
 import * as Sentry from '@sentry/sveltekit';
 import type { ProcessedQuote } from '$lib/utils/orderbook';
 import { getCurrentTradeId } from './tradeId';
+import { classifyError } from './classifyError';
+import type { TradeFlowStage } from './tradeFlow';
 
 export type TakeOrderFailureReason =
 	| 'no_quotes_available'
@@ -69,6 +71,30 @@ export interface TakeOrderTranscript {
 	timestamp: string; // ISO 8601
 }
 
+/** Map the market failure taxonomy onto the RAI-260 critical-flow stages. */
+export function getTakeOrderFailureStage(
+	reason: TakeOrderFailureReason,
+	error: unknown,
+	explicitStage?: TradeFlowStage
+): TradeFlowStage {
+	const errorClass = classifyError(error, 'market');
+	if (errorClass === 'user_rejected') return 'signing';
+	if (explicitStage) return explicitStage;
+
+	if (
+		reason === 'no_quotes_available' ||
+		reason === 'no_walk_fills' ||
+		reason === 'preflight_chain_unreachable' ||
+		reason === 'preflight_order_vanished' ||
+		reason === 'auto_retry_exhausted'
+	) {
+		return 'quote';
+	}
+	if (reason === 'unhydrated_fills') return 'calldata';
+	if (errorClass === 'no_liquidity' || errorClass === 'stale_oracle') return 'quote';
+	return 'submission';
+}
+
 /**
  * Dispatch a take-order failure transcript to both observability sinks.
  *
@@ -80,9 +106,12 @@ export interface TakeOrderTranscript {
 export function captureTakeOrderFailure(
 	err: unknown,
 	transcript: TakeOrderTranscript,
-	reason: TakeOrderFailureReason
+	reason: TakeOrderFailureReason,
+	explicitStage?: TradeFlowStage
 ): void {
 	const errorMessage = err instanceof Error ? err.message : String(err);
+	const stage = getTakeOrderFailureStage(reason, err, explicitStage);
+	const errorClass = classifyError(err, 'market');
 
 	// OBS-09 (Plan 02-02 Task 2): attach the active trade_id (if any) so the on-error
 	// Sentry Replay is navigable to PostHog events + pino logs. Conditional spread
@@ -94,14 +123,33 @@ export function captureTakeOrderFailure(
 	// Sink 1: Sentry — immediate alert + breadcrumb context with PII scrubbed by beforeSend
 	try {
 		Sentry.captureException(err, {
+			level:
+				errorClass === 'user_rejected' || errorClass === 'insufficient_balance'
+					? 'warning'
+					: 'error',
 			tags: {
+				feature: 'trade_flow',
 				failure_reason: reason,
-				side: transcript.side,
+				trade_stage: stage,
+				trade_operation: 'take_market_order',
+				order_type: 'market',
+				error_class: errorClass,
+				order_side: transcript.userAction.toLowerCase(),
+				maker_side: transcript.side,
 				...(tradeId ? { trade_id: tradeId } : {})
 			},
 			extra: {
 				...transcript,
 				errorMessage
+			},
+			contexts: {
+				trade_flow: {
+					stage,
+					operation: 'take_market_order',
+					order_type: 'market',
+					order_side: transcript.userAction.toLowerCase(),
+					...(tradeId ? { trade_id: tradeId } : {})
+				}
 			}
 		});
 	} catch (sentryErr) {

--- a/src/lib/services/observability/tradeFlow.ts
+++ b/src/lib/services/observability/tradeFlow.ts
@@ -1,0 +1,119 @@
+/**
+ * Sentry reporting for handled failures in the frontend trade flow (RAI-260).
+ *
+ * SvelteKit's global error hooks only see unhandled exceptions. Trade code deliberately
+ * converts most wallet/SDK failures into transaction-store state, so those failures need
+ * an explicit reporting boundary. This module keeps that boundary consistent and attaches
+ * the correlation fields required to reconstruct a single user attempt.
+ */
+
+import * as Sentry from '@sentry/sveltekit';
+import { classifyError } from './classifyError';
+import { getCurrentTradeId } from './tradeId';
+
+export type TradeFlowStage =
+	| 'quote'
+	| 'calldata'
+	| 'approval'
+	| 'signing'
+	| 'submission'
+	| 'confirmation';
+
+export interface TradeFlowContext {
+	stage: TradeFlowStage;
+	operation: string;
+	orderType: 'market' | 'limit' | 'dca';
+	orderSide?: 'buy' | 'sell';
+	tradeId?: string | null;
+	chainId?: number | null;
+	assetSymbol?: string;
+	paymentSymbol?: string;
+	batch?: number;
+	totalBatches?: number;
+}
+
+function asError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function compactContext(context: TradeFlowContext): Record<string, string | number> {
+	return Object.fromEntries(
+		Object.entries({
+			operation: context.operation,
+			order_type: context.orderType,
+			order_side: context.orderSide,
+			trade_id: context.tradeId ?? getCurrentTradeId() ?? undefined,
+			chain_id: context.chainId ?? undefined,
+			asset_symbol: context.assetSymbol,
+			payment_symbol: context.paymentSymbol,
+			batch: context.batch,
+			total_batches: context.totalBatches
+		}).filter((entry): entry is [string, string | number] => entry[1] !== undefined)
+	);
+}
+
+/**
+ * Classify a wallet-bound failure at the point where `sendTransaction` rejects.
+ * User rejection happens during signing; other failures at this boundary are submission
+ * failures (RPC, simulation, broadcast, or wallet transport).
+ */
+export function inferWalletFailureStage(error: unknown): 'signing' | 'submission' {
+	return classifyError(error) === 'user_rejected' ? 'signing' : 'submission';
+}
+
+/** Add a low-cardinality breadcrumb for the successful path leading up to an error. */
+export function addTradeFlowBreadcrumb(
+	context: TradeFlowContext,
+	status: 'started' | 'completed'
+): void {
+	try {
+		Sentry.addBreadcrumb({
+			category: 'trade.flow',
+			type: 'info',
+			level: 'info',
+			message: `${context.stage}:${context.operation}:${status}`,
+			data: compactContext(context)
+		});
+	} catch (sentryError) {
+		console.error('[tradeFlow] Sentry breadcrumb failed:', sentryError);
+	}
+}
+
+/**
+ * Capture a handled trade failure without throwing back into the transaction flow.
+ * Expected user-controlled failures stay visible for funnel diagnosis but use warning
+ * severity so they do not page as application incidents.
+ */
+export function captureTradeFlowError(error: unknown, context: TradeFlowContext): void {
+	const normalized = asError(error);
+	const errorClass = classifyError(
+		normalized,
+		context.orderType === 'market' ? 'market' : 'deploy'
+	);
+	const data = compactContext(context);
+	const tradeId = context.tradeId ?? getCurrentTradeId();
+
+	try {
+		Sentry.captureException(normalized, {
+			level:
+				errorClass === 'user_rejected' || errorClass === 'insufficient_balance'
+					? 'warning'
+					: 'error',
+			tags: {
+				feature: 'trade_flow',
+				trade_stage: context.stage,
+				trade_operation: context.operation,
+				order_type: context.orderType,
+				error_class: errorClass,
+				...(context.orderSide ? { order_side: context.orderSide } : {}),
+				...(tradeId ? { trade_id: tradeId } : {}),
+				...(context.chainId != null ? { chain_id: String(context.chainId) } : {})
+			},
+			contexts: {
+				trade_flow: data
+			}
+		});
+	} catch (sentryError) {
+		console.error('[tradeFlow] Sentry capture failed:', sentryError);
+	}
+}

--- a/src/lib/services/observability/tradeId.ts
+++ b/src/lib/services/observability/tradeId.ts
@@ -23,15 +23,21 @@ import * as Sentry from '@sentry/sveltekit';
 
 let current: string | null = null;
 
-export function mintTradeId(): string {
-	current = crypto.randomUUID();
+/** Restore a known trade id when a deferred UI flow resumes. */
+export function setTradeId(tradeId: string): void {
+	current = tradeId;
 	try {
 		Sentry.setTag('trade_id', current);
 	} catch (err) {
 		// Logging never throws back into caller (project convention)
 		console.error('[tradeId] Sentry.setTag failed:', err);
 	}
-	return current;
+}
+
+export function mintTradeId(): string {
+	const tradeId = crypto.randomUUID();
+	setTradeId(tradeId);
+	return tradeId;
 }
 
 export function getCurrentTradeId(): string | null {
@@ -62,10 +68,10 @@ export function clearTradeId(): void {
  * boundary (button → modal-confirm) and so keep the mint/clear lifecycle
  * inline.
  */
-export async function withTradeId<T>(fn: () => Promise<T> | T): Promise<T> {
-	mintTradeId();
+export async function withTradeId<T>(fn: (tradeId: string) => Promise<T> | T): Promise<T> {
+	const tradeId = mintTradeId();
 	try {
-		return await fn();
+		return await fn(tradeId);
 	} finally {
 		clearTradeId();
 	}

--- a/src/lib/services/orderDeployment.ts
+++ b/src/lib/services/orderDeployment.ts
@@ -41,8 +41,10 @@ import { trackTradeEvent } from '$lib/services/observability/tradeEvents';
  */
 export interface DeployEventContext {
 	order_type: 'limit' | 'dca';
+	order_side: 'buy' | 'sell';
 	asset_symbol: string;
 	payment_symbol: string;
+	trade_id: string;
 }
 
 /** Lazily resolve DotrainRegistry from the WASM-based orderbook package. */
@@ -259,6 +261,7 @@ export const getDcaDeploymentArgs = async (
 	// from the caller's eventContext — no silent fallback (checker fix #6).
 	trackTradeEvent('sign_trade', {
 		order_type: eventContext.order_type,
+		order_side: eventContext.order_side,
 		asset_symbol: eventContext.asset_symbol,
 		payment_symbol: eventContext.payment_symbol
 	});
@@ -313,6 +316,7 @@ export const getLimitOrderDeploymentArgs = async (
 	// OBS-07: see getDcaDeploymentArgs for emission rationale.
 	trackTradeEvent('sign_trade', {
 		order_type: eventContext.order_type,
+		order_side: eventContext.order_side,
 		asset_symbol: eventContext.asset_symbol,
 		payment_symbol: eventContext.payment_symbol
 	});

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -39,6 +39,14 @@ import {
 import { wrapToken, unwrapToken } from '$lib/services/wrapService';
 import { track } from '$lib/services/analytics';
 import { trackTradeEvent } from '$lib/services/observability/tradeEvents';
+import { clearTradeId, setTradeId } from '$lib/services/observability/tradeId';
+import {
+	addTradeFlowBreadcrumb,
+	captureTradeFlowError,
+	inferWalletFailureStage,
+	type TradeFlowContext,
+	type TradeFlowStage
+} from '$lib/services/observability/tradeFlow';
 import { createRaindexClient } from '$lib/clients/raindex';
 import { invalidateOrderQueries } from '$lib/queries/orderbook';
 import { invalidateUserVaultQueries } from '$lib/queries/vaults';
@@ -74,6 +82,36 @@ const sendTransaction = walletServiceSendTransaction;
 
 // Unified wait for transaction (works with both Dynamic and wagmi wallets, includes retry logic)
 const waitForTransaction = walletServiceWaitForTransaction;
+
+function deployFlowContext(
+	eventContext: DeployEventContext | undefined,
+	stage: TradeFlowStage,
+	operation: string,
+	chainId?: number
+): TradeFlowContext | null {
+	if (!eventContext) return null;
+	return {
+		stage,
+		operation,
+		orderType: eventContext.order_type,
+		orderSide: eventContext.order_side,
+		tradeId: eventContext.trade_id,
+		chainId,
+		assetSymbol: eventContext.asset_symbol,
+		paymentSymbol: eventContext.payment_symbol
+	};
+}
+
+function reportDeployFailure(
+	error: unknown,
+	eventContext: DeployEventContext | undefined,
+	stage: TradeFlowStage,
+	operation: string,
+	chainId?: number
+): void {
+	const context = deployFlowContext(eventContext, stage, operation, chainId);
+	if (context) captureTradeFlowError(error, context);
+}
 
 // Destructure the leaf-owned status-helper surface so the lifted method bodies
 // below can keep calling `awaitWalletConfirmation(...)` etc. unchanged. This
@@ -141,18 +179,25 @@ export const handleStrategyDeployment = async (
 	eventContext?: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	if (!config) throw new Error('Wagmi config not found');
-	const $signerAddress = get(walletAddress);
-	if (!$signerAddress) throw new Error('Signer address not found');
-
-	// Get network early - used for validation and later for subgraph queries
 	const network = get(currentNetwork);
+	if (!config) {
+		const error = new Error('Wagmi config not found');
+		reportDeployFailure(error, eventContext, 'submission', 'wallet_config', network?.id);
+		return transactionError(error.message as TransactionErrorMessage);
+	}
+	const $signerAddress = get(walletAddress);
+	if (!$signerAddress) {
+		const error = new Error('Signer address not found');
+		reportDeployFailure(error, eventContext, 'signing', 'wallet_identity', network?.id);
+		return transactionError(error.message as TransactionErrorMessage);
+	}
 
 	// Security: Validate orderbook address BEFORE any approvals are granted
 	// This prevents a compromised orderbook from receiving token approvals
 	try {
 		validateOrderbookAddress(deploymentArgs.orderbookAddress, network);
 	} catch (error) {
+		reportDeployFailure(error, eventContext, 'calldata', 'validate_orderbook', network.id);
 		return transactionError((error as Error).message as TransactionErrorMessage);
 	}
 
@@ -165,17 +210,23 @@ export const handleStrategyDeployment = async (
 		requiredAmount: bigint;
 	};
 
-	const decodedApprovals: DecodedApproval[] = deploymentArgs.approvals.map((approval) => {
-		const { args: approvalArgs } = decodeFunctionData({
-			abi: erc20Abi,
-			data: approval.calldata as Hex
+	let decodedApprovals: DecodedApproval[];
+	try {
+		decodedApprovals = deploymentArgs.approvals.map((approval) => {
+			const { args: approvalArgs } = decodeFunctionData({
+				abi: erc20Abi,
+				data: approval.calldata as Hex
+			});
+			return {
+				approval,
+				spender: approvalArgs[0] as Hex,
+				requiredAmount: BigInt(approvalArgs[1] as string)
+			};
 		});
-		return {
-			approval,
-			spender: approvalArgs[0] as Hex,
-			requiredAmount: BigInt(approvalArgs[1] as string)
-		};
-	});
+	} catch (error) {
+		reportDeployFailure(error, eventContext, 'calldata', 'decode_approval', network.id);
+		return transactionError(extractTransactionError(error));
+	}
 
 	if (decodedApprovals.length > 0) {
 		checkingWalletAllowance('Checking balances and allowances...');
@@ -183,20 +234,36 @@ export const handleStrategyDeployment = async (
 		// Check all balances in PARALLEL — balance shortfalls block deployment
 		// before any wallet prompt (cheaper failure mode for the user). Allowance
 		// reads are inside `ensureAllowance` so we don't double-read them here.
-		const balances = await Promise.all(
-			decodedApprovals.map((d) =>
-				readContract(config, {
-					abi: erc20Abi,
-					address: d.approval.token as `0x${string}`,
-					functionName: 'balanceOf',
-					args: [$signerAddress as Hex]
-				})
-			)
+		const approvalContext = deployFlowContext(
+			eventContext,
+			'approval',
+			'check_balances',
+			network.id
 		);
+		if (approvalContext) addTradeFlowBreadcrumb(approvalContext, 'started');
+		let balances: bigint[];
+		try {
+			balances = (await Promise.all(
+				decodedApprovals.map((d) =>
+					readContract(config, {
+						abi: erc20Abi,
+						address: d.approval.token as `0x${string}`,
+						functionName: 'balanceOf',
+						args: [$signerAddress as Hex]
+					})
+				)
+			)) as bigint[];
+		} catch (error) {
+			reportDeployFailure(error, eventContext, 'approval', 'check_balances', network.id);
+			return transactionError(extractTransactionError(error));
+		}
+		if (approvalContext) addTradeFlowBreadcrumb(approvalContext, 'completed');
 
 		for (let i = 0; i < decodedApprovals.length; i++) {
 			const { approval, requiredAmount } = decodedApprovals[i];
 			if (balances[i] < requiredAmount) {
+				const error = new Error(`Insufficient ${approval.symbol} balance`);
+				reportDeployFailure(error, eventContext, 'approval', 'check_balances', network.id);
 				return transactionError(
 					`Insufficient ${approval.symbol} balance. Please add more ${approval.symbol} to your wallet or reduce the ${approval.symbol} deposit amount in advanced options.` as TransactionErrorMessage
 				);
@@ -219,6 +286,13 @@ export const handleStrategyDeployment = async (
 					setStatus: (s) => transactionStoreInternal.update((state) => ({ ...state, status: s }))
 				});
 			} catch (error) {
+				reportDeployFailure(
+					error,
+					eventContext,
+					inferWalletFailureStage(error) === 'signing' ? 'signing' : 'approval',
+					'approve_token',
+					network.id
+				);
 				if (isStaleWalletSessionError(error)) {
 					const msg = await handleStaleWalletSession(config);
 					return transactionError(msg as TransactionErrorMessage);
@@ -229,12 +303,20 @@ export const handleStrategyDeployment = async (
 	}
 	let hash: Hash;
 	try {
+		const submitContext = deployFlowContext(
+			eventContext,
+			'submission',
+			'deploy_strategy',
+			network.id
+		);
+		if (submitContext) addTradeFlowBreadcrumb(submitContext, 'started');
 		awaitWalletConfirmation(`Awaiting wallet confirmation to deploy your strategy...`);
 
 		hash = await sendTransaction({
 			to: deploymentArgs.orderbookAddress as `0x${string}`,
 			data: deploymentArgs.deploymentCalldata as Hex
 		});
+		if (submitContext) addTradeFlowBreadcrumb(submitContext, 'completed');
 		// OBS-07 (Plan 02-03 Task 2c): tx hash returned post-dispatch — emit
 		// `broadcast` for limit/dca deploy paths. `confirmed` is emitted when the
 		// receipt-poll loop terminates successfully (transactionSuccess).
@@ -245,6 +327,13 @@ export const handleStrategyDeployment = async (
 			});
 		}
 	} catch (error) {
+		reportDeployFailure(
+			error,
+			eventContext,
+			inferWalletFailureStage(error),
+			'deploy_strategy',
+			network.id
+		);
 		if (isStaleWalletSessionError(error)) {
 			const msg = await handleStaleWalletSession(config);
 			return transactionError(msg as TransactionErrorMessage);
@@ -265,20 +354,30 @@ export const handleStrategyDeployment = async (
 		});
 	}
 
-	const tryFetchOrderLink = async () => {
-		const client = await createRaindexClient();
-		const orders = await client.getAddOrdersForTransaction(
-			network.id,
-			deploymentArgs.orderbookAddress as `0x${string}`,
-			hash as `0x${string}`
-		);
-		if (orders.error || !orders.value?.length) {
+	let orderLinkErrorReported = false;
+	const tryFetchOrderLink = async (): Promise<RaindexLink | null> => {
+		try {
+			const client = await createRaindexClient();
+			const orders = await client.getAddOrdersForTransaction(
+				network.id,
+				deploymentArgs.orderbookAddress as `0x${string}`,
+				hash as `0x${string}`
+			);
+			if (orders.error || !orders.value?.length) {
+				return null;
+			}
+			const orderHash = orders.value[0].orderHash;
+			const orderbookId = orders.value[0].orderbook;
+			return createRaindexLink(network.id, orderbookId, orderHash);
+		} catch (error) {
+			// Polling retries for up to a minute. Report the first transport failure only,
+			// preserving useful signal without emitting the same incident every two seconds.
+			if (!orderLinkErrorReported) {
+				orderLinkErrorReported = true;
+				reportDeployFailure(error, eventContext, 'confirmation', 'resolve_order_link', network.id);
+			}
 			return null;
 		}
-		const orderHash = orders.value[0].orderHash;
-		const orderbookId = orders.value[0].orderbook;
-		const chainId = network.id;
-		return createRaindexLink(chainId, orderbookId, orderHash);
 	};
 
 	// Poll for the order to be added to the orderbook
@@ -336,12 +435,12 @@ export const handleStrategyDeployment = async (
 	}, 2000);
 };
 
-export const showRainlangConfirmation = (
+export const showRainlangConfirmation = async (
 	composedRainlang: string,
 	deploymentArgs: DeploymentTransactionArgs,
 	assetTokenInfo?: AssetTokenInfo,
 	eventContext?: DeployEventContext
-) => {
+): Promise<void> => {
 	// Check if user wants to review strategy source code before deploying
 	const shouldReview = get(reviewStrategyOnDeploy);
 
@@ -350,14 +449,23 @@ export const showRainlangConfirmation = (
 		rainlangConfirmationModal.set({
 			show: true,
 			rainlangCode: composedRainlang,
-			onDeploy: () => {
+			onDeploy: async () => {
 				rainlangConfirmationModal.set({
 					show: false,
 					rainlangCode: '',
 					onDeploy: null,
 					onCancel: null
 				});
-				handleStrategyDeployment(deploymentArgs, assetTokenInfo, eventContext);
+				// The originating handler has already returned after opening this modal,
+				// so its withTradeId/finally lifecycle has cleared the module scope. Restore
+				// the explicit id while the deferred wallet flow runs so PostHog funnel
+				// events and ambient Sentry scope share the same correlation id.
+				if (eventContext) setTradeId(eventContext.trade_id);
+				try {
+					await handleStrategyDeployment(deploymentArgs, assetTokenInfo, eventContext);
+				} finally {
+					if (eventContext) clearTradeId();
+				}
 			},
 			onCancel: () => {
 				rainlangConfirmationModal.set({
@@ -371,7 +479,7 @@ export const showRainlangConfirmation = (
 		});
 	} else {
 		// Skip modal and deploy directly
-		handleStrategyDeployment(deploymentArgs, assetTokenInfo, eventContext);
+		await handleStrategyDeployment(deploymentArgs, assetTokenInfo, eventContext);
 	}
 };
 
@@ -382,7 +490,7 @@ export const handleDsfDeploy = async (args: MarketMakingDeploymentArgs) => {
 	awaitWalletConfirmation(`Preparing strategy...`);
 	const { composedRainlang, deploymentArgs } = await getMarketMakingDeploymentArgs(network, args);
 
-	showRainlangConfirmation(composedRainlang, deploymentArgs);
+	await showRainlangConfirmation(composedRainlang, deploymentArgs);
 };
 
 export const handleDcaDeploy = async (
@@ -390,14 +498,28 @@ export const handleDcaDeploy = async (
 	eventContext: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	if (!config) throw new Error('Wagmi config not found');
 	const network = get(currentNetwork);
+	if (!config) {
+		const error = new Error('Wagmi config not found');
+		reportDeployFailure(error, eventContext, 'calldata', 'prepare_dca', network?.id);
+		throw error;
+	}
 	awaitWalletConfirmation(`Preparing strategy...`);
-	const { composedRainlang, deploymentArgs } = await getDcaDeploymentArgs(
-		network,
-		args,
-		eventContext
-	);
+	const calldataContext = deployFlowContext(eventContext, 'calldata', 'prepare_dca', network.id);
+	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'started');
+	let composedRainlang: string;
+	let deploymentArgs: DeploymentTransactionArgs;
+	try {
+		({ composedRainlang, deploymentArgs } = await getDcaDeploymentArgs(
+			network,
+			args,
+			eventContext
+		));
+	} catch (error) {
+		reportDeployFailure(error, eventContext, 'calldata', 'prepare_dca', network.id);
+		throw error;
+	}
+	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'completed');
 
 	// Only show Track in Wallet for Buy orders (when user is acquiring an asset)
 	// Buy DCA: outputToken is payment token (e.g., USDC), inputToken is the asset
@@ -411,7 +533,7 @@ export const handleDcaDeploy = async (
 			}
 		: undefined;
 
-	showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
+	await showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
 };
 
 export const handleLimitDeploy = async (
@@ -419,14 +541,28 @@ export const handleLimitDeploy = async (
 	eventContext: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	if (!config) throw new Error('Wagmi config not found');
 	const network = get(currentNetwork);
+	if (!config) {
+		const error = new Error('Wagmi config not found');
+		reportDeployFailure(error, eventContext, 'calldata', 'prepare_limit', network?.id);
+		throw error;
+	}
 	awaitWalletConfirmation(`Preparing strategy...`);
-	const { composedRainlang, deploymentArgs } = await getLimitOrderDeploymentArgs(
-		network,
-		args,
-		eventContext
-	);
+	const calldataContext = deployFlowContext(eventContext, 'calldata', 'prepare_limit', network.id);
+	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'started');
+	let composedRainlang: string;
+	let deploymentArgs: DeploymentTransactionArgs;
+	try {
+		({ composedRainlang, deploymentArgs } = await getLimitOrderDeploymentArgs(
+			network,
+			args,
+			eventContext
+		));
+	} catch (error) {
+		reportDeployFailure(error, eventContext, 'calldata', 'prepare_limit', network.id);
+		throw error;
+	}
+	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'completed');
 
 	// Only show Track in Wallet for Buy orders (when user is acquiring an asset)
 	// Buy Limit: outputToken is payment token (e.g., USDC), inputToken is the asset
@@ -440,7 +576,7 @@ export const handleLimitDeploy = async (
 			}
 		: undefined;
 
-	showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
+	await showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
 };
 
 export const handleWithdraw = async (vault: RaindexVault) => {
@@ -1023,5 +1159,5 @@ export const handleFolioDeploy = async (args: FolioDeploymentArgs) => {
 	awaitWalletConfirmation(`Preparing strategy...`);
 	const { composedRainlang, deploymentArgs } = await getFolioDeploymentArgs(network, args);
 
-	showRainlangConfirmation(composedRainlang, deploymentArgs);
+	await showRainlangConfirmation(composedRainlang, deploymentArgs);
 };

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -50,7 +50,7 @@ export const oracleQuotes = mapQueryData(oracleQuotesQuery, {} as Record<string,
 export const rainlangConfirmationModal = writable<{
 	show: boolean;
 	rainlangCode: string;
-	onDeploy: (() => void) | null;
+	onDeploy: (() => void | Promise<void>) | null;
 	onCancel: (() => void) | null;
 }>({
 	show: false,

--- a/tests/lib/components/orders/DcaOrder.events.test.ts
+++ b/tests/lib/components/orders/DcaOrder.events.test.ts
@@ -15,9 +15,7 @@ const componentSource = readFileSync(componentPath, 'utf-8');
 
 describe('DcaOrder.svelte event instrumentation (Plan 02-03 Task 2b)', () => {
 	it('Test D1: imports trade lifecycle modules (raw analytics import removed)', () => {
-		expect(componentSource).toMatch(
-			/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/
-		);
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/);
 		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeId['"]/);
 		expect(componentSource).toMatch(/trackTradeEvent/);
 		expect(componentSource).toMatch(/withTradeId/);
@@ -49,7 +47,7 @@ describe('DcaOrder.svelte event instrumentation (Plan 02-03 Task 2b)', () => {
 
 	it('Test D5: deploy handler brackets the submit body with withTradeId()', () => {
 		// withTradeId owns mint/clear lifecycle — call site must not open-code it.
-		expect(componentSource).toMatch(/await\s+withTradeId\(/);
+		expect(componentSource).toMatch(/await\s+withTradeId\(async\s*\(tradeId\)/);
 		expect(componentSource).not.toMatch(/mintTradeId\(\)/);
 		expect(componentSource).not.toMatch(/clearTradeId\(\)/);
 	});
@@ -63,6 +61,17 @@ describe('DcaOrder.svelte event instrumentation (Plan 02-03 Task 2b)', () => {
 	it("Test D7: DCA caller passes eventContext: { order_type: 'dca' } to transactionStore.handleDcaDeploy", () => {
 		// Per checker fix #6: no silent fallback — DCA must explicitly identify itself.
 		expect(componentSource).toMatch(/order_type:\s*['"]dca['"]/);
+		expect(componentSource).toMatch(/trade_id:\s*tradeId/);
+		expect(componentSource).toMatch(/await\s+transactionStore\.handleDcaDeploy/);
+	});
+
+	it('Test D7b: deploy event context keeps user-perspective symbols stable across order sides', () => {
+		const deployStart = componentSource.indexOf('await transactionStore.handleDcaDeploy');
+		expect(deployStart).toBeGreaterThan(-1);
+		const deployCall = componentSource.slice(deployStart, deployStart + 1800);
+		expect(deployCall).toMatch(/asset_symbol:\s*selectedInputToken\?\.symbol \?\? ''/);
+		expect(deployCall).toMatch(/payment_symbol:\s*selectedOutputToken\?\.symbol \?\? ''/);
+		expect(deployCall).not.toMatch(/asset_symbol:[\s\S]*?orderSide === ['"]Buy['"]/);
 	});
 
 	it("Test D8: occurrences of order_type: 'dca' >= 2 (mount + deploy events at minimum)", () => {

--- a/tests/lib/components/orders/LimitOrder.events.test.ts
+++ b/tests/lib/components/orders/LimitOrder.events.test.ts
@@ -16,9 +16,7 @@ const componentSource = readFileSync(componentPath, 'utf-8');
 
 describe('LimitOrder.svelte event instrumentation (Plan 02-03 Task 2a)', () => {
 	it('Test L1: imports trade lifecycle modules', () => {
-		expect(componentSource).toMatch(
-			/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/
-		);
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/);
 		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeId['"]/);
 		expect(componentSource).toMatch(/mintTradeId/);
 		expect(componentSource).toMatch(/clearTradeId/);
@@ -56,9 +54,7 @@ describe('LimitOrder.svelte event instrumentation (Plan 02-03 Task 2a)', () => {
 	it('Test L4b: warning-deferred paths (proceedWithDeploy + cancelDeploy) call clearTradeId', () => {
 		// Pitfall 2 (T-2-E) — warning-acknowledged AND warning-cancel paths must
 		// clear the deferred trade_id minted by handleDeploy.
-		const proceedFn = componentSource.match(
-			/const proceedWithDeploy = [\s\S]*?\n\s*\};/
-		);
+		const proceedFn = componentSource.match(/const proceedWithDeploy = [\s\S]*?\n\s*\};/);
 		const cancelFn = componentSource.match(/const cancelDeploy = [\s\S]*?\n\s*\};/);
 		expect(proceedFn).toBeTruthy();
 		expect(cancelFn).toBeTruthy();
@@ -66,10 +62,26 @@ describe('LimitOrder.svelte event instrumentation (Plan 02-03 Task 2a)', () => {
 		expect(cancelFn![0]).toMatch(/clearTradeId\(\)/);
 	});
 
+	it('Test L4c: component teardown clears a trade id deferred to the warning modal', () => {
+		const destroyFn = componentSource.match(/onDestroy\(\(\) => \{[\s\S]*?\n\s*\}\);/);
+		expect(destroyFn).toBeTruthy();
+		expect(destroyFn![0]).toMatch(/if \(pendingTradeId\)[\s\S]*?clearTradeId\(\)/);
+		expect(destroyFn![0]).toMatch(/pendingTradeId = null/);
+	});
+
 	it('Test L5: emits trade_failed with order_type "limit" and error_class on error path', () => {
 		expect(componentSource).toMatch(
 			/trackTradeEvent\(\s*['"]trade_failed['"][\s\S]*?order_type:\s*['"]limit['"][\s\S]*?error_class:/
 		);
+	});
+
+	it('Test L5b: warning-acknowledged deployment failures emit trade_failed', () => {
+		const proceedFn = componentSource.match(/const proceedWithDeploy = [\s\S]*?\n\s*\};/);
+		expect(proceedFn).toBeTruthy();
+		expect(proceedFn![0]).toMatch(
+			/catch \(error\)[\s\S]*?trackTradeEvent\(\s*['"]trade_failed['"]/
+		);
+		expect(proceedFn![0]).toMatch(/error_class:\s*classifyError\(error\)/);
 	});
 
 	it('Test L6: panel-level events route through trackTradeEvent', () => {
@@ -88,9 +100,7 @@ describe('LimitOrder.svelte event instrumentation (Plan 02-03 Task 2a)', () => {
 	});
 
 	it('Test L8: component imports the shared classifyError', () => {
-		expect(componentSource).toMatch(
-			/from\s+['"]\$lib\/services\/observability\/classifyError['"]/
-		);
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/classifyError['"]/);
 		expect(componentSource).toMatch(/classifyError\s*\(/);
 	});
 
@@ -99,5 +109,7 @@ describe('LimitOrder.svelte event instrumentation (Plan 02-03 Task 2a)', () => {
 		// (Task 2c modifies the orderDeployment.ts signature; LimitOrder must update
 		// the call site to satisfy the typed contract).
 		expect(componentSource).toMatch(/order_type:\s*['"]limit['"]/);
+		expect(componentSource).toMatch(/trade_id:\s*(tradeId|pendingTradeId)/);
+		expect(componentSource).toMatch(/await\s+transactionStore\.handleLimitDeploy/);
 	});
 });

--- a/tests/lib/components/orders/MarketOrder.events.test.ts
+++ b/tests/lib/components/orders/MarketOrder.events.test.ts
@@ -96,9 +96,7 @@ describe('MarketOrder.svelte event instrumentation (Plan 02-03 Task 1a)', () => 
 	});
 
 	it("Test 5b: component imports the shared classifyError + calls it with the 'market' scope", () => {
-		expect(componentSource).toMatch(
-			/from\s+['"]\$lib\/services\/observability\/classifyError['"]/
-		);
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/classifyError['"]/);
 		expect(componentSource).toMatch(/classifyError\s*\([^,]*,\s*['"]market['"]\s*\)/);
 	});
 
@@ -110,15 +108,41 @@ describe('MarketOrder.svelte event instrumentation (Plan 02-03 Task 1a)', () => 
 		expect(componentSource).toMatch(/trackTradeEvent\(\s*['"]trade_panel_abandoned['"]/);
 		expect(componentSource).toMatch(/trackTradeEvent\(\s*['"]trade_error_shown['"]/);
 		// And the raw `track` import must not be needed in the component anymore.
-		expect(componentSource).not.toMatch(/import\s+\{\s*track\s*\}\s+from\s+['"]\$lib\/services\/analytics['"]/);
+		expect(componentSource).not.toMatch(
+			/import\s+\{\s*track\s*\}\s+from\s+['"]\$lib\/services\/analytics['"]/
+		);
 	});
 
 	it('Test 7: imports both new lifecycle modules', () => {
-		expect(componentSource).toMatch(
-			/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/
-		);
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeEvents['"]/);
 		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeId['"]/);
 		expect(componentSource).toMatch(/trackTradeEvent/);
 		expect(componentSource).toMatch(/withTradeId/);
+	});
+
+	it('Test 8: reports submit-time quote and preparation failures with the explicit trade id', () => {
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/tradeFlow['"]/);
+		expect(componentSource).toMatch(/withTradeId\(async\s*\(tradeId\)/);
+		expect(componentSource).toMatch(/captureTradeFlowError/);
+		expect(componentSource).toMatch(/flowContext\(['"]quote['"]/);
+		expect(componentSource).toMatch(/activeStage\s*=\s*['"]calldata['"]/);
+	});
+
+	it('Test 9: reports token-configuration failures during quote preparation', () => {
+		const validationContexts = componentSource.match(
+			/flowContext\(['"]quote['"],\s*['"]validate_token_config['"]\)/g
+		);
+		expect(validationContexts).toHaveLength(2);
+		expect(componentSource).not.toMatch(
+			/flowContext\(['"]calldata['"],\s*['"]validate_token_config['"]\)/
+		);
+	});
+
+	it('Test 10: remaps unexpected post-preparation failures at the wallet boundary', () => {
+		expect(componentSource).toMatch(/inferWalletFailureStage/);
+		expect(componentSource).toMatch(
+			/activeStage === ['"]calldata['"]\s*\? inferWalletFailureStage\(error\)\s*:\s*activeStage/
+		);
+		expect(componentSource).toMatch(/flowContext\(failureStage, ['"]submit_market_order['"]\)/);
 	});
 });

--- a/tests/lib/services/observability/captureTakeOrderFailure.test.ts
+++ b/tests/lib/services/observability/captureTakeOrderFailure.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as Sentry from '@sentry/sveltekit';
 import {
 	captureTakeOrderFailure,
+	getTakeOrderFailureStage,
 	type TakeOrderTranscript,
 	type TakeOrderFailureReason
 } from '$lib/services/observability/captureTakeOrderFailure';
@@ -66,11 +67,18 @@ describe('captureTakeOrderFailure', () => {
 		captureTakeOrderFailure(err, transcript, 'no_quotes_available');
 
 		expect(captureSpy).toHaveBeenCalledTimes(1);
-		const [capturedErr, opts] = captureSpy.mock.calls[0] as [unknown, { tags?: Record<string, string>; extra?: Record<string, unknown> }];
+		const [capturedErr, opts] = captureSpy.mock.calls[0] as [
+			unknown,
+			{ tags?: Record<string, string>; extra?: Record<string, unknown> }
+		];
 		expect(capturedErr).toBe(err);
 		expect(opts?.tags).toMatchObject({
+			feature: 'trade_flow',
 			failure_reason: 'no_quotes_available',
-			side: 'ask'
+			trade_stage: 'quote',
+			order_type: 'market',
+			order_side: 'buy',
+			maker_side: 'ask'
 		});
 		// `extra` must include the entire transcript (fullQuotePayload + onChainStateRead)
 		expect(opts?.extra).toBeDefined();
@@ -94,6 +102,29 @@ describe('captureTakeOrderFailure', () => {
 		expect(consoleSpy).toHaveBeenCalled();
 	});
 
+	it('maps quote, calldata, signing, and submission failures to critical-flow stages', () => {
+		expect(getTakeOrderFailureStage('no_quotes_available', new Error('none'))).toBe('quote');
+		expect(getTakeOrderFailureStage('unhydrated_fills', new Error('missing order data'))).toBe(
+			'calldata'
+		);
+		expect(getTakeOrderFailureStage('aggregated_failed', new Error('User rejected request'))).toBe(
+			'signing'
+		);
+		expect(
+			getTakeOrderFailureStage(
+				'caught_exception',
+				new Error('Failed to generate calldata'),
+				'calldata'
+			)
+		).toBe('calldata');
+		expect(getTakeOrderFailureStage('caught_exception', new Error('missing ratio'), 'quote')).toBe(
+			'quote'
+		);
+		expect(getTakeOrderFailureStage('aggregated_failed', new Error('RPC broadcast failed'))).toBe(
+			'submission'
+		);
+	});
+
 	it('emits a `[take-order failed]` console.error line with JSON-stringified payload', () => {
 		vi.spyOn(Sentry, 'captureException').mockImplementation(() => 'evt-id');
 		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -102,9 +133,7 @@ describe('captureTakeOrderFailure', () => {
 		captureTakeOrderFailure(new Error('boom'), transcript, 'caught_exception');
 
 		// Find the `[take-order failed]` invocation (there should be exactly one such line)
-		const matchingCall = consoleSpy.mock.calls.find(
-			(call) => call[0] === '[take-order failed]'
-		);
+		const matchingCall = consoleSpy.mock.calls.find((call) => call[0] === '[take-order failed]');
 		expect(matchingCall, '[take-order failed] line was not emitted').toBeDefined();
 		expect(matchingCall).toHaveLength(2);
 
@@ -122,6 +151,34 @@ describe('captureTakeOrderFailure', () => {
 		expect(parsed.onChainStateRead).toEqual(transcript.onChainStateRead);
 	});
 
+	it('keeps expected wallet failures at warning severity', () => {
+		const captureSpy = vi.spyOn(Sentry, 'captureException');
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		captureTakeOrderFailure(
+			new Error('User rejected the request'),
+			makeTranscript(),
+			'aggregated_failed',
+			'submission'
+		);
+		captureTakeOrderFailure(
+			new Error('Insufficient balance'),
+			makeTranscript(),
+			'aggregated_failed',
+			'submission'
+		);
+		captureTakeOrderFailure(
+			new Error('RPC broadcast failed'),
+			makeTranscript(),
+			'aggregated_failed',
+			'submission'
+		);
+
+		expect(captureSpy.mock.calls[0][1]).toMatchObject({ level: 'warning' });
+		expect(captureSpy.mock.calls[1][1]).toMatchObject({ level: 'warning' });
+		expect(captureSpy.mock.calls[2][1]).toMatchObject({ level: 'error' });
+	});
+
 	it('does not throw back to caller when Sentry.captureException throws (T-07-04)', () => {
 		vi.spyOn(Sentry, 'captureException').mockImplementation(() => {
 			throw new Error('Sentry SDK exploded');
@@ -136,7 +193,9 @@ describe('captureTakeOrderFailure', () => {
 
 		// The Sentry-failure log line is emitted via console.error
 		const sentryFailureLine = consoleSpy.mock.calls.find(
-			(call) => typeof call[0] === 'string' && call[0].includes('[captureTakeOrderFailure] Sentry sink failed')
+			(call) =>
+				typeof call[0] === 'string' &&
+				call[0].includes('[captureTakeOrderFailure] Sentry sink failed')
 		);
 		expect(sentryFailureLine).toBeDefined();
 
@@ -209,14 +268,13 @@ describe('captureTakeOrderFailure', () => {
 			captureTakeOrderFailure(new Error('x'), makeTranscript(), 'no_quotes_available');
 
 			expect(captureSpy).toHaveBeenCalledTimes(1);
-			const [, opts] = captureSpy.mock.calls[0] as [
-				unknown,
-				{ tags: Record<string, string> }
-			];
+			const [, opts] = captureSpy.mock.calls[0] as [unknown, { tags: Record<string, string> }];
 			expect(opts.tags.trade_id).toBe(fakeTradeId);
 			// Existing tags still present + unchanged (Test 4 regression guard)
 			expect(opts.tags.failure_reason).toBe('no_quotes_available');
-			expect(opts.tags.side).toBe('ask');
+			expect(opts.tags.order_side).toBe('buy');
+			expect(opts.tags.maker_side).toBe('ask');
+			expect(opts.tags).not.toHaveProperty('side');
 		});
 
 		it('Test 2: omits trade_id key from tags when getCurrentTradeId returns null', () => {
@@ -226,33 +284,24 @@ describe('captureTakeOrderFailure', () => {
 
 			captureTakeOrderFailure(new Error('x'), makeTranscript(), 'no_quotes_available');
 
-			const [, opts] = captureSpy.mock.calls[0] as [
-				unknown,
-				{ tags: Record<string, string> }
-			];
+			const [, opts] = captureSpy.mock.calls[0] as [unknown, { tags: Record<string, string> }];
 			// Critical: literally no `trade_id` key — assert via Object.keys, not `== null`,
 			// per acceptance criteria. The conditional spread `...(tradeId ? {...} : {})`
 			// must produce an object with no `trade_id` property at all.
 			expect(Object.keys(opts.tags)).not.toContain('trade_id');
 		});
 
-		it('Test 4: failure_reason and side tags unchanged regardless of trade_id presence', () => {
+		it('Test 4: failure_reason and explicit side tags are stable regardless of trade_id', () => {
 			vi.mocked(getCurrentTradeId).mockReturnValue('550e8400-e29b-41d4-a716-446655440000');
 			const captureSpy = vi.spyOn(Sentry, 'captureException');
 			vi.spyOn(console, 'error').mockImplementation(() => {});
 
-			captureTakeOrderFailure(
-				new Error('x'),
-				makeTranscript({ side: 'bid' }),
-				'aggregated_failed'
-			);
+			captureTakeOrderFailure(new Error('x'), makeTranscript({ side: 'bid' }), 'aggregated_failed');
 
-			const [, opts] = captureSpy.mock.calls[0] as [
-				unknown,
-				{ tags: Record<string, string> }
-			];
+			const [, opts] = captureSpy.mock.calls[0] as [unknown, { tags: Record<string, string> }];
 			expect(opts.tags.failure_reason).toBe('aggregated_failed');
-			expect(opts.tags.side).toBe('bid');
+			expect(opts.tags.order_side).toBe('buy');
+			expect(opts.tags.maker_side).toBe('bid');
 		});
 	});
 

--- a/tests/lib/services/observability/tradeFlow.test.ts
+++ b/tests/lib/services/observability/tradeFlow.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as Sentry from '@sentry/sveltekit';
+import {
+	addTradeFlowBreadcrumb,
+	captureTradeFlowError,
+	inferWalletFailureStage,
+	type TradeFlowContext
+} from '$lib/services/observability/tradeFlow';
+
+vi.mock('$lib/services/observability/tradeId', () => ({
+	getCurrentTradeId: vi.fn(() => 'trade-from-scope')
+}));
+
+const context: TradeFlowContext = {
+	stage: 'calldata',
+	operation: 'prepare_limit',
+	orderType: 'limit',
+	orderSide: 'buy',
+	tradeId: 'trade-explicit',
+	chainId: 8453,
+	assetSymbol: 'wtSTOX',
+	paymentSymbol: 'USDC'
+};
+
+describe('tradeFlow Sentry reporter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.restoreAllMocks();
+	});
+
+	it('captures handled failures with the critical-flow correlation tags and context', () => {
+		const captureSpy = vi.spyOn(Sentry, 'captureException');
+		const error = new Error('calldata generation failed');
+
+		captureTradeFlowError(error, context);
+
+		expect(captureSpy).toHaveBeenCalledTimes(1);
+		const [captured, options] = captureSpy.mock.calls[0] as [
+			unknown,
+			{
+				level: string;
+				tags: Record<string, string>;
+				contexts: Record<string, Record<string, unknown>>;
+			}
+		];
+		expect(captured).toBe(error);
+		expect(options.level).toBe('error');
+		expect(options.tags).toMatchObject({
+			feature: 'trade_flow',
+			trade_stage: 'calldata',
+			trade_operation: 'prepare_limit',
+			order_type: 'limit',
+			order_side: 'buy',
+			trade_id: 'trade-explicit',
+			chain_id: '8453'
+		});
+		expect(options.contexts.trade_flow).toMatchObject({
+			asset_symbol: 'wtSTOX',
+			payment_symbol: 'USDC'
+		});
+	});
+
+	it('downgrades expected user rejection and balance failures to warning severity', () => {
+		const captureSpy = vi.spyOn(Sentry, 'captureException');
+
+		captureTradeFlowError(new Error('User rejected the request'), {
+			...context,
+			stage: 'signing'
+		});
+		captureTradeFlowError(new Error('Insufficient balance'), {
+			...context,
+			stage: 'approval'
+		});
+
+		expect(
+			captureSpy.mock.calls.map((call) => (call[1] as { level?: string } | undefined)?.level)
+		).toEqual(['warning', 'warning']);
+	});
+
+	it('distinguishes signing rejection from submission failures', () => {
+		expect(inferWalletFailureStage(new Error('User denied transaction'))).toBe('signing');
+		expect(inferWalletFailureStage(new Error('RPC broadcast failed'))).toBe('submission');
+	});
+
+	it('adds stage breadcrumbs with the same correlation data', () => {
+		const breadcrumbSpy = vi.spyOn(Sentry, 'addBreadcrumb');
+
+		addTradeFlowBreadcrumb(context, 'started');
+
+		expect(breadcrumbSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				category: 'trade.flow',
+				message: 'calldata:prepare_limit:started',
+				data: expect.objectContaining({ trade_id: 'trade-explicit', chain_id: 8453 })
+			})
+		);
+	});
+
+	it('never lets a Sentry SDK failure break the trade flow', () => {
+		vi.spyOn(Sentry, 'captureException').mockImplementation(() => {
+			throw new Error('SDK unavailable');
+		});
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => captureTradeFlowError(new Error('original'), context)).not.toThrow();
+	});
+});

--- a/tests/lib/services/observability/tradeId.test.ts
+++ b/tests/lib/services/observability/tradeId.test.ts
@@ -18,7 +18,8 @@ import * as Sentry from '@sentry/sveltekit';
 import {
 	mintTradeId,
 	getCurrentTradeId,
-	clearTradeId
+	clearTradeId,
+	setTradeId
 } from '$lib/services/observability/tradeId';
 
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -76,7 +77,14 @@ describe('tradeId', () => {
 		expect(errorLine).toBeDefined();
 	});
 
-	it('Test 6: clearTradeId() calls Sentry.setTag(\'trade_id\', undefined)', () => {
+	it('Test 6: setTradeId() restores a known id and its Sentry scope tag', () => {
+		const setTagSpy = vi.spyOn(Sentry, 'setTag');
+		setTradeId('deferred-trade-id');
+		expect(getCurrentTradeId()).toBe('deferred-trade-id');
+		expect(setTagSpy).toHaveBeenCalledWith('trade_id', 'deferred-trade-id');
+	});
+
+	it("Test 7: clearTradeId() calls Sentry.setTag('trade_id', undefined)", () => {
 		mintTradeId();
 		const setTagSpy = vi.spyOn(Sentry, 'setTag');
 		clearTradeId();

--- a/tests/lib/services/orderDeployment.events.test.ts
+++ b/tests/lib/services/orderDeployment.events.test.ts
@@ -40,6 +40,8 @@ describe('orderDeployment.ts mandatory eventContext (Plan 02-03 Task 2c)', () =>
 		expect(orderDeploymentSource).toMatch(
 			/export\s+(interface|type)\s+DeployEventContext[\s\S]*?order_type:\s*['"]limit['"]\s*\|\s*['"]dca['"]/
 		);
+		expect(orderDeploymentSource).toMatch(/trade_id:\s*string/);
+		expect(orderDeploymentSource).toMatch(/order_side:\s*['"]buy['"]\s*\|\s*['"]sell['"]/);
 	});
 
 	it('Test O3: getLimitOrderDeploymentArgs requires eventContext as second parameter (no `?`, no default)', () => {
@@ -55,19 +57,22 @@ describe('orderDeployment.ts mandatory eventContext (Plan 02-03 Task 2c)', () =>
 		);
 	});
 
-	it('Test O5: emits sign_trade with order_type from eventContext (not hardcoded literal)', () => {
-		expect(orderDeploymentSource).toMatch(
-			/trackTradeEvent\(\s*['"]sign_trade['"][\s\S]{0,300}?order_type:\s*eventContext\.order_type/
+	it('Test O5: emits sign_trade with order type and side from eventContext', () => {
+		const signCalls = orderDeploymentSource.match(
+			/trackTradeEvent\(\s*['"]sign_trade['"][\s\S]*?\n\s*\}\);/g
 		);
+		expect(signCalls).toHaveLength(2);
+		for (const call of signCalls ?? []) {
+			expect(call).toMatch(/order_type:\s*eventContext\.order_type/);
+			expect(call).toMatch(/order_side:\s*eventContext\.order_side/);
+		}
 	});
 
 	it("Test O6: NO silent 'limit' literal default in trackTradeEvent calls (checker fix #6)", () => {
 		// All trackTradeEvent invocations in orderDeployment.ts MUST use
 		// eventContext.order_type. A bare `order_type: 'limit'` literal would be
 		// the silent-fallback bug — assert it's absent.
-		const calls = orderDeploymentSource.match(
-			/trackTradeEvent\([\s\S]*?\}\s*\)/g
-		) ?? [];
+		const calls = orderDeploymentSource.match(/trackTradeEvent\([\s\S]*?\}\s*\)/g) ?? [];
 		for (const call of calls) {
 			// Either uses eventContext.order_type, OR doesn't include order_type.
 			// Hardcoded 'limit' or 'dca' literals are a bug.
@@ -114,5 +119,28 @@ describe('deployTransactionStore.ts plumbs eventContext through (Plan 02-03 Task
 		// only when an eventContext is plumbed through (from limit/DCA paths).
 		expect(deployStoreSource).toMatch(/trackTradeEvent\(\s*['"]broadcast['"]/);
 		expect(deployStoreSource).toMatch(/trackTradeEvent\(\s*['"]confirmed['"]/);
+	});
+
+	it('Test S4: reports handled calldata, signing, submission, and confirmation failures to Sentry', () => {
+		expect(deployStoreSource).toMatch(/captureTradeFlowError/);
+		for (const stage of ['calldata', 'approval', 'signing', 'submission', 'confirmation']) {
+			expect(deployStoreSource).toContain(`'${stage}'`);
+		}
+		expect(deployStoreSource).toMatch(/tradeId:\s*eventContext\.trade_id/);
+	});
+
+	it('Test S5: uses one operation name for balance reads and insufficient-balance failures', () => {
+		expect(deployStoreSource).toContain("'check_balances'");
+		expect(deployStoreSource).not.toContain("'check_balance'");
+	});
+
+	it('Test S6: restores and clears the explicit trade id around deferred modal deployment', () => {
+		const confirmationStart = deployStoreSource.indexOf('export const showRainlangConfirmation');
+		expect(confirmationStart).toBeGreaterThan(-1);
+		const confirmationBlock = deployStoreSource.slice(confirmationStart, confirmationStart + 2400);
+		expect(confirmationBlock).toMatch(/onDeploy:\s*async/);
+		expect(confirmationBlock).toMatch(/setTradeId\(eventContext\.trade_id\)/);
+		expect(confirmationBlock).toMatch(/await handleStrategyDeployment/);
+		expect(confirmationBlock).toMatch(/finally[\s\S]*?clearTradeId\(\)/);
 	});
 });

--- a/tests/lib/transactionStore.test.ts
+++ b/tests/lib/transactionStore.test.ts
@@ -295,7 +295,13 @@ describe('transactionStore tests', () => {
 						maxTradeAmount: 1000000000000000000n,
 						depositAmount: 2000000000000000000n
 					},
-					{ order_type: 'dca', asset_symbol: 'tNVDA', payment_symbol: 'USDC' }
+					{
+						order_type: 'dca',
+						order_side: 'buy',
+						trade_id: 'test-dca-trade',
+						asset_symbol: 'tNVDA',
+						payment_symbol: 'USDC'
+					}
 				),
 			expectedFn: getDcaDeploymentArgs
 		},
@@ -309,7 +315,13 @@ describe('transactionStore tests', () => {
 						ioRatio: '1',
 						depositAmount: 1000000000000000000n
 					},
-					{ order_type: 'limit', asset_symbol: 'tNVDA', payment_symbol: 'USDC' }
+					{
+						order_type: 'limit',
+						order_side: 'buy',
+						trade_id: 'test-limit-trade',
+						asset_symbol: 'tNVDA',
+						payment_symbol: 'USDC'
+					}
 				),
 			expectedFn: getLimitOrderDeploymentArgs
 		},


### PR DESCRIPTION
## Summary

- Add a shared Sentry reporter for handled frontend trade failures, attaching `trade_id`, stage, operation, order type/side, chain, token symbols, and a safe error class.
- Cover the full critical path from submit-time quote refresh/selection through calldata generation, approvals, wallet signing, transaction submission, and post-submit order-link resolution.
- Enrich existing market take-order reports with critical-flow stages and correlation context while retaining the replay transcript and failure taxonomy.
- Carry trade IDs explicitly through limit/DCA price-warning and strategy-review modals so delayed signing and submission failures remain tied to the initiating user attempt.
- Record successful stage breadcrumbs to reconstruct the path leading to a captured failure, while classifying user rejection and insufficient balance as warning-level events.
- Keep observability failures fail-open so a Sentry SDK problem cannot interrupt a trade.
- Harden reviewed telemetry paths by restoring deferred trade IDs during strategy review, reporting deferred deployment failures, using explicit execution stages, and separating maker-side from user-facing order-side dimensions.

## Verification

- `bun run test --run` — 71 test files passed; 798 tests passed, 1 skipped
- `bun run check` — 0 errors and 0 warnings
- `bun run lint-check`
- `bun run format-check`
- `git diff --check`

## Linear

Fixes RAI-260

- [RAI-260 — Integrate Sentry in the ST0x frontend critical flow](https://linear.app/makeitrain/issue/RAI-260/integrate-sentry-in-the-st0x-frontend-critical-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end trade-flow tracking across market, limit, and DCA deployment, including stage-aware progress breadcrumbs and richer failure reporting.
  * Deployment “sign” events now include order side and a unique trade identifier.
* **Bug Fixes**
  * Improved stale quote handling with explicit refetch and better error outcomes.
  * Ensured deferred limit-order confirmations retain the correct trade identifier through teardown and modal flow.
* **Tests**
  * Expanded coverage for trade identifier propagation, observability breadcrumbs, and failure-stage classification (including warning vs error severity).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
