### PR TITLE
feat(api): preserve typed REST error metadata

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -280,11 +280,14 @@ export async function fetchAndQuotePaymentTokenOrders(
 		}
 	});
 
-	// Log any failed token fetches
-	for (const result of results) {
-		if (result.status === 'rejected') {
-			console.warn('[orders] Token fetch failed:', result.reason);
-		}
+	const failures = results.filter(
+		(result): result is PromiseRejectedResult => result.status === 'rejected'
+	);
+	if (failures.length > 0 && processedQuotes.length === 0) {
+		throw failures[0].reason;
+	}
+	for (const failure of failures) {
+		console.warn('[orders] Token fetch failed; using partial orderbook:', failure.reason);
 	}
 
 	return processedQuotes;
@@ -366,8 +369,12 @@ export async function fetchAndQuoteTokenOrders(
 			hasMore = response.pagination.hasMore;
 			page++;
 		} catch (error) {
-			console.warn(`[orders] Page ${page} fetch failed for token ${tokenAddress}:`, error);
-			break;
+			if (processedQuotes.length === 0) throw error;
+			console.warn(
+				`[orders] Page ${page} fetch failed for token ${tokenAddress}; using partial orderbook:`,
+				error
+			);
+			hasMore = false;
 		}
 	}
 	if (hasMore) {

--- a/src/lib/clients/http.test.ts
+++ b/src/lib/clients/http.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchJson, HttpError, isRateLimitError } from './http';
+
+describe('fetchJson structured errors', () => {
+	it('surfaces 429 metadata without creating a retry storm', async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			new Response('{}', {
+				status: 429,
+				headers: { 'retry-after': '2' }
+			})
+		);
+
+		const result = fetchJson('/api/st0x/v1/orders/token/test', { fetchFn });
+
+		await expect(result).rejects.toMatchObject({
+			status: 429,
+			code: 'HTTP_429',
+			retryAfter: '2'
+		});
+		await expect(result).rejects.toSatisfy(isRateLimitError);
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('preserves API code, request id, status, and retry metadata', async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					request_id: 'request-123',
+					error: {
+						code: 'ORDERS_QUERY_FAILED',
+						message: 'The order source could not serve this request'
+					}
+				}),
+				{
+					status: 502,
+					headers: { 'retry-after': '5' }
+				}
+			)
+		);
+
+		const result = fetchJson('/api/st0x/v1/orders/token/test', {
+			fetchFn,
+			retries: 0
+		});
+
+		await expect(result).rejects.toBeInstanceOf(HttpError);
+		await expect(result).rejects.toMatchObject({
+			name: 'HttpError',
+			status: 502,
+			code: 'ORDERS_QUERY_FAILED',
+			requestId: 'request-123',
+			publicMessage: 'The order source could not serve this request',
+			retryAfter: '5'
+		});
+	});
+
+	it('does not retry a non-retryable client failure', async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					request_id: 'request-400',
+					error: { code: 'SWAP_UNSUPPORTED_TOKEN', message: 'Unsupported token' }
+				}),
+				{ status: 400 }
+			)
+		);
+
+		await expect(fetchJson('/api/st0x/v1/swap/quote', { fetchFn })).rejects.toMatchObject({
+			code: 'SWAP_UNSUPPORTED_TOKEN'
+		});
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses the correlation header when a noncanonical error has no body request id', async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			new Response('gateway failed', {
+				status: 502,
+				statusText: 'Bad Gateway',
+				headers: { 'x-request-id': 'proxy-request-456' }
+			})
+		);
+
+		await expect(
+			fetchJson('/api/st0x/v1/orders/token/test', { fetchFn, retries: 0 })
+		).rejects.toMatchObject({
+			code: 'HTTP_502',
+			requestId: 'proxy-request-456',
+			publicMessage: 'Bad Gateway'
+		});
+	});
+});

--- a/src/lib/clients/http.ts
+++ b/src/lib/clients/http.ts
@@ -6,6 +6,45 @@ export interface FetchJsonOptions extends RequestInit {
 	fetchFn?: FetchLike;
 }
 
