### PR TITLE
feat(trading): add structured user-facing error model

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -27,6 +27,7 @@
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS
 	} from '$lib/services/marketOrderExecution';
+	import { createTradeError, toUserFacingTradeError } from '$lib/services/tradeError';
 
 	// Quick Trade intentionally uses a fixed 1% slippage tolerance to keep the
 	// simplified flow free of advanced order controls.
@@ -406,7 +407,10 @@
 		}
 
 		const orderSide = isBuying ? 'Buy' : 'Sell';
-		if (!tradeAnchor) return;
+		if (!tradeAnchor) {
+			tradeError = createTradeError('SWAP_QUOTE_FAILED', { stage: 'quote' }).message;
+			return;
+		}
 
 		isExecutingTrade = true;
 		tradeError = null;
@@ -433,14 +437,18 @@
 			});
 
 			if (!result.success) {
-				tradeError = result.error || 'Trade failed';
+				const userFacingError =
+					result.tradeError ?? toUserFacingTradeError(result.error, 'submission');
+				tradeError = userFacingError.message;
 				track('quick_trade_failed', {
 					token_symbol: selectedToken?.symbol,
 					direction: isBuying ? 'buy' : 'sell',
 					usdc_amount: topAmount,
 					token_amount: bottomAmount,
 					avg_price: quote?.avgPrice,
-					error: tradeError
+					error: tradeError,
+					error_code: userFacingError.code,
+					request_id: userFacingError.requestId
 				});
 			} else {
 				tradeSubmittedSuccessfully = true;
@@ -457,14 +465,17 @@
 			}
 		} catch (error) {
 			console.error('Trade error:', error);
-			tradeError = error instanceof Error ? error.message : 'Trade failed';
+			const userFacingError = toUserFacingTradeError(error, 'submission');
+			tradeError = userFacingError.message;
 			track('quick_trade_failed', {
 				token_symbol: selectedToken?.symbol,
 				direction: isBuying ? 'buy' : 'sell',
 				usdc_amount: topAmount,
 				token_amount: bottomAmount,
 				avg_price: quote?.avgPrice,
-				error: tradeError
+				error: tradeError,
+				error_code: userFacingError.code,
+				request_id: userFacingError.requestId
 			});
 		} finally {
 			isExecutingTrade = false;

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -21,13 +21,13 @@
 	} from '$lib/services/marketOrderExecution';
 	import { isOutsideMarketHours } from '$lib/utils/marketHours';
 	import { trackTradeEvent, type ErrorClass } from '$lib/services/observability/tradeEvents';
-	import { classifyError } from '$lib/services/observability/classifyError';
 	import {
 		captureTradeFlowError,
 		inferWalletFailureStage,
 		type TradeFlowStage
 	} from '$lib/services/observability/tradeFlow';
 	import { withTradeId } from '$lib/services/observability/tradeId';
+	import { toUserFacingTradeError } from '$lib/services/tradeError';
 	import { onMount } from 'svelte';
 
 	export let orderSide: 'Buy' | 'Sell' = 'Buy';
