### PR TITLE
fix(metrics): align Raindex settings with v6 schema

### DIFF
--- a/src/lib/clients/raindex.ts
+++ b/src/lib/clients/raindex.ts
@@ -19,14 +19,14 @@ const PRIMARY_RPC = publicEnv.PUBLIC_BASE_RPC_URL || 'https://base-rpc.publicnod
  *  - No network fetch on client boot.
  *  - Deterministic config — we know exactly what the SDK sees.
  *
- * When adding a new chain, add a `networks`, `subgraphs`, `metaboards`, `orderbooks`,
+ * When adding a new chain, add a `networks`, `subgraphs`, `metaboards`, `raindexes`,
  * and `rainlangs` entry below.
  *
  * NOTE: RPCs here are NOT the same as in networks.ts. The Raindex SDK uses
  * multicall eth_call for quote simulation — many public RPCs (llamarpc, meowrpc,
  * blastapi, tenderly) don't support this. Use RPCs known to handle eth_call.
  */
-const SETTINGS_YAML = `version: 5
+const SETTINGS_YAML = `version: 6
 networks:
   base:
     rpcs:
@@ -38,7 +38,7 @@ subgraphs:
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn
 metaboards:
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
-orderbooks:
+raindexes:
   base:
     address: 0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D
     network: base

--- a/tests/lib/clients/raindex.test.ts
+++ b/tests/lib/clients/raindex.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+import { createRaindexClient } from '$lib/clients/raindex';
+
+describe('Raindex client configuration', () => {
+	it('initializes with the current SDK schema', async () => {
+		const client = await createRaindexClient();
+
+		expect(client).toBeDefined();
+		client.free();
+	});
+});


### PR DESCRIPTION
## Summary

- update the embedded Raindex settings to schema version 6 required by `@rainlanguage/raindex` alpha.238
- rename the legacy `orderbooks` settings section to the v6 `raindexes` section
- add regression coverage that constructs a real `RaindexClient` from the embedded settings

## Current production issue

The deployed platform metrics page cannot construct `RaindexClient` because the v6 SDK rejects the embedded v5 settings. Vault data is therefore unavailable and DEX liquidity renders as `$0.00`.

<img width="1309" height="868" alt="Platform metrics showing the Vault data incomplete version mismatch" src="https://github.com/user-attachments/assets/62fe6948-54e9-44cc-b5e6-1fee95b5c27c" />

## Verification

- `npm test -- --run` — 78 test files passed; 828 tests passed, 1 skipped
- `npm run check` — 0 errors and 0 warnings
- `npm test -- --run tests/lib/clients/raindex.test.ts`
- `npx prettier --check src/lib/clients/raindex.ts tests/lib/clients/raindex.test.ts`
- direct `RaindexClient.new()` initialization with the updated embedded settings
- `git diff --check`