+interface ErrorEnvelope {
+	request_id?: unknown;
+	error?: {
+		code?: unknown;
+		message?: unknown;
+	};
+}
+
+export interface HttpErrorOptions {
+	status: number;
+	code: string;
+	requestId: string | null;
+	publicMessage: string;
+	retryAfter: string | null;
+}
+
+/** Structured HTTP failure retained across the browser/API proxy boundary. */
+export class HttpError extends Error {
+	readonly status: number;
+	readonly code: string;
+	readonly requestId: string | null;
+	readonly publicMessage: string;
+	readonly retryAfter: string | null;
+
+	constructor(options: HttpErrorOptions) {
+		super(options.publicMessage);
+		this.name = 'HttpError';
+		this.status = options.status;
+		this.code = options.code;
+		this.requestId = options.requestId;
+		this.publicMessage = options.publicMessage;
+		this.retryAfter = options.retryAfter;
+	}
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+	return error instanceof HttpError;
+}
+
 // NOTE: 429 (Too Many Requests) and 503 (Service Unavailable) are deliberately
 // EXCLUDED. When the upstream is overloaded and shedding load, retrying these is a
 // retry storm that amplifies the very problem — every retry adds load precisely when
@@ -17,11 +56,56 @@ const defaultRetryableStatuses = new Set([408, 500, 502, 504]);
 
 /** True when an error thrown by fetchJson/fetchText represents an upstream 429. */
 export function isRateLimitError(error: unknown): boolean {
-	return error instanceof Error && /^HTTP 429\b/.test(error.message);
+	return (
+		(isHttpError(error) && error.status === 429) ||
+		(error instanceof Error && /^HTTP 429\b/.test(error.message))
+	);
 }
 
 async function delay(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseErrorEnvelope(text: string): ErrorEnvelope | null {
+	if (!text) return null;
+	try {
+		const value = JSON.parse(text) as unknown;
+		return typeof value === 'object' && value !== null ? (value as ErrorEnvelope) : null;
+	} catch {
+		return null;
+	}
+}
+
+function httpErrorFromResponse(response: Response, text: string): HttpError {
+	const envelope = parseErrorEnvelope(text);
+	const code =
+		typeof envelope?.error?.code === 'string' ? envelope.error.code : `HTTP_${response.status}`;
+	const publicMessage =
+		typeof envelope?.error?.message === 'string'
+			? envelope.error.message
+			: response.statusText || 'Request failed';
+	const requestId =
+		typeof envelope?.request_id === 'string'
+			? envelope.request_id
+			: response.headers.get('x-request-id');
+
+	return new HttpError({
+		status: response.status,
+		code,
+		requestId,
+		publicMessage,
+		retryAfter: response.headers.get('retry-after')
+	});
+}
+
+function retryDelayFor(error: HttpError, fallbackMs: number): number {
+	if (!error.retryAfter) return fallbackMs;
+
+	const seconds = Number(error.retryAfter);
+	if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+
+	const retryAt = Date.parse(error.retryAfter);
+	return Number.isNaN(retryAt) ? fallbackMs : Math.max(0, retryAt - Date.now());
 }
 
 /**
@@ -43,14 +127,14 @@ async function fetchWithRetry<T>(
 			const response = await fetchFn(url, requestInit);
 			const text = await response.text();
 			if (!response.ok) {
+				const httpError = httpErrorFromResponse(response, text);
 				// Only retry on selected status codes
 				if (defaultRetryableStatuses.has(response.status) && attempt < retries) {
 					attempt += 1;
-					await delay(retryDelayMs * Math.pow(2, attempt - 1));
+					await delay(retryDelayFor(httpError, retryDelayMs * Math.pow(2, attempt - 1)));
 					continue;
 				}
-				const message = text || `${response.status} ${response.statusText}`;
-				throw new Error(`HTTP ${response.status}: ${message}`);
+				throw httpError;
 			}
 
 			// Create a synthetic Response with the already-read text for the parser
@@ -59,6 +143,9 @@ async function fetchWithRetry<T>(
 			);
 		} catch (error) {
 			lastError = error;
+			if (isHttpError(error)) {
+				break;
+			}
 			if (attempt >= retries) {
 				break;
 			}

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -77,6 +77,15 @@ export function getRequestContext(): RequestContext | undefined {
 	return contextStore.getStore();
 }
 
+/** Keep correlation IDs compatible with the REST API's accepted header contract. */
+export function requestIdOrUuid(value: string | null | undefined): string {
+	const trimmed = value?.trim();
+	if (trimmed && trimmed.length <= 128 && /^[\x20-\x7E]+$/.test(trimmed)) {
+		return trimmed;
+	}
+	return randomUUID();
+}
+
 /**
  * SvelteKit `Handle` hook — must be the FIRST link in the sequence chain so that:
  *  - Sentry breadcrumbs see the request_id;
@@ -93,7 +102,7 @@ export function getRequestContext(): RequestContext | undefined {
  * lack the field rather than blocking the request).
  */
 export const requestContextHandle: Handle = async ({ event, resolve }) => {
-	const request_id = event.request.headers.get('x-request-id') ?? randomUUID();
+	const request_id = requestIdOrUuid(event.request.headers.get('x-request-id'));
 	const sessionId = event.cookies.get('session');
 	let wallet: string | null = null;
 	if (sessionId && /^[a-f0-9]{64}$/.test(sessionId)) {

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -7,9 +7,27 @@
  */
 
 import { env } from '$env/dynamic/private';
+import { getLogger, getRequestContext, requestIdOrUuid } from '$lib/server/logger';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const TOKEN_DETAILS_LIST_PATH = 'v1/tokens/details';
+
+function errorResponse(requestId: string, status: number, code: string, message: string): Response {
+	return new Response(
+		JSON.stringify({
+			request_id: requestId,
+			error: { code, message }
+		}),
+		{
+			status,
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Request-Id': requestId,
+				'Cache-Control': 'no-store'
+			}
+		}
+	);
+}
 
 function getApiBase(): string {
 	const url = env.ST0X_API_URL;
@@ -106,6 +124,9 @@ async function shouldCacheResponse(pathSuffix: string, response: Response): Prom
 }
 
 const proxyRequest = async ({ request, params, url }: RequestEvent) => {
+	const requestId = requestIdOrUuid(
+		getRequestContext()?.request_id ?? request.headers.get('x-request-id')
+	);
 	let apiBase: string;
 	let authHeader: string;
 	try {
@@ -113,17 +134,14 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 		authHeader = getAuthHeader();
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : 'Proxy configuration error';
-		console.error('[st0x-proxy] Config error:', msg);
-		return new Response(JSON.stringify({ error: msg }), {
-			status: 503,
-			headers: { 'Content-Type': 'application/json' }
-		});
+		getLogger().error({ error: { message: msg } }, 'st0x proxy configuration error');
+		return errorResponse(requestId, 503, 'UPSTREAM_UNAVAILABLE', 'The trading API is unavailable');
 	}
 
 	const pathSuffix = Array.isArray(params.path) ? params.path.join('/') : params.path ?? '';
 	const matched = matchProxyRoute(request.method, pathSuffix);
 	if (!matched) {
-		return new Response('Not found', { status: 404 });
+		return errorResponse(requestId, 404, 'NOT_FOUND', 'Proxy route not found');
 	}
 	const targetUrl = `${apiBase}/${pathSuffix}${url.search}`;
 
@@ -131,6 +149,7 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 	headers.set('Content-Type', 'application/json');
 	headers.set('Accept', 'application/json');
 	headers.set('Authorization', authHeader);
+	headers.set('X-Request-Id', requestId);
 
 	const init: RequestInit = {
 		method: request.method,
@@ -148,16 +167,22 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 		response = await fetch(targetUrl, init);
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : 'Unknown upstream error';
-		console.error(`[st0x-proxy] Upstream fetch failed (${targetUrl}):`, msg);
-		return new Response(JSON.stringify({ error: 'Upstream API unreachable', detail: msg }), {
-			status: 502,
-			headers: { 'Content-Type': 'application/json' }
-		});
+		getLogger().error(
+			{ error: { message: msg }, upstream_path: pathSuffix },
+			'st0x upstream request failed'
+		);
+		return errorResponse(requestId, 503, 'UPSTREAM_UNAVAILABLE', 'The trading API is unavailable');
 	}
 
 	const responseHeaders = new Headers();
 	responseHeaders.set('Content-Type', response.headers.get('Content-Type') ?? 'application/json');
-	if (matched.cache && (await shouldCacheResponse(pathSuffix, response))) {
+	for (const headerName of ['x-request-id', 'retry-after']) {
+		const value = response.headers.get(headerName);
+		if (value) responseHeaders.set(headerName, value);
+	}
+	if (!response.ok) {
+		responseHeaders.set('Cache-Control', 'no-store');
+	} else if (matched.cache && (await shouldCacheResponse(pathSuffix, response))) {
 		responseHeaders.set('Cache-Control', matched.cache);
 	}
 

--- a/tests/lib/api/orders.test.ts
+++ b/tests/lib/api/orders.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Float } from '@rainlanguage/float';
-import { fetchAndQuoteTokenOrders } from '$lib/api/orders';
+import { fetchAndQuotePaymentTokenOrders, fetchAndQuoteTokenOrders } from '$lib/api/orders';
 import { apiGetOrdersByToken, type ApiOrderSummary } from '$lib/api/st0xApi';
 
 vi.mock('$lib/api/st0xApi', async (importOriginal) => {
@@ -92,5 +92,63 @@ describe('fetchAndQuoteTokenOrders', () => {
 		const quotes = await fetchAndQuoteTokenOrders(8453, stockToken.address, paymentToken);
 
 		expect(quotes).toEqual([]);
+	});
+
+	it('propagates REST failures instead of presenting an empty orderbook', async () => {
+		vi.mocked(apiGetOrdersByToken).mockRejectedValueOnce(new Error('REST unavailable'));
+
+		await expect(fetchAndQuoteTokenOrders(8453, stockToken.address, paymentToken)).rejects.toThrow(
+			'REST unavailable'
+		);
+	});
+
+	it('returns earlier pages when a later page fails', async () => {
+		vi.mocked(apiGetOrdersByToken)
+			.mockResolvedValueOnce({
+				orders: [orderSummary()],
+				pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: true }
+			})
+			.mockRejectedValueOnce(new Error('page 2 unavailable'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		const quotes = await fetchAndQuoteTokenOrders(8453, stockToken.address, paymentToken);
+
+		expect(quotes).toHaveLength(1);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining('using partial orderbook'),
+			expect.any(Error)
+		);
+		warn.mockRestore();
+	});
+});
+
+describe('fetchAndQuotePaymentTokenOrders', () => {
+	it('propagates REST failures when no usable quotes remain', async () => {
+		vi.mocked(apiGetOrdersByToken).mockReset();
+		vi.mocked(apiGetOrdersByToken).mockRejectedValue(new Error('REST unavailable'));
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'REST unavailable'
+		);
+	});
+
+	it('returns quotes from successful tokens when another token request fails', async () => {
+		vi.mocked(apiGetOrdersByToken).mockReset();
+		vi.mocked(apiGetOrdersByToken)
+			.mockResolvedValueOnce({
+				orders: [orderSummary()],
+				pagination: { page: 1, pageSize: 50, totalOrders: 1, totalPages: 1, hasMore: false }
+			})
+			.mockRejectedValue(new Error('token unavailable'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
+
+		expect(quotes).toHaveLength(1);
+		expect(warn).toHaveBeenCalledWith(
+			'[orders] Token fetch failed; using partial orderbook:',
+			expect.any(Error)
+		);
+		warn.mockRestore();
 	});
 });

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -9,11 +9,17 @@ vi.mock('$env/dynamic/private', () => ({
 
 type St0xProxyEvent = Parameters<typeof GET>[0];
 
-function proxyEvent(method: string, path: string, body?: BodyInit): St0xProxyEvent {
+function proxyEvent(
+	method: string,
+	path: string,
+	body?: BodyInit,
+	headers?: Record<string, string>
+): St0xProxyEvent {
 	const event = createMockRequestEvent({
 		method,
 		url: `http://localhost/api/st0x/${path}?page=1`,
-		body
+		body,
+		headers
 	});
 	return {
 		...event,
@@ -341,5 +347,95 @@ describe('/api/st0x proxy', () => {
 			'https://api.example.test/v1/tokens/0xToken/details?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
+	});
+
+	it('forwards the website request id and preserves upstream correlation metadata', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					request_id: 'web-request-123',
+					error: { code: 'ORDERS_QUERY_FAILED', message: 'Order source unavailable' }
+				}),
+				{
+					status: 502,
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Request-Id': 'web-request-123',
+						'Retry-After': '5'
+					}
+				}
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(
+			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+				'X-Request-Id': 'web-request-123'
+			})
+		);
+
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect((init.headers as Headers).get('X-Request-Id')).toBe('web-request-123');
+		expect(response.status).toBe(502);
+		expect(response.headers.get('X-Request-Id')).toBe('web-request-123');
+		expect(response.headers.get('Retry-After')).toBe('5');
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		expect(await response.json()).toMatchObject({
+			request_id: 'web-request-123',
+			error: { code: 'ORDERS_QUERY_FAILED' }
+		});
+	});
+
+	it('replaces an invalid request id before forwarding it upstream', async () => {
+		const incomingId = 'x'.repeat(129);
+		const fetchMock = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+			const requestId = (init.headers as Headers).get('X-Request-Id');
+			return new Response(
+				JSON.stringify({
+					request_id: requestId,
+					error: { code: 'ORDERS_QUERY_FAILED', message: 'Order source unavailable' }
+				}),
+				{
+					status: 502,
+					headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId ?? '' }
+				}
+			);
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(
+			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+				'X-Request-Id': incomingId
+			})
+		);
+		const body = await response.json();
+		const forwardedId = (fetchMock.mock.calls[0][1].headers as Headers).get('X-Request-Id');
+
+		expect(forwardedId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(forwardedId).not.toBe(incomingId);
+		expect(response.headers.get('X-Request-Id')).toBe(forwardedId);
+		expect(body.request_id).toBe(forwardedId);
+	});
+
+	it('returns a correlated static envelope when the upstream cannot be reached', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('private DNS detail')));
+
+		const response = await GET(
+			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+				'X-Request-Id': 'web-request-503'
+			})
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get('X-Request-Id')).toBe('web-request-503');
+		expect(body).toEqual({
+			request_id: 'web-request-503',
+			error: {
+				code: 'UPSTREAM_UNAVAILABLE',
+				message: 'The trading API is unavailable'
+			}
+		});
+		expect(JSON.stringify(body)).not.toContain('private DNS detail');
 	});
 });