@@ -602,12 +602,13 @@
 				});
 
 				if (!result.success && result.error) {
-					orderPreparationError = result.error;
+					const userFacingError =
+						result.tradeError ?? toUserFacingTradeError(result.error, activeStage);
+					orderPreparationError = userFacingError.message;
 					// Prefer the service's discriminated errorClass; fall back to
 					// substring-classifying the user-facing string only if absent
 					// (shouldn't happen post-Phase-2 but kept as a defence).
-					const eventErrorClass =
-						result.errorClass ?? classifyError(new Error(result.error), 'market');
+					const eventErrorClass = result.errorClass ?? userFacingError.errorClass;
 					serviceErrorClass = eventErrorClass;
 					trackTradeEvent('trade_failed', {
 						order_type: 'market',
@@ -620,7 +621,9 @@
 						),
 						avg_price: marketPrice,
 						error_class: eventErrorClass,
-						error_message: result.error
+						error_message: userFacingError.message,
+						error_code: userFacingError.code,
+						...(userFacingError.requestId ? { request_id: userFacingError.requestId } : {})
 					});
 				} else if (result.success) {
 					tradeSubmittedSuccessfully = true;
@@ -644,7 +647,8 @@
 				const failureStage =
 					activeStage === 'calldata' ? inferWalletFailureStage(error) : activeStage;
 				captureTradeFlowError(error, flowContext(failureStage, 'submit_market_order'));
-				orderPreparationError = error instanceof Error ? error.message : 'Unknown error occurred';
+				const userFacingError = toUserFacingTradeError(error, failureStage);
+				orderPreparationError = userFacingError.message;
 				trackTradeEvent('trade_failed', {
 					order_type: 'market',
 					order_side: orderSide.toLowerCase() as 'buy' | 'sell',
@@ -655,8 +659,10 @@
 						inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
 					),
 					avg_price: marketPrice,
-					error_class: classifyError(error, 'market'),
-					error_message: orderPreparationError
+					error_class: userFacingError.errorClass,
+					error_message: userFacingError.message,
+					error_code: userFacingError.code,
+					...(userFacingError.requestId ? { request_id: userFacingError.requestId } : {})
 				});
 			} finally {
 				isSubmittingMarketOrder = false;

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -25,7 +25,11 @@ import {
 	sendTransaction,
 	waitForTransaction
 } from '$lib/services/walletService';
-import { classifyError } from '$lib/services/observability/classifyError';
+import {
+	toUserFacingTradeError,
+	type TradeErrorStage,
+	type UserFacingTradeError
+} from '$lib/services/tradeError';
 import {
 	addTradeFlowBreadcrumb,
 	captureTradeFlowError
@@ -76,6 +80,7 @@ export interface MarketOrderResult {
 	success: boolean;
 	error?: string;
 	errorClass?: ErrorClass;
+	tradeError?: UserFacingTradeError;
 }
 
 export function oracleReferenceIoRatio(
@@ -390,21 +395,29 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		paymentSymbol: paymentToken.symbol
 	});
 	let activeStage: 'quote' | 'calldata' | 'submission' = 'calldata';
+	let activeTradeErrorStage: TradeErrorStage = 'calldata';
 
 	const failWith = (error: unknown): MarketOrderResult => {
-		const message = error instanceof Error ? error.message : 'Unknown error occurred';
+		const rawMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+		const tradeError = toUserFacingTradeError(error, activeTradeErrorStage);
 		transactionStoreInternal.update((state) => ({
 			...state,
 			status: TransactionStatus.ERROR,
-			error: message
+			error: tradeError.message
 		}));
-		return { success: false, error: message, errorClass: classifyError(error, 'market') };
+		return {
+			success: false,
+			error: rawMessage,
+			errorClass: tradeError.errorClass,
+			tradeError
+		};
 	};
 
 	try {
 		const taker = getSignerAddress();
 		if (!taker) {
-			return { success: false, error: 'Wallet not connected. Please reconnect and try again.' };
+			activeTradeErrorStage = 'signing';
+			return failWith(new Error('Wallet not connected. Please reconnect and try again.'));
 		}
 
 		const request = buildCalldataRequest(input, taker);
@@ -423,8 +436,10 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		});
 
 		if (response.approvals.length > 0) {
+			activeTradeErrorStage = 'approval';
 			const inputTokenDecimals = orderSide === 'Buy' ? paymentToken.decimals : assetToken.decimals;
 			await submitApprovals(response.approvals, request, network, inputTokenDecimals);
+			activeTradeErrorStage = 'calldata';
 			response = await apiGetSwapCalldataV2(
 				buildApprovalRetryRequest(request, response.resolvedPriceCap)
 			);
@@ -432,6 +447,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 
 		const transaction = validateReadyCalldata(response, request, network);
 		activeStage = 'submission';
+		activeTradeErrorStage = 'signing';
 		addTradeFlowBreadcrumb(flowContext('submission', 'take_market_order'), 'started');
 		trackTradeEvent('sign_trade', {
 			order_type: 'market',
@@ -439,6 +455,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		});
 		transactionStoreInternal.awaitWalletConfirmation('Awaiting wallet confirmation...');
 		const hash = await sendTransaction(transaction);
+		activeTradeErrorStage = 'confirmation';
 		trackTradeEvent('broadcast', {
 			order_type: 'market',
 			order_side: orderSide.toLowerCase() as 'buy' | 'sell',

--- a/src/lib/services/observability/tradeEvents.ts
+++ b/src/lib/services/observability/tradeEvents.ts
@@ -64,6 +64,8 @@ export interface TradeEventProps {
 	slippage_bps?: number;
 	error_class?: ErrorClass;
 	error_message?: string;
+	error_code?: string;
+	request_id?: string;
 	// Tolerate existing call-site extras (e.g. token_symbol, intended_trade_size_usd)
 	[key: string]: unknown;
 }

--- a/src/lib/services/observability/tradeFlow.ts
+++ b/src/lib/services/observability/tradeFlow.ts
@@ -10,6 +10,8 @@
 import * as Sentry from '@sentry/sveltekit';
 import { classifyError } from './classifyError';
 import { getCurrentTradeId } from './tradeId';
+import { toUserFacingTradeError } from '$lib/services/tradeError';
+import { isHttpError } from '$lib/clients/http';
 
 export type TradeFlowStage =
 	| 'quote'
@@ -86,11 +88,15 @@ export function addTradeFlowBreadcrumb(
  */
 export function captureTradeFlowError(error: unknown, context: TradeFlowContext): void {
 	const normalized = asError(error);
-	const errorClass = classifyError(
-		normalized,
-		context.orderType === 'market' ? 'market' : 'deploy'
-	);
-	const data = compactContext(context);
+	const userFacingError = toUserFacingTradeError(error, context.stage);
+	const errorClass = isHttpError(error)
+		? userFacingError.errorClass
+		: classifyError(normalized, context.orderType === 'market' ? 'market' : 'deploy');
+	const data = {
+		...compactContext(context),
+		error_code: userFacingError.code,
+		...(userFacingError.requestId ? { request_id: userFacingError.requestId } : {})
+	};
 	const tradeId = context.tradeId ?? getCurrentTradeId();
 
 	try {
@@ -105,9 +111,11 @@ export function captureTradeFlowError(error: unknown, context: TradeFlowContext)
 				trade_operation: context.operation,
 				order_type: context.orderType,
 				error_class: errorClass,
+				error_code: userFacingError.code,
 				...(context.orderSide ? { order_side: context.orderSide } : {}),
 				...(tradeId ? { trade_id: tradeId } : {}),
-				...(context.chainId != null ? { chain_id: String(context.chainId) } : {})
+				...(context.chainId != null ? { chain_id: String(context.chainId) } : {}),
+				...(userFacingError.requestId ? { request_id: userFacingError.requestId } : {})
 			},
 			contexts: {
 				trade_flow: data

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -1,0 +1,307 @@
+import { isHttpError } from '$lib/clients/http';
+import type { ErrorClass } from '$lib/services/observability/tradeEvents';
+
+export type TradeErrorStage =
+	| 'quote'
+	| 'calldata'
+	| 'approval'
+	| 'signing'
+	| 'submission'
+	| 'confirmation';
+
+export type TradeErrorAction =
+	| 'retry'
+	| 'adjust_amount'
+	| 'reconnect_wallet'
+	| 'review_balance'
+	| 'try_later'
+	| 'contact_support'
+	| 'none';
+
+export interface UserFacingTradeError {
+	code: string;
+	title: string;
+	message: string;
+	requestId: string | null;
+	stage: TradeErrorStage;
+	retryable: boolean;
+	action: TradeErrorAction;
+	errorClass: ErrorClass;
+}
+
+type CatalogEntry = Omit<UserFacingTradeError, 'code' | 'requestId' | 'stage'>;
+
+const trustedTradeErrors = new WeakSet<object>();
+
+const DEFAULT_ERROR: CatalogEntry = {
+	title: 'Trade could not be completed',
+	message: 'Try again. If the problem continues, share the error details with support.',
+	retryable: true,
+	action: 'retry',
+	errorClass: 'unknown'
+};
+
+const ERROR_CATALOG: Record<string, CatalogEntry> = {
+	SWAP_UNSUPPORTED_TOKEN: {
+		title: 'Token not supported',
+		message: 'Choose another token pair and try again.',
+		retryable: false,
+		action: 'none',
+		errorClass: 'unknown'
+	},
+	SWAP_NO_LIQUIDITY: {
+		title: 'No liquidity for this trade',
+		message:
+			'No liquidity available right now for this size. Try a smaller amount or check back in a minute.',
+		retryable: true,
+		action: 'adjust_amount',
+		errorClass: 'no_liquidity'
+	},
+	SWAP_QUOTE_FAILED: {
+		title: 'Quote unavailable',
+		message: 'We could not calculate a reliable quote. Refresh the market data and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'unknown'
+	},
+	SWAP_PREFLIGHT_FAILED: {
+		title: 'Trade verification failed',
+		message: 'We could not verify the trade against the latest chain state. Try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'preflight_chain_unreachable'
+	},
+	SWAP_CALLDATA_FAILED: {
+		title: 'Trade preparation failed',
+		message: 'We could not prepare the transaction. Refresh the quote and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'unknown'
+	},
+	ORDERS_QUERY_FAILED: {
+		title: 'Market data unavailable',
+		message: 'We could not load current orders. Try again in a moment.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'rpc_error'
+	},
+	UPSTREAM_UNAVAILABLE: {
+		title: 'Trading service unavailable',
+		message: 'A trading service is temporarily unavailable. Try again in a moment.',
+		retryable: true,
+		action: 'try_later',
+		errorClass: 'rpc_error'
+	},
+	RATE_LIMITED: {
+		title: 'Too many requests',
+		message: 'Please wait a moment before trying again.',
+		retryable: true,
+		action: 'try_later',
+		errorClass: 'rpc_error'
+	},
+	NOT_YET_INDEXED: {
+		title: 'Trade data is still indexing',
+		message: 'This trade data is not available yet. Wait a moment and try again.',
+		retryable: true,
+		action: 'try_later',
+		errorClass: 'unknown'
+	},
+	BAD_REQUEST: {
+		title: 'Trade details were not accepted',
+		message: 'Review the trade details and try again.',
+		retryable: false,
+		action: 'none',
+		errorClass: 'unknown'
+	},
+	UNPROCESSABLE_ENTITY: {
+		title: 'Trade details were not accepted',
+		message: 'Review the trade details and try again.',
+		retryable: false,
+		action: 'none',
+		errorClass: 'unknown'
+	},
+	UNAUTHORIZED: {
+		title: 'Trading service unavailable',
+		message:
+			'The trading service could not authorize this request. Contact support if it continues.',
+		retryable: false,
+		action: 'contact_support',
+		errorClass: 'unknown'
+	},
+	FORBIDDEN: {
+		title: 'Trading service unavailable',
+		message:
+			'The trading service could not authorize this request. Contact support if it continues.',
+		retryable: false,
+		action: 'contact_support',
+		errorClass: 'unknown'
+	},
+	NOT_FOUND: {
+		title: 'Trade route unavailable',
+		message: 'The requested trade route is not available. Refresh and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'unknown'
+	},
+	INTERNAL_ERROR: {
+		...DEFAULT_ERROR,
+		title: 'Trading service error'
+	},
+	TRADE_WALLET_NOT_CONNECTED: {
+		title: 'Wallet disconnected',
+		message: 'Reconnect your wallet and try again.',
+		retryable: true,
+		action: 'reconnect_wallet',
+		errorClass: 'unknown'
+	},
+	TRADE_WALLET_ACTION_REJECTED: {
+		title: 'Wallet action cancelled',
+		message: 'No transaction was submitted. You can try again when ready.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'user_rejected'
+	},
+	TRADE_INSUFFICIENT_BALANCE: {
+		title: 'Insufficient balance',
+		message: 'Reduce the amount or add funds before trying again.',
+		retryable: false,
+		action: 'review_balance',
+		errorClass: 'insufficient_balance'
+	},
+	TRADE_MARKET_CLOSED: {
+		title: 'Market closed',
+		message: 'This market is currently closed. Try again during market hours.',
+		retryable: false,
+		action: 'try_later',
+		errorClass: 'market_closed'
+	},
+	TRADE_SLIPPAGE_EXCEEDED: {
+		title: 'Price moved beyond your limit',
+		message: 'Refresh the quote or adjust the slippage setting before trying again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'slippage_exceeded'
+	},
+	TRADE_PREFLIGHT_CHAIN_UNREACHABLE: {
+		title: 'Could not verify orderbook state',
+		message: 'Unable to verify orderbook state. Please refresh quotes and retry.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'preflight_chain_unreachable'
+	},
+	TRADE_AUTO_RETRY_EXHAUSTED: {
+		title: 'No liquidity for this trade',
+		message:
+			'No liquidity available right now for this size. Try a smaller amount or check back in a minute.',
+		retryable: true,
+		action: 'adjust_amount',
+		errorClass: 'auto_retry_exhausted'
+	},
+	TRADE_APPROVAL_FAILED: {
+		title: 'Approval failed',
+		message: 'The token approval did not complete. Check your wallet and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'unknown'
+	},
+	TRADE_SIGNING_FAILED: {
+		title: 'Signature failed',
+		message: 'The wallet signature did not complete. Check your wallet and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'unknown'
+	},
+	TRADE_SUBMISSION_FAILED: {
+		title: 'Transaction submission failed',
+		message: 'The transaction was not submitted. Check your connection and try again.',
+		retryable: true,
+		action: 'retry',
+		errorClass: 'rpc_error'
+	},
+	TRADE_CONFIRMATION_FAILED: {
+		title: 'Transaction confirmation failed',
+		message: 'We could not confirm the transaction. Check the block explorer before retrying.',
+		retryable: false,
+		action: 'contact_support',
+		errorClass: 'rpc_error'
+	},
+	TRADE_UNKNOWN: DEFAULT_ERROR
+};
+
+const STAGE_FALLBACK: Record<TradeErrorStage, string> = {
+	quote: 'SWAP_QUOTE_FAILED',
+	calldata: 'SWAP_CALLDATA_FAILED',
+	approval: 'TRADE_APPROVAL_FAILED',
+	signing: 'TRADE_SIGNING_FAILED',
+	submission: 'TRADE_SUBMISSION_FAILED',
+	confirmation: 'TRADE_CONFIRMATION_FAILED'
+};
+
+function safeCode(code: string): string {
+	return /^[A-Z][A-Z0-9_]{0,63}$/.test(code) ? code : 'TRADE_UNKNOWN';
+}
+
+export function createTradeError(
+	code: string,
+	options: {
+		stage: TradeErrorStage;
+		requestId?: string | null;
+		errorClass?: ErrorClass;
+	}
+): UserFacingTradeError {
+	const safe = safeCode(code);
+	const entry = ERROR_CATALOG[safe] ?? DEFAULT_ERROR;
+	const result: UserFacingTradeError = {
+		code: safe,
+		title: entry.title,
+		message: entry.message,
+		requestId: options.requestId ?? null,
+		stage: options.stage,
+		retryable: entry.retryable,
+		action: entry.action,
+		errorClass: options.errorClass ?? entry.errorClass
+	};
+	trustedTradeErrors.add(result);
+	return result;
+}
+
+export function isUserFacingTradeError(error: unknown): error is UserFacingTradeError {
+	return Boolean(error && typeof error === 'object' && trustedTradeErrors.has(error));
+}
+
+export function toUserFacingTradeError(
+	error: unknown,
+	stage: TradeErrorStage,
+	fallbackCode: string = STAGE_FALLBACK[stage]
+): UserFacingTradeError {
+	if (isUserFacingTradeError(error)) return error;
+	if (isHttpError(error)) {
+		return createTradeError(error.code, { stage, requestId: error.requestId });
+	}
+
+	const candidate = error as { code?: unknown; message?: unknown } | null;
+	const message = String(candidate?.message ?? error ?? '').toLowerCase();
+	if (candidate?.code === 4001 || /user (rejected|denied)|request rejected/.test(message)) {
+		return createTradeError('TRADE_WALLET_ACTION_REJECTED', { stage });
+	}
+	if (/insufficient|exceeds balance/.test(message)) {
+		return createTradeError('TRADE_INSUFFICIENT_BALANCE', { stage });
+	}
+	if (/wallet.*(not connected|disconnected)/.test(message)) {
+		return createTradeError('TRADE_WALLET_NOT_CONNECTED', { stage });
+	}
+	if (message.includes('slippage')) {
+		return createTradeError('TRADE_SLIPPAGE_EXCEEDED', { stage });
+	}
+	if (message.includes('liquidity') || message.includes('no_walk_fills')) {
+		return createTradeError('SWAP_NO_LIQUIDITY', { stage });
+	}
+	if (message.includes('market') && message.includes('closed')) {
+		return createTradeError('TRADE_MARKET_CLOSED', { stage });
+	}
+	if (/rpc|network|timed? ?out|timeout|connection/.test(message)) {
+		return createTradeError('UPSTREAM_UNAVAILABLE', { stage });
+	}
+
+	return createTradeError(fallbackCode, { stage });
+}

--- a/tests/lib/components/orders/MarketOrder.events.test.ts
+++ b/tests/lib/components/orders/MarketOrder.events.test.ts
@@ -92,9 +92,10 @@ describe('MarketOrder.svelte event instrumentation (Plan 02-03 Task 1a)', () => 
 		expect(classifyError(undefined, 'market')).toBe('unknown');
 	});
 
-	it("Test 5b: component imports the shared classifyError + calls it with the 'market' scope", () => {
-		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/observability\/classifyError['"]/);
-		expect(componentSource).toMatch(/classifyError\s*\([^,]*,\s*['"]market['"]\s*\)/);
+	it('Test 5b: component uses the structured trade error model for failures', () => {
+		expect(componentSource).toMatch(/from\s+['"]\$lib\/services\/tradeError['"]/);
+		expect(componentSource).toMatch(/toUserFacingTradeError\s*\(/);
+		expect(componentSource).toMatch(/error_code:\s*userFacingError\.code/);
 	});
 
 	it('Test 6: panel-level events route through trackTradeEvent', () => {

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -61,6 +61,7 @@ import {
 	executeMarketOrder,
 	oracleReferenceIoRatio
 } from '$lib/services/marketOrderExecution';
+import { HttpError } from '$lib/clients/http';
 import { TAKE_ORDERS_4_ABI } from '$lib/services/takeOrders4Abi';
 import type { ApiSwapCalldataV2Request } from '$lib/api/st0xApi';
 
@@ -571,5 +572,50 @@ describe('executeMarketOrder REST calldata execution', () => {
 		expect(result.error).toContain('unexpected token');
 		expect(mocks.sendTransaction).not.toHaveBeenCalled();
 		expect(mocks.captureTradeFlowError).toHaveBeenCalled();
+	});
+
+	it('preserves structured API error metadata for the support UI', async () => {
+		mocks.apiGetSwapCalldataV2.mockRejectedValue(
+			new HttpError({
+				status: 503,
+				code: 'UPSTREAM_UNAVAILABLE',
+				requestId: 'request-42',
+				publicMessage: 'Trading service unavailable',
+				retryAfter: null
+			})
+		);
+
+		const result = await executeMarketOrder({
+			orderSide: 'Buy',
+			amount: 1_000_000_000_000_000_000n,
+			...tokens,
+			network
+		});
+
+		expect(result.tradeError).toMatchObject({
+			code: 'UPSTREAM_UNAVAILABLE',
+			requestId: 'request-42',
+			stage: 'calldata'
+		});
+	});
+
+	it('maps wallet rejection to the signing support code', async () => {
+		mocks.sendTransaction.mockRejectedValue(new Error('User rejected request'));
+
+		const result = await executeMarketOrder({
+			orderSide: 'Buy',
+			amount: 1_000_000_000_000_000_000n,
+			...tokens,
+			network
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errorClass: 'user_rejected',
+			tradeError: {
+				code: 'TRADE_WALLET_ACTION_REJECTED',
+				stage: 'signing'
+			}
+		});
 	});
 });

--- a/tests/lib/services/observability/tradeFlow.test.ts
+++ b/tests/lib/services/observability/tradeFlow.test.ts
@@ -6,6 +6,7 @@ import {
 	inferWalletFailureStage,
 	type TradeFlowContext
 } from '$lib/services/observability/tradeFlow';
+import { HttpError } from '$lib/clients/http';
 
 vi.mock('$lib/services/observability/tradeId', () => ({
 	getCurrentTradeId: vi.fn(() => 'trade-from-scope')
@@ -52,11 +53,40 @@ describe('tradeFlow Sentry reporter', () => {
 			order_type: 'limit',
 			order_side: 'buy',
 			trade_id: 'trade-explicit',
-			chain_id: '8453'
+			chain_id: '8453',
+			error_code: 'SWAP_CALLDATA_FAILED'
 		});
 		expect(options.contexts.trade_flow).toMatchObject({
 			asset_symbol: 'wtSTOX',
-			payment_symbol: 'USDC'
+			payment_symbol: 'USDC',
+			error_code: 'SWAP_CALLDATA_FAILED'
+		});
+	});
+
+	it('attaches API error code and request id to Sentry tags and context', () => {
+		const captureSpy = vi.spyOn(Sentry, 'captureException');
+		const error = new HttpError({
+			status: 502,
+			code: 'ORDERS_QUERY_FAILED',
+			requestId: 'request-42',
+			publicMessage: 'Order source unavailable',
+			retryAfter: null
+		});
+
+		captureTradeFlowError(error, { ...context, stage: 'quote' });
+
+		const options = captureSpy.mock.calls[0][1] as {
+			tags: Record<string, string>;
+			contexts: Record<string, Record<string, unknown>>;
+		};
+		expect(options.tags).toMatchObject({
+			error_code: 'ORDERS_QUERY_FAILED',
+			request_id: 'request-42',
+			error_class: 'rpc_error'
+		});
+		expect(options.contexts.trade_flow).toMatchObject({
+			error_code: 'ORDERS_QUERY_FAILED',
+			request_id: 'request-42'
 		});
 	});
 
@@ -75,6 +105,30 @@ describe('tradeFlow Sentry reporter', () => {
 		expect(
 			captureSpy.mock.calls.map((call) => (call[1] as { level?: string } | undefined)?.level)
 		).toEqual(['warning', 'warning']);
+	});
+
+	it('keeps diagnostic error class independent from the support code', () => {
+		const captureSpy = vi.spyOn(Sentry, 'captureException');
+
+		captureTradeFlowError(new Error('Stale oracle price'), {
+			...context,
+			stage: 'quote',
+			orderType: 'market'
+		});
+		captureTradeFlowError(new Error('RPC network failed'), {
+			...context,
+			stage: 'approval'
+		});
+
+		const calls = captureSpy.mock.calls.map((call) => call[1] as { tags: Record<string, string> });
+		expect(calls[0].tags).toMatchObject({
+			error_class: 'stale_oracle',
+			error_code: 'SWAP_QUOTE_FAILED'
+		});
+		expect(calls[1].tags).toMatchObject({
+			error_class: 'rpc_error',
+			error_code: 'UPSTREAM_UNAVAILABLE'
+		});
 	});
 
 	it('distinguishes signing rejection from submission failures', () => {

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { HttpError } from '$lib/clients/http';
+import { createTradeError, toUserFacingTradeError } from '$lib/services/tradeError';
+
+describe('tradeError', () => {
+	it('maps a typed REST failure without exposing its raw public message', () => {
+		const error = new HttpError({
+			status: 502,
+			code: 'ORDERS_QUERY_FAILED',
+			requestId: 'request-42',
+			publicMessage: 'raw upstream wording',
+			retryAfter: null
+		});
+
+		expect(toUserFacingTradeError(error, 'quote')).toEqual({
+			code: 'ORDERS_QUERY_FAILED',
+			title: 'Market data unavailable',
+			message: 'We could not load current orders. Try again in a moment.',
+			requestId: 'request-42',
+			stage: 'quote',
+			retryable: true,
+			action: 'retry',
+			errorClass: 'rpc_error'
+		});
+	});
+
+	it('uses a safe generic presentation for a future canonical API code', () => {
+		const error = new HttpError({
+			status: 500,
+			code: 'FUTURE_API_FAILURE',
+			requestId: 'request-future',
+			publicMessage: 'do not display this',
+			retryAfter: null
+		});
+
+		const result = toUserFacingTradeError(error, 'calldata');
+		expect(result.code).toBe('FUTURE_API_FAILURE');
+		expect(result.requestId).toBe('request-future');
+		expect(result.message).not.toContain('do not display this');
+	});
+
+	it('normalizes wallet rejection and balance failures to stable local codes', () => {
+		expect(toUserFacingTradeError({ code: 4001, message: 'Rejected' }, 'signing')).toMatchObject({
+			code: 'TRADE_WALLET_ACTION_REJECTED',
+			errorClass: 'user_rejected'
+		});
+		expect(toUserFacingTradeError(new Error('insufficient funds'), 'approval')).toMatchObject({
+			code: 'TRADE_INSUFFICIENT_BALANCE',
+			errorClass: 'insufficient_balance'
+		});
+	});
+
+	it('rejects unsafe codes before they reach support details or telemetry', () => {
+		const result = createTradeError('bad code\nsecret', { stage: 'submission' });
+		expect(result.code).toBe('TRADE_UNKNOWN');
+	});
+
+	it('does not trust structurally similar objects from wallets or SDKs', () => {
+		const injected = {
+			code: 'ORDERS_QUERY_FAILED',
+			title: 'Injected title',
+			message: 'Injected raw detail',
+			requestId: 'injected-request',
+			stage: 'quote',
+			retryable: false,
+			action: 'none',
+			errorClass: 'unknown'
+		};
+
+		const result = toUserFacingTradeError(injected, 'quote');
+		expect(result.code).toBe('SWAP_QUOTE_FAILED');
+		expect(result.message).not.toContain('Injected');
+		expect(result.requestId).toBeNull();
+	});
+
+	it('provides wait-for-indexing guidance for the canonical REST code', () => {
+		const error = new HttpError({
+			status: 404,
+			code: 'NOT_YET_INDEXED',
+			requestId: 'request-indexing',
+			publicMessage: 'not yet indexed',
+			retryAfter: null
+		});
+
+		expect(toUserFacingTradeError(error, 'quote')).toMatchObject({
+			code: 'NOT_YET_INDEXED',
+			action: 'try_later',
+			retryable: true
+		});
+	});
+});


### PR DESCRIPTION
## Chained PRs

- Stack 2 of 3
- Parent: [#224](https://github.com/SARKEX/st0x/pull/224)
- Child: [#226](https://github.com/SARKEX/st0x/pull/226)
- Companion REST API stack: [ST0x-Technology/st0x.rest.api#155](https://github.com/ST0x-Technology/st0x.rest.api/pull/155) → [#156](https://github.com/ST0x-Technology/st0x.rest.api/pull/156)

## Motivation

Trade failures came from multiple SDK, wallet, RPC, API, and transaction stages without one safe, stable model for UI, analytics, and observability.

## Solution

- Add a catalogued `UserFacingTradeError` with stable code, message, stage, retryability, action, error class, and optional request ID.
- Classify quote, approval, signing, submission, confirmation, wallet, RPC, and downstream API failures without exposing raw exceptions.
- Preserve the existing diagnostic error taxonomy independently from the support-facing code.
- Attach error code and request ID to Sentry trade captures and PostHog trade events.
- Keep structurally similar untrusted objects from bypassing the catalog.

## Checks

- [x] Focused error-model, market execution, Sentry, and event tests
- [x] `bun run check`
- [x] `bun run lint-check`
- [x] `bun run format-check`
- [x] Full suite on the completed stack: 77 files passed; 830 tests passed, 1 skipped
- [x] Staged local review completed clean after fixes

## Linear

Fixes RAI-333

- [RAI-333 — Surface user-facing error codes for support and debugging](https://linear.app/makeitrain/issue/RAI-333/surface-user-facing-error-codes-for-support-and-debugging)