### PR TITLE
feat(trading): surface support error codes in the UI

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -16,6 +16,8 @@
 		getMakerOutputTokenAddress
 	} from '$lib/types/orderPerspective';
 	import Button from './ui/Button.svelte';
+	import TradeErrorPanel from './trade/TradeErrorPanel.svelte';
+	import { selectVisibleTradeError, toTradeFailureAnalytics } from './trade/tradeErrorUi';
 	import { isOutsideMarketHours } from '$lib/utils/marketHours';
 	import { track } from '$lib/services/analytics';
 	import QuickTradeChart from './QuickTradeChart.svelte';
@@ -27,7 +29,11 @@
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS
 	} from '$lib/services/marketOrderExecution';
-	import { createTradeError, toUserFacingTradeError } from '$lib/services/tradeError';
+	import {
+		createTradeError,
+		toUserFacingTradeError,
+		type UserFacingTradeError
+	} from '$lib/services/tradeError';
 
 	// Quick Trade intentionally uses a fixed 1% slippage tolerance to keep the
 	// simplified flow free of advanced order controls.
@@ -78,7 +84,7 @@
 		topAmount = '';
 		bottomAmount = '';
 		lastEditedField = null;
-		tradeError = null;
+		tradeErrorDetails = null;
 	}
 
 	function toggleDropdown(e: MouseEvent) {
@@ -115,7 +121,18 @@
 	let isBuying = true;
 	let lastEditedField: 'top' | 'bottom' | null = null;
 	let isExecutingTrade = false;
-	let tradeError: string | null = null;
+	let tradeErrorDetails: UserFacingTradeError | null = null;
+	$: tradeError = tradeErrorDetails?.message ?? null;
+	let tradeErrorNetworkId = $currentNetwork?.id;
+
+	function clearTradeError() {
+		tradeErrorDetails = null;
+	}
+
+	$: if ($currentNetwork?.id !== tradeErrorNetworkId) {
+		tradeErrorNetworkId = $currentNetwork?.id;
+		clearTradeError();
+	}
 
 	// ============ DATA LOADING ============
 	$: paymentToken = $currentNetwork?.defaultPaymentToken;
@@ -181,6 +198,13 @@
 			return apiGetSwapQuoteV2(marketQuoteRequest);
 		}
 	});