--- a/tests/lib/server/logger.test.ts
+++ b/tests/lib/server/logger.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { pickLevelForRoute, getRequestContext, getLogger } from '$lib/server/logger';
+import {
+	pickLevelForRoute,
+	getRequestContext,
+	getLogger,
+	requestContextHandle
+} from '$lib/server/logger';
 
 describe('pickLevelForRoute', () => {
 	// Status takes precedence over route. Verified for every route bucket
@@ -79,6 +84,30 @@ describe('pickLevelForRoute', () => {
 });
 
 describe('getRequestContext', () => {
+	it('replaces an invalid incoming request id before context, logging, and response handling', async () => {
+		const incomingId = 'x'.repeat(129);
+		let contextId: string | undefined;
+		const event = {
+			request: new Request('http://localhost/api/st0x/health', {
+				headers: { 'x-request-id': incomingId }
+			}),
+			url: new URL('http://localhost/api/st0x/health'),
+			cookies: { get: () => undefined }
+		};
+
+		const response = await requestContextHandle({
+			event,
+			resolve: async () => {
+				contextId = getRequestContext()?.request_id;
+				return new Response('ok');
+			}
+		} as unknown as Parameters<typeof requestContextHandle>[0]);
+
+		expect(contextId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(contextId).not.toBe(incomingId);
+		expect(response.headers.get('x-request-id')).toBe(contextId);
+	});
+
 	// requestContextHandle calls contextStore.run(...) inside a SvelteKit hook;
 	// at the unit-test level we can't easily spin a real Handle event, so the
 	// smoke test below uses an internal AsyncLocalStorage instance to exercise


### PR DESCRIPTION
## Chained PRs

- Stack 1 of 3
- Child: [#225](https://github.com/SARKEX/st0x/pull/225)
- Companion REST API stack: [ST0x-Technology/st0x.rest.api#155](https://github.com/ST0x-Technology/st0x.rest.api/pull/155) → [#156](https://github.com/ST0x-Technology/st0x.rest.api/pull/156)

## Motivation

The website transport discarded stable REST error codes and request correlation IDs, which prevented support from connecting a user screenshot to API logs and traces.

## Solution

- Preserve canonical status, code, public message, request ID, retry metadata, and safe fallbacks in `HttpError`.
- Proxy typed REST envelopes without caching failures or leaking upstream details.
- Forward validated correlation IDs consistently between the browser, website, and REST API.
- Stop retrying permanent client failures while honoring `Retry-After` for transient responses.
- Propagate orders API failures instead of converting them into empty liquidity results.

## Checks

- [x] Focused transport, proxy, request-context, and orders tests
- [x] `bun run check`
- [x] `bun run lint-check`
- [x] `bun run format-check`
- [x] Full suite on the completed stack: 77 files passed; 830 tests passed, 1 skipped
- [x] Local REST → website proxy correlation check

## Linear

Fixes RAI-333

- [RAI-333 — Surface user-facing error codes for support and debugging](https://linear.app/makeitrain/issue/RAI-333/surface-user-facing-error-codes-for-support-and-debugging)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order-fetch and token aggregation behavior: REST/API failures now propagate when no valid quotes exist, and partial results now surface with warnings when appropriate.
  * Standardized proxy error responses with consistent JSON schema, correct status codes, and correlated `X-Request-Id`/`request_id` headers.
  * Prevented sensitive upstream failure details from being returned.
* **Reliability**
  * Validates incoming request IDs (trim/character checks, safe UUID fallback) and preserves correlation through proxy requests/responses.
  * Improved HTTP retry handling, including honoring `Retry-After` guidance and better rate-limit recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->