+	$: quoteTradeError =
+		$marketQuoteQuery?.isError && !$marketQuoteQuery?.data
+			? toUserFacingTradeError($marketQuoteQuery?.error, 'quote')
+			: null;
+	// A blocking no-data quote failure describes the current form context and
+	// must not be hidden by an older execution failure.
+	$: visibleTradeError = selectVisibleTradeError(quoteTradeError, tradeErrorDetails);
 
 	// On mount: analytics only. The selected-token query above fetches the visible quote data.
 	onMount(() => {
@@ -346,6 +370,7 @@
 		lastEditedField = 'top';
 		// Clear the other field to prevent both having user-entered values while prices load
 		bottomAmount = '';
+		clearTradeError();
 	}
 
 	function handleBottomInput(e: Event) {
@@ -354,10 +379,12 @@
 		lastEditedField = 'bottom';
 		// Clear the other field to prevent both having user-entered values while prices load
 		topAmount = '';
+		clearTradeError();
 	}
 
 	function handleSwapDirection() {
 		isBuying = !isBuying;
+		clearTradeError();
 		track('quick_trade_direction_changed', {
 			direction: isBuying ? 'buy' : 'sell',
 			token_symbol: selectedToken?.symbol
@@ -370,6 +397,7 @@
 		const flooredAmount = Math.floor(amount * 100) / 100;
 		topAmount = flooredAmount.toFixed(2);
 		lastEditedField = 'top';
+		clearTradeError();
 	}
 
 	function handleTokenPercentClick(percent: number) {
@@ -378,6 +406,7 @@
 		const flooredAmount = Math.floor(amount * 1e6) / 1e6;
 		bottomAmount = flooredAmount.toFixed(6);
 		lastEditedField = 'bottom';
+		clearTradeError();
 	}
 
 	// ============ TRADE EXECUTION ============
@@ -408,12 +437,12 @@
 
 		const orderSide = isBuying ? 'Buy' : 'Sell';
 		if (!tradeAnchor) {
-			tradeError = createTradeError('SWAP_QUOTE_FAILED', { stage: 'quote' }).message;
+			tradeErrorDetails = createTradeError('SWAP_QUOTE_FAILED', { stage: 'quote' });
 			return;
 		}
 
 		isExecutingTrade = true;
-		tradeError = null;
+		tradeErrorDetails = null;
 
 		try {
 			const { executeMarketOrder } = await import('$lib/services/marketOrderExecution');
@@ -439,16 +468,14 @@
 			if (!result.success) {
 				const userFacingError =
 					result.tradeError ?? toUserFacingTradeError(result.error, 'submission');
-				tradeError = userFacingError.message;
+				tradeErrorDetails = userFacingError;
 				track('quick_trade_failed', {
 					token_symbol: selectedToken?.symbol,
 					direction: isBuying ? 'buy' : 'sell',
 					usdc_amount: topAmount,
 					token_amount: bottomAmount,
 					avg_price: quote?.avgPrice,
-					error: tradeError,
-					error_code: userFacingError.code,
-					request_id: userFacingError.requestId
+					...toTradeFailureAnalytics(userFacingError)
 				});
 			} else {
 				tradeSubmittedSuccessfully = true;
@@ -466,16 +493,14 @@
 		} catch (error) {
 			console.error('Trade error:', error);
 			const userFacingError = toUserFacingTradeError(error, 'submission');
-			tradeError = userFacingError.message;
+			tradeErrorDetails = userFacingError;
 			track('quick_trade_failed', {
 				token_symbol: selectedToken?.symbol,
 				direction: isBuying ? 'buy' : 'sell',
 				usdc_amount: topAmount,
 				token_amount: bottomAmount,
 				avg_price: quote?.avgPrice,
-				error: tradeError,
-				error_code: userFacingError.code,
-				request_id: userFacingError.requestId
+				...toTradeFailureAnalytics(userFacingError)
 			});
 		} finally {
 			isExecutingTrade = false;
@@ -742,10 +767,8 @@
 		</div>
 
 		<!-- Error display -->
-		{#if tradeError}
-			<div class="rounded-lg bg-down-soft px-3 py-2 text-center text-sm text-down">
-				{tradeError}
-			</div>
+		{#if visibleTradeError}
+			<TradeErrorPanel error={visibleTradeError} />
 		{/if}
 
 		<!-- Action button -->

--- a/src/lib/components/TransactionModal.svelte
+++ b/src/lib/components/TransactionModal.svelte
@@ -2,6 +2,7 @@
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import TradeErrorPanel from '$lib/components/trade/TradeErrorPanel.svelte';
 	import transactionStore, { TransactionStatus } from '$lib/stores/transaction';
 	import { TransactionErrorMessage } from '$lib/types/errors';
 	// currentNetwork not needed directly; TxLink uses it from store
@@ -129,10 +130,16 @@
 						{$transactionStore.status}
 					{/if}
 				</p>
-				<p class="mt-2 text-center text-base text-text-2" data-testid="error-message">
-					{$transactionStore.error}
-				</p>
-				{#if $transactionStore.error === TransactionErrorMessage.GENERIC}
+				{#if $transactionStore.tradeError}
+					<div class="mt-2 w-full">
+						<TradeErrorPanel error={$transactionStore.tradeError} />
+					</div>
+				{:else}
+					<p class="mt-2 text-center text-base text-text-2" data-testid="error-message">
+						{$transactionStore.error}
+					</p>
+				{/if}
+				{#if !$transactionStore.tradeError && $transactionStore.error === TransactionErrorMessage.GENERIC}
 					<p class="mt-2 text-center text-sm text-text-2">
 						If this issue persists, please contact support on our
 						<a

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -27,7 +27,13 @@
 		type TradeFlowStage
 	} from '$lib/services/observability/tradeFlow';
 	import { withTradeId } from '$lib/services/observability/tradeId';
-	import { toUserFacingTradeError } from '$lib/services/tradeError';
+	import {
+		createTradeError,
+		toUserFacingTradeError,
+		type UserFacingTradeError
+	} from '$lib/services/tradeError';
+	import TradeErrorPanel from '$lib/components/trade/TradeErrorPanel.svelte';
+	import { selectVisibleTradeError } from '$lib/components/trade/tradeErrorUi';
 	import { onMount } from 'svelte';
 
 	export let orderSide: 'Buy' | 'Sell' = 'Buy';
@@ -229,10 +235,6 @@
 
 	$: isQuoteStale = quoteFreshnessSeconds > ORDERBOOK_MAX_STALENESS_MS / 1000;
 
-	// Keep the API's terminal no-liquidity failure inline without resetting the
-	// user's input. The REST service owns quote selection and calldata generation.
-	$: noLiquidityError = (orderPreparationError ?? '').includes('No liquidity available right now');
-
 	// State for market price and quantity
 	let marketPrice: number = 0; // Human-readable price (quote per asset)
 	let selectedAmount: bigint = 0n; // Quantity to acquire from order outputs (in output token decimals)
@@ -240,16 +242,13 @@
 	let priceError = false;
 	let priceErrorReason: 'no_quotes' | 'no_fill' | 'error' | null = null;
 	let orderPreparationError: string | null = null;
+	let orderPreparationTradeError: UserFacingTradeError | null = null;
 
 	// Best orderbook price based on order side (from parent props)
 	// Buy: use sellPrice (best ask - what you pay when buying)
 	// Sell: use buyPrice (best bid - what you get when selling)
 	$: bestOrderbookPrice = orderSide === 'Buy' ? sellPrice : buyPrice;
 
-	// Clear preparation error when inputs change
-	$: if (selectedAmount || orderSide) {
-		orderPreparationError = null;
-	}
 	$: paymentToken = $currentNetwork?.defaultPaymentToken || $currentNetwork?.paymentTokens?.[0];
 	$: paymentTokenSymbol = paymentToken?.symbol ?? 'Quote';
 
@@ -315,11 +314,23 @@
 	// + trade_failed event_class never disagree with the service's own
 	// classification. Reset on each new submit; null when no service-side error
 	// is in flight (the reactive block below then falls back to the local
-	// signals: insufficientBalanceError, noLiquidityError, priceError, …).
+	// signals: insufficientBalanceError, priceError, …).
 	let serviceErrorClass: ErrorClass | null = null;
+	// Clear only failure state when the trade context changes. The amount and
+	// other form choices remain intact so the user can correct and retry.
+	$: if (
+		selectedAmount ||
+		orderSide ||
+		assetToken?.address ||
+		paymentToken?.address ||
+		$currentNetwork?.id
+	) {
+		orderPreparationError = null;
+		orderPreparationTradeError = null;
+		serviceErrorClass = null;
+	}
 	$: errorClass = (() => {
 		if (insufficientBalanceError) return 'insufficient_balance';
-		if (noLiquidityError) return 'no_liquidity';
 		if (serviceErrorClass) return serviceErrorClass;
 		if (isOutsideMarketHours() && orderPreparationError) return 'market_closed';
 		if (priceError && (priceErrorReason === 'no_quotes' || priceErrorReason === 'no_fill'))
@@ -330,6 +341,26 @@
 
 	// The REST quote uses the same mode, amount, slippage and oracle guard as
 	// calldata generation. The browser only formats the returned simulation.
+	$: marketQuoteTradeError =
+		$marketQuoteQuery?.isError && !$marketQuoteQuery?.data
+			? toUserFacingTradeError($marketQuoteQuery?.error, 'quote')
+			: null;
+	$: quoteCalculationTradeError =
+		priceError && selectedAmount > 0n
+			? createTradeError(
+					priceErrorReason === 'no_quotes' || priceErrorReason === 'no_fill'
+						? 'SWAP_NO_LIQUIDITY'
+						: 'SWAP_QUOTE_FAILED',
+					{ stage: 'quote' }
+				)
+			: null;
+	$: visibleTradeError = selectVisibleTradeError(
+		marketQuoteTradeError,
+		orderPreparationTradeError,
+		quoteCalculationTradeError
+	);
+
+	// Liquidity warning: check if there's enough liquidity within price guard
 	let insufficientLiquidityWarning: boolean = false;
 	let availableLiquidityFormatted: string = '0';
 	$: quoteOraclePrice = assetToken
@@ -528,6 +559,7 @@
 		}
 		isSubmittingMarketOrder = true;
 		orderPreparationError = null;
+		orderPreparationTradeError = null;
 		serviceErrorClass = null;
 
 		// Mint after early-return guards so unauthenticated/idle clicks do not
@@ -565,7 +597,10 @@
 						new Error('Payment token configuration is incomplete'),
 						flowContext('quote', 'validate_token_config')
 					);
-					orderPreparationError = 'Token configuration error. Please refresh the page.';
+					orderPreparationTradeError = createTradeError('SWAP_QUOTE_FAILED', {
+						stage: 'quote'
+					});
+					orderPreparationError = orderPreparationTradeError.message;
 					return;
 				}
 				if (!assetToken || typeof assetToken.decimals !== 'number') {
@@ -573,7 +608,10 @@
 						new Error('Asset token configuration is incomplete'),
 						flowContext('quote', 'validate_token_config')
 					);
-					orderPreparationError = 'Token configuration error. Please refresh the page.';
+					orderPreparationTradeError = createTradeError('SWAP_QUOTE_FAILED', {
+						stage: 'quote'
+					});
+					orderPreparationError = orderPreparationTradeError.message;
 					return;
 				}
 				// Execution requests fresh REST API-built calldata with the same
@@ -604,6 +642,7 @@
 				if (!result.success && result.error) {
 					const userFacingError =
 						result.tradeError ?? toUserFacingTradeError(result.error, activeStage);
+					orderPreparationTradeError = userFacingError;
 					orderPreparationError = userFacingError.message;
 					// Prefer the service's discriminated errorClass; fall back to
 					// substring-classifying the user-facing string only if absent
@@ -648,6 +687,7 @@
 					activeStage === 'calldata' ? inferWalletFailureStage(error) : activeStage;
 				captureTradeFlowError(error, flowContext(failureStage, 'submit_market_order'));
 				const userFacingError = toUserFacingTradeError(error, failureStage);
+				orderPreparationTradeError = userFacingError;
 				orderPreparationError = userFacingError.message;
 				trackTradeEvent('trade_failed', {
 					order_type: 'market',
@@ -812,15 +852,6 @@
 							{/if}
 						</p>
 					{/if}
-					<!-- TRADE-03 D-05 (Plan 02-06): terminal-state inline error when the
-					 pre-flight + auto-retry cascade exhausts. User input stays intact (no
-					 form reset, no toast). Copy locked in 02-CONTEXT.md D-05. -->
-					{#if noLiquidityError}
-						<p class="mt-2 text-xs text-red-400">
-							No liquidity available right now for this size. Try a smaller amount or check back in
-							a minute.
-						</p>
-					{/if}
 				</div>
 			</div>
 
@@ -957,30 +988,9 @@
 								{/if}
 							</div>
 						{/if}
-						{#if priceError && selectedAmount && selectedAmount > 0n}
-							<div
-								class="mt-2 rounded-md border border-red-500/30 bg-red-500/10 p-2 text-sm text-red-300"
-							>
-								{#if priceErrorReason === 'no_quotes'}
-									No orders available within acceptable price range. Try a limit order instead to
-									set your own price.
-								{:else if priceErrorReason === 'no_fill'}
-									Order amount too large for current liquidity. Try a smaller amount or use a limit
-									order.
-								{:else}
-									Unable to fetch market price. Please try again or use a limit order.
-								{/if}
-							</div>
-						{/if}
-						{#if orderPreparationError && !noLiquidityError}
-							<!-- TRADE-03: when the D-05 inline block above is rendering the
-							 verbatim "No liquidity available right now ..." copy, suppress
-							 the generic orderPreparationError box so the message is not
-							 duplicated. Other preparation errors still surface here. -->
-							<div
-								class="mt-2 rounded-md border border-red-500/30 bg-red-500/10 p-2 text-sm text-red-300"
-							>
-								{orderPreparationError}
+						{#if visibleTradeError}
+							<div class="mt-2">
+								<TradeErrorPanel error={visibleTradeError} />
 							</div>
 						{/if}
 					</div>

--- a/src/lib/components/trade/TradeErrorPanel.svelte
+++ b/src/lib/components/trade/TradeErrorPanel.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import type { UserFacingTradeError } from '$lib/services/tradeError';
+
+	export let error: UserFacingTradeError;
+
+	let copied = false;
+
+	$: supportDetails = [
+		`Error code: ${error.code}`,
+		...(error.requestId ? [`Request ID: ${error.requestId}`] : []),
+		`Stage: ${error.stage}`
+	].join('\n');
+
+	async function copySupportDetails(): Promise<void> {
+		try {
+			await navigator.clipboard.writeText(supportDetails);
+			copied = true;
+			setTimeout(() => (copied = false), 2_000);
+		} catch {
+			copied = false;
+		}
+	}
+</script>
+
+<div
+	class="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-left"
+	data-testid="trade-error-panel"
+	data-error-code={error.code}
+	data-error-stage={error.stage}
+	role="alert"
+>
+	<div class="flex items-start gap-2.5">
+		<div
+			class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-red-400/50 text-xs font-semibold text-red-300"
+			aria-hidden="true"
+		>
+			!
+		</div>
+		<div class="min-w-0 flex-1">
+			<p class="text-sm font-medium text-red-200">{error.title}</p>
+			<p class="mt-1 text-xs leading-5 text-red-200/80">{error.message}</p>
+
+			<div class="mt-2.5 border-t border-red-400/20 pt-2.5">
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px]">
+					<span class="text-red-200/60">Error code</span>
+					<code
+						class="break-all rounded border border-red-400/20 bg-black/20 px-1.5 py-0.5 font-mono text-red-100"
+						data-testid="trade-error-code">{error.code}</code
+					>
+					{#if error.requestId}
+						<span class="text-red-200/60">Reference</span>
+						<code class="break-all font-mono text-red-100/80" data-testid="trade-error-request-id"
+							>{error.requestId}</code
+						>
+					{/if}
+				</div>
+
+				<button
+					type="button"
+					class="mt-2 text-[11px] font-medium text-red-200/70 underline decoration-red-300/30 underline-offset-2 transition-colors hover:text-red-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-red-300/60"
+					on:click={copySupportDetails}
+					aria-label="Copy error details"
+				>
+					{copied ? 'Copied' : 'Copy details'}
+				</button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/trade/tradeErrorUi.ts
+++ b/src/lib/components/trade/tradeErrorUi.ts
@@ -1,0 +1,20 @@
+import type { UserFacingTradeError } from '$lib/services/tradeError';
+
+/**
+ * A no-data quote failure is the blocking failure for the current trade
+ * context, so it takes precedence over an older execution failure.
+ */
+export function selectVisibleTradeError(
+	...errors: Array<UserFacingTradeError | null>
+): UserFacingTradeError | null {
+	return errors.find((error): error is UserFacingTradeError => error !== null) ?? null;
+}
+
+/** Build analytics fields from the value created in the current call stack. */
+export function toTradeFailureAnalytics(error: UserFacingTradeError) {
+	return {
+		error: error.message,
+		error_code: error.code,
+		request_id: error.requestId
+	};
+}

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -58,6 +58,7 @@ import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken } from '$lib/uti
 import { ZERO_FLOAT_HEX } from '$lib/config/constants';
 import { getMakerOutputTokenAddress, getMakerInputTokenAddress } from '$lib/types/orderPerspective';
 import { TransactionErrorMessage } from '$lib/types/errors';
+import { toUserFacingTradeError } from '$lib/services/tradeError';
 import { isStaleWalletSessionError, handleStaleWalletSession } from '$lib/utils/walletUtils';
 import {
 	transactionStoreInternal,
@@ -130,6 +131,17 @@ const {
 	transactionError
 } = transactionStoreInternal;
 
+/** Preserve the original failure long enough to retain typed codes and request IDs. */
+function setDeployTransactionError(
+	error: unknown,
+	eventContext: DeployEventContext | undefined,
+	stage: TradeFlowStage,
+	message: TransactionErrorMessage = extractTransactionError(error),
+	hash?: string
+): void {
+	transactionError(message, hash, eventContext ? toUserFacingTradeError(error, stage) : undefined);
+}
+
 // Find a vault by matching both vault ID and token address
 // Vault IDs can be decimal strings or hex strings, so we check both formats
 function findVaultByIdAndToken(
@@ -183,13 +195,23 @@ export const handleStrategyDeployment = async (
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'submission', 'wallet_config', network?.id);
-		return transactionError(error.message as TransactionErrorMessage);
+		return setDeployTransactionError(
+			error,
+			eventContext,
+			'submission',
+			error.message as TransactionErrorMessage
+		);
 	}
 	const $signerAddress = get(walletAddress);
 	if (!$signerAddress) {
 		const error = new Error('Signer address not found');
 		reportDeployFailure(error, eventContext, 'signing', 'wallet_identity', network?.id);
-		return transactionError(error.message as TransactionErrorMessage);
+		return setDeployTransactionError(
+			error,
+			eventContext,
+			'signing',
+			error.message as TransactionErrorMessage
+		);
 	}
 
 	// Security: Validate orderbook address BEFORE any approvals are granted
@@ -198,7 +220,12 @@ export const handleStrategyDeployment = async (
 		validateOrderbookAddress(deploymentArgs.raindexAddress, network);
 	} catch (error) {
 		reportDeployFailure(error, eventContext, 'calldata', 'validate_orderbook', network.id);
-		return transactionError((error as Error).message as TransactionErrorMessage);
+		return setDeployTransactionError(
+			error,
+			eventContext,
+			'calldata',
+			(error as Error).message as TransactionErrorMessage
+		);
 	}
 
 	// Decode each approval calldata once + check balances in parallel.
@@ -225,7 +252,7 @@ export const handleStrategyDeployment = async (
 		});
 	} catch (error) {
 		reportDeployFailure(error, eventContext, 'calldata', 'decode_approval', network.id);
-		return transactionError(extractTransactionError(error));
+		return setDeployTransactionError(error, eventContext, 'calldata');
 	}
 
 	if (decodedApprovals.length > 0) {
@@ -255,7 +282,7 @@ export const handleStrategyDeployment = async (
 			)) as bigint[];
 		} catch (error) {
 			reportDeployFailure(error, eventContext, 'approval', 'check_balances', network.id);
-			return transactionError(extractTransactionError(error));
+			return setDeployTransactionError(error, eventContext, 'approval');
 		}
 		if (approvalContext) addTradeFlowBreadcrumb(approvalContext, 'completed');
 
@@ -264,7 +291,10 @@ export const handleStrategyDeployment = async (
 			if (balances[i] < requiredAmount) {
 				const error = new Error(`Insufficient ${approval.symbol} balance`);
 				reportDeployFailure(error, eventContext, 'approval', 'check_balances', network.id);
-				return transactionError(
+				return setDeployTransactionError(
+					error,
+					eventContext,
+					'approval',
 					`Insufficient ${approval.symbol} balance. Please add more ${approval.symbol} to your wallet or reduce the ${approval.symbol} deposit amount in advanced options.` as TransactionErrorMessage
 				);
 			}
@@ -286,18 +316,18 @@ export const handleStrategyDeployment = async (
 					setStatus: (s) => transactionStoreInternal.update((state) => ({ ...state, status: s }))
 				});
 			} catch (error) {
-				reportDeployFailure(
-					error,
-					eventContext,
-					inferWalletFailureStage(error) === 'signing' ? 'signing' : 'approval',
-					'approve_token',
-					network.id
-				);
+				const failureStage = inferWalletFailureStage(error) === 'signing' ? 'signing' : 'approval';
+				reportDeployFailure(error, eventContext, failureStage, 'approve_token', network.id);
 				if (isStaleWalletSessionError(error)) {
 					const msg = await handleStaleWalletSession(config);
-					return transactionError(msg as TransactionErrorMessage);
+					return setDeployTransactionError(
+						error,
+						eventContext,
+						failureStage,
+						msg as TransactionErrorMessage
+					);
 				}
-				return transactionError(extractTransactionError(error));
+				return setDeployTransactionError(error, eventContext, failureStage);
 			}
 		}
 	}
@@ -327,18 +357,18 @@ export const handleStrategyDeployment = async (
 			});
 		}
 	} catch (error) {
-		reportDeployFailure(
-			error,
-			eventContext,
-			inferWalletFailureStage(error),
-			'deploy_strategy',
-			network.id
-		);
+		const failureStage = inferWalletFailureStage(error);
+		reportDeployFailure(error, eventContext, failureStage, 'deploy_strategy', network.id);
 		if (isStaleWalletSessionError(error)) {
 			const msg = await handleStaleWalletSession(config);
-			return transactionError(msg as TransactionErrorMessage);
+			return setDeployTransactionError(
+				error,
+				eventContext,
+				failureStage,
+				msg as TransactionErrorMessage
+			);
 		}
-		return transactionError(extractTransactionError(error));
+		return setDeployTransactionError(error, eventContext, failureStage);
 	}
 
 	// OBS-07: emit `confirmed` once the deploy is confirmed on-chain. The
@@ -502,6 +532,12 @@ export const handleDcaDeploy = async (
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_dca', network?.id);
+		setDeployTransactionError(
+			error,
+			eventContext,
+			'calldata',
+			error.message as TransactionErrorMessage
+		);
 		throw error;
 	}
 	awaitWalletConfirmation(`Preparing strategy...`);
@@ -517,6 +553,7 @@ export const handleDcaDeploy = async (
 		));
 	} catch (error) {
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_dca', network.id);
+		setDeployTransactionError(error, eventContext, 'calldata');
 		throw error;
 	}
 	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'completed');
@@ -545,6 +582,12 @@ export const handleLimitDeploy = async (
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_limit', network?.id);
+		setDeployTransactionError(
+			error,
+			eventContext,
+			'calldata',
+			error.message as TransactionErrorMessage
+		);
 		throw error;
 	}
 	awaitWalletConfirmation(`Preparing strategy...`);
@@ -560,6 +603,7 @@ export const handleLimitDeploy = async (
 		));
 	} catch (error) {
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_limit', network.id);
+		setDeployTransactionError(error, eventContext, 'calldata');
 		throw error;
 	}
 	if (calldataContext) addTradeFlowBreadcrumb(calldataContext, 'completed');

--- a/src/lib/stores/transactionShared.ts
+++ b/src/lib/stores/transactionShared.ts
@@ -5,8 +5,8 @@
  * and partial-fill-detection state machines can share TransactionStatus +
  * interfaces without circular imports, and so the types are easily unit-tested.
  *
- * This file is a LEAF — it imports nothing from $lib/services or any other
- * $lib/stores/* module. The dependency-graph direction is one-way:
+ * This file is a runtime LEAF — it imports no values from $lib/services or any
+ * other $lib/stores/* module. The dependency-graph direction is one-way:
  *   transactionShared → consumers (deployTransactionStore, marketTakeStore,
  *                                   approvalStore, partialFillDetection,
  *                                   transaction.ts façade)
@@ -16,6 +16,7 @@ import { writable } from 'svelte/store';
 import type { Hex } from 'viem';
 import type { Network } from '$lib/config/network';
 import { TransactionErrorMessage } from '$lib/types/errors';
+import type { UserFacingTradeError } from '$lib/services/tradeError';
 
 /**
  * Classify error messages into safe, non-sensitive categories for analytics.
@@ -135,6 +136,7 @@ const initialState = {
 	data: null as TransactionMetadata | null,
 	functionName: '',
 	message: '',
+	tradeError: null as UserFacingTradeError | null,
 	multiTxAcknowledged: false,
 	onMultiTxAcknowledge: null as (() => void) | null
 };
@@ -161,6 +163,7 @@ const createTransactionStore = () => {
 			hash?: string;
 			error?: string;
 			data?: TransactionMetadata | null;
+			tradeError?: UserFacingTradeError | null;
 		} = {}
 	) =>
 		update((state) => ({
@@ -169,7 +172,8 @@ const createTransactionStore = () => {
 			message: options.message ?? '',
 			hash: options.hash ?? '',
 			error: options.error ?? '',
-			data: options.data ?? null
+			data: options.data ?? null,
+			tradeError: options.tradeError ?? null
 		}));
 
 	const checkingWalletAllowance = (message?: string) =>
@@ -179,8 +183,11 @@ const createTransactionStore = () => {
 	const awaitApprovalTx = (hash: string) => setState(TransactionStatus.PENDING_APPROVAL, { hash });
 	const transactionSuccess = (hash: string, message?: string, data?: TransactionMetadata) =>
 		setState(TransactionStatus.SUCCESS, { hash, message, data });
-	const transactionError = (message: TransactionErrorMessage, hash?: string) =>
-		setState(TransactionStatus.ERROR, { error: message, hash });
+	const transactionError = (
+		message: TransactionErrorMessage,
+		hash?: string,
+		tradeError?: UserFacingTradeError
+	) => setState(TransactionStatus.ERROR, { error: message, hash, tradeError });
 
 	const acknowledgeMultiTx = () => {
 		update((state) => {

--- a/tests/lib/components/TradeErrorPanel.test.ts
+++ b/tests/lib/components/TradeErrorPanel.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import TradeErrorPanel from '$lib/components/trade/TradeErrorPanel.svelte';
+import { createTradeError } from '$lib/services/tradeError';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('TradeErrorPanel', () => {
+	it('renders the human message, stable code, and optional request reference', () => {
+		const error = createTradeError('ORDERS_QUERY_FAILED', {
+			stage: 'quote',
+			requestId: 'request-42'
+		});
+
+		render(TradeErrorPanel, { error });
+
+		expect(screen.getByRole('alert')).toHaveAttribute('data-error-code', 'ORDERS_QUERY_FAILED');
+		expect(screen.getByText('Market data unavailable')).toBeInTheDocument();
+		expect(screen.getByTestId('trade-error-code')).toHaveTextContent('ORDERS_QUERY_FAILED');
+		expect(screen.getByTestId('trade-error-request-id')).toHaveTextContent('request-42');
+	});
+
+	it('copies a support-ready code, request id, and stage', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, 'clipboard', {
+			configurable: true,
+			value: { writeText }
+		});
+		const error = createTradeError('UPSTREAM_UNAVAILABLE', {
+			stage: 'submission',
+			requestId: 'request-99'
+		});
+
+		render(TradeErrorPanel, { error });
+		await fireEvent.click(screen.getByRole('button', { name: 'Copy error details' }));
+
+		expect(writeText).toHaveBeenCalledWith(
+			'Error code: UPSTREAM_UNAVAILABLE\nRequest ID: request-99\nStage: submission'
+		);
+		await waitFor(() => expect(screen.getByText('Copied')).toBeInTheDocument());
+	});
+});
+
+describe('QuickTrade support error wiring', () => {
+	const componentSource = readFileSync(
+		resolve(process.cwd(), 'src/lib/components/QuickTrade.svelte'),
+		'utf-8'
+	);
+
+	it('clears a prior execution failure for every form-context mutation', () => {
+		for (const handler of [
+			'handleTopInput',
+			'handleBottomInput',
+			'handleSwapDirection',
+			'handleUsdcPercentClick',
+			'handleTokenPercentClick'
+		]) {
+			const body = componentSource.match(new RegExp(`function ${handler}\\([^]*?\\n\\t}`))?.[0];
+			expect(body, handler).toContain('clearTradeError()');
+		}
+	});
+
+	it('uses the current structured error to build failure analytics', () => {
+		expect(componentSource.match(/\.\.\.toTradeFailureAnalytics\(userFacingError\)/g)).toHaveLength(
+			2
+		);
+		expect(componentSource).not.toMatch(/^\s*error:\s*tradeError/m);
+	});
+});
+
+describe('TransactionModal support error wiring', () => {
+	const componentSource = readFileSync(
+		resolve(process.cwd(), 'src/lib/components/TransactionModal.svelte'),
+		'utf-8'
+	);
+
+	it('renders structured transaction errors through the shared support panel', () => {
+		expect(componentSource).toContain(
+			"import TradeErrorPanel from '$lib/components/trade/TradeErrorPanel.svelte'"
+		);
+		expect(componentSource).toContain('<TradeErrorPanel error={$transactionStore.tradeError} />');
+	});
+});

--- a/tests/lib/components/orders/MarketOrder.test.ts
+++ b/tests/lib/components/orders/MarketOrder.test.ts
@@ -174,96 +174,32 @@ describe('MarketOrder price calculations', () => {
 	});
 });
 
-/**
- * TRADE-03 D-05 (Plan 02-06): inline terminal-state error rendering.
- *
- * Approach — pure-logic verification + source-content assertion. Per
- * `.planning/codebase/TESTING.md` "Component tests" the standing pattern is to
- * "prefer testing pure logic extracted from a component over rendering the
- * component when business logic can be lifted." Rendering MarketOrder.svelte
- * end-to-end requires a TanStack QueryClient + currentNetwork + assetToken +
- * walletService scaffolding heavier than the value of a single rendering test;
- * this test instead asserts the two contracts that the D-05 wiring depends on:
- *
- *   1. The verbatim D-05 copy is present in the .svelte source exactly once.
- *   2. The reactive predicate `noLiquidityError` correctly derives terminal
- *      state from a candidate error string.
- *
- * The implementation in MarketOrder.svelte derives `noLiquidityError` from
- * `(orderPreparationError ?? '').includes('No liquidity available right now')`
- * — `orderPreparationError` holds the user-facing string returned by
- * `executeMarketOrder()` (the failWith() user-facing copy that flows from the
- * pre-flight + auto-walk cascade in marketOrderExecution.ts).
- */
-describe('MarketOrder D-05 inline terminal error (TRADE-03)', () => {
-	const componentPath = resolve(
-		process.cwd(),
-		'src/lib/components/orders/MarketOrder.svelte'
-	);
+/** RAI-333: every market failure funnels through one structured support panel. */
+describe('MarketOrder structured support error surface (RAI-333)', () => {
+	const componentPath = resolve(process.cwd(), 'src/lib/components/orders/MarketOrder.svelte');
 	const componentSource = readFileSync(componentPath, 'utf-8');
 
-	// The pure predicate that drives the inline render. Mirrors the reactive
-	// declaration `$: noLiquidityError = (orderPreparationError ?? '').includes(...)`
-	// so the test fails immediately if the predicate logic ever drifts.
-	function noLiquidityError(orderPreparationError: string | null): boolean {
-		return (orderPreparationError ?? '').includes('No liquidity available right now');
-	}
-
-	it('renders the D-05 verbatim copy exactly once in the component source', () => {
-		// 02-VALIDATION.md gate: literal copy appears once. This guards against
-		// future contributors adding a duplicate inline error (the existing
-		// orderPreparationError block was suppressed via `&& !noLiquidityError`
-		// to prevent a double render).
-		const matches = componentSource.match(/No liquidity available right now for this size/g) ?? [];
-		expect(matches).toHaveLength(1);
+	it('renders failures through the shared support panel', () => {
+		expect(componentSource).toMatch(/import TradeErrorPanel/);
+		expect(componentSource).toMatch(/\{#if visibleTradeError\}/);
+		expect(componentSource).toMatch(/<TradeErrorPanel error=\{visibleTradeError\}/);
 	});
 
-	it('declares the noLiquidityError reactive and references it in an {#if} block', () => {
-		// noLiquidityError must appear at least twice: one declaration at the
-		// `$:` reactive site, one usage in the `{#if noLiquidityError}` block.
-		// The suppression guard on orderPreparationError adds a third reference.
-		const matches = componentSource.match(/noLiquidityError/g) ?? [];
-		expect(matches.length).toBeGreaterThanOrEqual(2);
-		expect(componentSource).toMatch(/\{#if noLiquidityError\}/);
-	});
-
-	it('uses text-red-400 for terminal-state styling (not yellow / not gray)', () => {
-		// D-05: terminal state, not informational. The freshness banner uses
-		// text-yellow-400 / text-gray-500; the D-05 block is hard red.
-		// Find the noLiquidityError block and assert text-red-400 is the chosen class.
-		const blockMatch = componentSource.match(
-			/\{#if noLiquidityError\}[\s\S]*?\{\/if\}/
+	it('prioritizes a current downstream API failure over stale execution and local failures', () => {
+		expect(componentSource).toMatch(
+			/selectVisibleTradeError\(\s*marketQuoteTradeError,\s*orderPreparationTradeError,\s*quoteCalculationTradeError/
 		);
-		expect(blockMatch).toBeTruthy();
-		expect(blockMatch![0]).toContain('text-red-400');
 	});
 
-	it('predicate returns true ONLY for the D-05 verbatim copy, not unrelated errors', () => {
-		// Positive case — the actual D-05 string from marketOrderExecution.ts.
-		expect(
-			noLiquidityError(
-				'No liquidity available right now for this size. Try a smaller amount or check back in a minute.'
-			)
-		).toBe(true);
-
-		// Negative cases — other failWith() user-facing strings must NOT trigger
-		// the D-05 block (they render through the generic orderPreparationError
-		// path instead). Maps to the unrelated-error branch in the plan's
-		// component-render scaffold.
-		expect(noLiquidityError('Wallet rejected the transaction')).toBe(false);
-		expect(noLiquidityError('Unable to verify orderbook state. Please refresh quotes and retry.')).toBe(
-			false
+	it('clears execution failure state when amount, side, token, or network changes', () => {
+		expect(componentSource).toMatch(
+			/selectedAmount\s*\|\|[\s\S]*orderSide\s*\|\|[\s\S]*assetToken\?\.address\s*\|\|[\s\S]*paymentToken\?\.address\s*\|\|[\s\S]*\$currentNetwork\?\.id/
 		);
-		expect(noLiquidityError('Unable to calculate order price. Please try again.')).toBe(false);
-		expect(noLiquidityError(null)).toBe(false);
-		expect(noLiquidityError('')).toBe(false);
+		expect(componentSource).toMatch(/serviceErrorClass\s*=\s*null/);
 	});
 
-	it('does NOT render the inline error when orderPreparationError is empty (IDLE state)', () => {
-		// The {#if noLiquidityError} block evaluates to false when the predicate
-		// returns false, which is the equivalent of "in IDLE state, the inline
-		// terminal-error copy is not in the rendered output."
-		expect(noLiquidityError(null)).toBe(false);
-		expect(noLiquidityError('')).toBe(false);
+	it('does not duplicate the terminal no-liquidity copy in MarketOrder', () => {
+		expect(componentSource).not.toContain('No liquidity available right now for this size');
+		expect(componentSource).not.toMatch(/\{#if noLiquidityError\}/);
 	});
 });

--- a/tests/lib/components/tradeErrorUi.test.ts
+++ b/tests/lib/components/tradeErrorUi.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createTradeError } from '$lib/services/tradeError';
+import {
+	selectVisibleTradeError,
+	toTradeFailureAnalytics
+} from '$lib/components/trade/tradeErrorUi';
+
+describe('trade error UI state', () => {
+	it('gives the current blocking quote failure precedence over an older execution failure', () => {
+		const executionError = createTradeError('WALLET_SIGNATURE_REJECTED', {
+			stage: 'signing'
+		});
+		const quoteError = createTradeError('ORDERS_QUERY_FAILED', {
+			stage: 'quote',
+			requestId: 'request-current'
+		});
+
+		expect(selectVisibleTradeError(quoteError, executionError)).toBe(quoteError);
+		expect(selectVisibleTradeError(null, executionError)).toBe(executionError);
+	});
+
+	it('builds a self-consistent analytics payload from the current error', () => {
+		const error = createTradeError('UPSTREAM_UNAVAILABLE', {
+			stage: 'submission',
+			requestId: 'request-99'
+		});
+
+		expect(toTradeFailureAnalytics(error)).toEqual({
+			error: error.message,
+			error_code: 'UPSTREAM_UNAVAILABLE',
+			request_id: 'request-99'
+		});
+	});
+});

--- a/tests/lib/stores/transactionShared.test.ts
+++ b/tests/lib/stores/transactionShared.test.ts
@@ -49,6 +49,7 @@ describe('transactionShared leaf module', () => {
 				data: null,
 				functionName: '',
 				message: '',
+				tradeError: null,
 				multiTxAcknowledged: false,
 				onMultiTxAcknowledge: null
 			});
@@ -83,12 +84,8 @@ describe('transactionShared leaf module', () => {
 		} as unknown as Network;
 
 		it('isOrderbookTrusted is case-insensitive', () => {
-			expect(
-				isOrderbookTrusted('0xabc0000000000000000000000000000000000001', network)
-			).toBe(true);
-			expect(
-				isOrderbookTrusted('0x0000000000000000000000000000000000000bad', network)
-			).toBe(false);
+			expect(isOrderbookTrusted('0xabc0000000000000000000000000000000000001', network)).toBe(true);
+			expect(isOrderbookTrusted('0x0000000000000000000000000000000000000bad', network)).toBe(false);
 		});
 
 		it('validateOrderbookAddress throws on untrusted address', () => {

--- a/tests/lib/transactionStore.test.ts
+++ b/tests/lib/transactionStore.test.ts
@@ -19,6 +19,7 @@ import {
 import { mockCurrentNetwork } from '../mocks/mockCurrentNetwork';
 import { createRaindexClient } from '$lib/clients/raindex';
 import { decodeFunctionData } from 'viem';
+import { HttpError } from '$lib/clients/http';
 
 // Shared mock network object to avoid repetition
 const mockNetwork = mockCurrentNetwork;
@@ -381,6 +382,39 @@ describe('transactionStore tests', () => {
 	}
 
 	// Unified parameterized tests for all deployment handlers
+	it.each([
+		['DCA', deploymentHandlers[1], getDcaDeploymentArgs],
+		['Limit Order', deploymentHandlers[2], getLimitOrderDeploymentArgs]
+	] as const)(
+		'preserves structured API failures for %s preparation',
+		async (_name, deployment, deploymentArgsMock) => {
+			const failure = new HttpError({
+				status: 503,
+				code: 'UPSTREAM_UNAVAILABLE',
+				requestId: 'request-deploy-42',
+				publicMessage: 'Trading service unavailable',
+				retryAfter: null
+			});
+			vi.mocked(deploymentArgsMock).mockRejectedValueOnce(failure);
+
+			await expect(deployment.handler(transactionStore)).rejects.toBe(failure);
+			let state: unknown;
+			const unsubscribe = transactionStore.subscribe((value) => {
+				state = value;
+			});
+			unsubscribe();
+
+			expect(state).toMatchObject({
+				status: 'Something went wrong',
+				tradeError: {
+					code: 'UPSTREAM_UNAVAILABLE',
+					requestId: 'request-deploy-42',
+					stage: 'calldata'
+				}
+			});
+		}
+	);
+
 	deploymentHandlers.forEach(({ name, handler, expectedFn }) => {
 		it(`should call handle${name}Deploy`, async () => {
 			const deployPromise = handler(transactionStore);


### PR DESCRIPTION
## Chained PRs

- Stack 3 of 3
- Parent: [#225](https://github.com/SARKEX/st0x/pull/225)
- Companion REST API stack: [ST0x-Technology/st0x.rest.api#155](https://github.com/ST0x-Technology/st0x.rest.api/pull/155) → [#156](https://github.com/ST0x-Technology/st0x.rest.api/pull/156)

## Motivation

Users could see a human-readable trade failure but had no stable identifier to share with support, and stale errors could mask the current failure after trade inputs changed.

## Solution

- Add a shared inline support panel that displays the human title/message, stable error code, optional request reference, and copyable support details.
- Use the panel in Quick Trade and Market Order for quote, signing, submission, and downstream failures.
- Keep trade inputs intact while clearing stale execution state when amount, side, token, or network context changes.
- Give the current blocking quote failure precedence over an older execution failure.
- Keep analytics payloads internally consistent by deriving message, code, and request ID from the same current error.

## Checks

- [x] Component and state regression tests
- [x] `bun run check`
- [x] `bun run lint-check`
- [x] `bun run format-check`
- [x] Full suite: 77 files passed; 830 tests passed, 1 skipped
- [x] Two-reviewer round plus clean follow-up review
- [x] In-app browser verified human text, `ORDERS_QUERY_FAILED`, quote stage, and request reference

## Linear

Fixes RAI-333

- [RAI-333 — Surface user-facing error codes for support and debugging](https://linear.app/makeitrain/issue/RAI-333/surface-user-facing-error-codes-for-support-and-debugging)