### PR TITLE
fix(trade): temp raindex↔orderbook subgraph compat proxy

### DIFF
--- a/src/lib/clients/raindex.ts
+++ b/src/lib/clients/raindex.ts
@@ -1,6 +1,8 @@
 import { RaindexClient } from '@rainlanguage/raindex';
 import { env as publicEnv } from '$env/dynamic/public';
+import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
+import { RAINDEX_SUBGRAPH_COMPAT_PATH } from '$lib/config/raindexSubgraph';
 type RaindexClientInstance = RaindexClient;
 
 // SEC-01 / Phase 3 D-02: Same PUBLIC_BASE_RPC_URL the client networks config reads.
@@ -8,6 +10,23 @@ type RaindexClientInstance = RaindexClient;
 // Alchemy URL via Vercel env vars. The literal Alchemy URL was committed pre-Phase-3
 // and is rotated as part of the SEC-01 deploy (see 03-RUNBOOK.md / Plan 03-10).
 const PRIMARY_RPC = publicEnv.PUBLIC_BASE_RPC_URL || 'https://base-rpc.publicnode.com';
+
+/**
+ * TEMP: route RaindexClient subgraph traffic through the same-origin rewrite
+ * proxy until Goldsky serves the renamed `raindex` schema. Absolute URL required
+ * by the WASM fetch layer (`response.url` must parse).
+ */
+function resolveSubgraphUrl(): string {
+	if (browser && typeof window !== 'undefined' && window.location?.origin) {
+		return `${window.location.origin}${RAINDEX_SUBGRAPH_COMPAT_PATH}`;
+	}
+	const base =
+		publicEnv.PUBLIC_APP_URL ||
+		(typeof process !== 'undefined' && process.env.VERCEL_URL
+			? `https://${process.env.VERCEL_URL}`
+			: 'http://127.0.0.1:5173');
+	return `${base.replace(/\/$/, '')}${RAINDEX_SUBGRAPH_COMPAT_PATH}`;
+}
 
 /**
  * Raindex settings YAML.
@@ -25,8 +44,13 @@ const PRIMARY_RPC = publicEnv.PUBLIC_BASE_RPC_URL || 'https://base-rpc.publicnod
  * NOTE: RPCs here are NOT the same as in networks.ts. The Raindex SDK uses
  * multicall eth_call for quote simulation — many public RPCs (llamarpc, meowrpc,
  * blastapi, tenderly) don't support this. Use RPCs known to handle eth_call.
+ *
+ * TEMP subgraph URL: `/api/public/raindex-subgraph-compat` rewrites raindex↔orderbook
+ * against the still-live `ob4-base/2026-02-05-c4ef` deployment. Swap back to the
+ * direct Goldsky URL once the renamed subgraph is deployed.
  */
-const SETTINGS_YAML = `version: 6
+function buildSettingsYaml(): string {
+	return `version: 6
 networks:
   base:
     rpcs:
@@ -35,7 +59,7 @@ networks:
     network-id: 8453
     currency: ETH
 subgraphs:
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn
+  base: ${resolveSubgraphUrl()}
 metaboards:
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
 raindexes:
@@ -49,6 +73,7 @@ rainlangs:
     address: 0x22508460712C350e914b49155982d3A92D923b10
     network: base
 `;
+}
 
 // Two-client pool for load balancing
 interface ClientPool {
@@ -65,9 +90,10 @@ const poolInitPromise: Map<number, Promise<ClientPool>> = new Map();
  */
 
 async function initializePool(_network: Network): Promise<ClientPool> {
+	const settings = buildSettingsYaml();
 	const [resultA, resultB] = await Promise.all([
-		RaindexClient.new([SETTINGS_YAML]),
-		RaindexClient.new([SETTINGS_YAML])
+		RaindexClient.new([settings]),
+		RaindexClient.new([settings])
 	]);
 
 	if (resultA.error) {
@@ -120,7 +146,7 @@ export async function getLoadBalancedClient(network: Network): Promise<RaindexCl
  * Create a RaindexClient from the hardcoded settings YAML.
  */
 export async function createRaindexClient(): Promise<RaindexClientInstance> {
-	const clientResult = await RaindexClient.new([SETTINGS_YAML]);
+	const clientResult = await RaindexClient.new([buildSettingsYaml()]);
 	if (clientResult.error) {
 		throw new Error(`Failed to create RaindexClient: ${clientResult.error.readableMsg}`);
 	}

--- a/src/lib/config/raindexSubgraph.ts
+++ b/src/lib/config/raindexSubgraph.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared Raindex subgraph endpoints / compat proxy path.
+ * Keep rewrite logic in `$lib/server/raindexSubgraphCompat` (server-only).
+ */
+
+/** Still-live Goldsky deployment (pre-rename `orderbook` schema). */
+export const LEGACY_ORDERBOOK_SUBGRAPH_URL =
+	'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn';
+
+/**
+ * TEMP same-origin proxy that rewrites raindex↔orderbook for SDK v6.
+ * Remove once the renamed Goldsky subgraph URL is wired in.
+ */
+export const RAINDEX_SUBGRAPH_COMPAT_PATH = '/api/public/raindex-subgraph-compat';

--- a/src/lib/server/raindexSubgraphCompat.ts
+++ b/src/lib/server/raindexSubgraphCompat.ts
@@ -1,0 +1,75 @@
+/**
+ * TEMP (remove once the renamed raindex Goldsky subgraph is live):
+ * Bridge SDK schema v6 (`raindex` / `Raindex`) to the still-deployed
+ * `ob4-base/2026-02-05-c4ef` subgraph (`orderbook` / `Orderbook`).
+ *
+ * Source schema is already renamed:
+ * https://github.com/rainlanguage/raindex/blob/main/subgraph/schema.graphql
+ * Live Goldsky still serves the pre-rename field names.
+ */
+
+import { LEGACY_ORDERBOOK_SUBGRAPH_URL } from '$lib/config/raindexSubgraph';
+
+export { LEGACY_ORDERBOOK_SUBGRAPH_URL, RAINDEX_SUBGRAPH_COMPAT_PATH } from '$lib/config/raindexSubgraph';
+
+/** Rewrite an SDK (modern) GraphQL request body for the legacy subgraph. */
+export function rewriteRaindexQueryToLegacy(body: string): string {
+	return body.replace(/\bRaindex\b/g, 'Orderbook').replace(/\braindex\b/g, 'orderbook');
+}
+
+/**
+ * Rewrite a legacy subgraph JSON response for the SDK.
+ * Only remaps object keys + `__typename` values — never string payloads —
+ * so addresses / meta bytes cannot be corrupted.
+ */
+export function rewriteOrderbookResponseToModern(body: string): string {
+	const data: unknown = JSON.parse(body);
+	return JSON.stringify(rewriteKeysDeep(data));
+}
+
+const KEY_MAP: Record<string, string> = {
+	orderbook: 'raindex',
+	Orderbook: 'Raindex'
+};
+
+const TYPENAME_MAP: Record<string, string> = {
+	Orderbook: 'Raindex'
+};
+
+function rewriteKeysDeep(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(rewriteKeysDeep);
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+			const nextKey = KEY_MAP[key] ?? key;
+			let nextVal = rewriteKeysDeep(child);
+			if (key === '__typename' && typeof child === 'string' && TYPENAME_MAP[child]) {
+				nextVal = TYPENAME_MAP[child];
+			}
+			out[nextKey] = nextVal;
+		}
+		return out;
+	}
+	return value;
+}
+
+export async function proxyRaindexSubgraphCompat(requestBody: string): Promise<{
+	status: number;
+	body: string;
+}> {
+	const upstream = await fetch(LEGACY_ORDERBOOK_SUBGRAPH_URL, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: rewriteRaindexQueryToLegacy(requestBody)
+	});
+	const text = await upstream.text();
+	if (!upstream.ok) {
+		return { status: upstream.status, body: text };
+	}
+	try {
+		return { status: upstream.status, body: rewriteOrderbookResponseToModern(text) };
+	} catch {
+		// Upstream returned non-JSON (rare); pass through unchanged.
+		return { status: upstream.status, body: text };
+	}
+}

--- a/src/routes/api/public/raindex-subgraph-compat/+server.ts
+++ b/src/routes/api/public/raindex-subgraph-compat/+server.ts
@@ -1,0 +1,24 @@
+/**
+ * TEMP public proxy: translates Raindex SDK v6 GraphQL (`raindex`) to the
+ * still-live Goldsky `orderbook` schema. Remove when the renamed subgraph URL
+ * is wired into `src/lib/clients/raindex.ts`.
+ */
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { proxyRaindexSubgraphCompat } from '$lib/server/raindexSubgraphCompat';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const contentType = request.headers.get('content-type') ?? '';
+	if (!contentType.includes('application/json') && !contentType.includes('application/graphql')) {
+		throw error(415, 'Expected application/json GraphQL body');
+	}
+
+	const body = await request.text();
+	if (!body) throw error(400, 'Empty body');
+
+	const { status, body: responseBody } = await proxyRaindexSubgraphCompat(body);
+	return new Response(responseBody, {
+		status,
+		headers: { 'content-type': 'application/json' }
+	});
+};

--- a/tests/lib/server/raindexSubgraphCompat.test.ts
+++ b/tests/lib/server/raindexSubgraphCompat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+	rewriteOrderbookResponseToModern,
+	rewriteRaindexQueryToLegacy
+} from '$lib/server/raindexSubgraphCompat';
+
+describe('raindexSubgraphCompat rewrites', () => {
+	it('rewrites modern GraphQL field/type names to legacy orderbook schema', () => {
+		const query = `{
+      orders {
+        raindex { id }
+      }
+      Raindex(id: "0x1") { id }
+    }`;
+		const legacy = rewriteRaindexQueryToLegacy(query);
+		expect(legacy).toContain('orderbook { id }');
+		expect(legacy).toContain('Orderbook(id:');
+		expect(legacy).not.toMatch(/\braindex\b/);
+		expect(legacy).not.toMatch(/\bRaindex\b/);
+	});
+
+	it('rewrites legacy JSON keys and __typename without touching string values', () => {
+		const legacy = JSON.stringify({
+			data: {
+				orders: [
+					{
+						__typename: 'Order',
+						orderHash: '0xabc',
+						orderbook: { __typename: 'Orderbook', id: '0xe522' },
+						meta: 'orderbook-should-stay-literal'
+					}
+				]
+			}
+		});
+		const modern = JSON.parse(rewriteOrderbookResponseToModern(legacy));
+		expect(modern.data.orders[0].raindex).toEqual({ __typename: 'Raindex', id: '0xe522' });
+		expect(modern.data.orders[0].orderbook).toBeUndefined();
+		expect(modern.data.orders[0].meta).toBe('orderbook-should-stay-literal');
+	});
+});


### PR DESCRIPTION
## Summary
- Unblocks market take-orders broken after the Raindex settings v6 cutover (`orderbooks` → `raindexes`): `@rainlanguage/raindex` queries `raindex` fields while live Goldsky `ob4-base/2026-02-05-c4ef` still exposes `orderbook`.
- Adds a temporary same-origin GraphQL rewrite proxy at `/api/public/raindex-subgraph-compat` and points `RaindexClient` settings at it.
- Verified locally: `getOrders` for a live order hash succeeds; `getTakeOrdersCalldata` no longer fails with schema errors.

## Revert plan
**This PR is temporary and should be reverted** once Raindex deploys a Goldsky subgraph with the renamed schema (`raindex` / `Raindex` per [upstream schema.graphql](https://github.com/rainlanguage/raindex/blob/main/subgraph/schema.graphql)).

When that URL is available:
1. Point `src/lib/clients/raindex.ts` subgraphs.base back at the new Goldsky endpoint (direct, no proxy).
2. Delete `src/routes/api/public/raindex-subgraph-compat/`, `src/lib/server/raindexSubgraphCompat.ts`, `src/lib/config/raindexSubgraph.ts`, and the compat tests.
3. Revert or supersede this PR.

## Test plan
- [x] `npm test -- --run tests/lib/server/raindexSubgraphCompat.test.ts tests/lib/clients/raindex.test.ts`
- [x] Local/preview: place a market sell/buy; confirm no `preflight_chain_unreachable` / `No hydrated RaindexOrder instances`
- [x] Confirm Network tab hits `/api/public/raindex-subgraph-compat` for Raindex SDK GraphQL


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raindex connectivity by dynamically resolving the subgraph endpoint across browser, deployed, and local environments.
  * Added compatibility handling so modern Raindex requests and responses work with the legacy subgraph schema.
  * Added validation for proxy requests, including unsupported content types and empty request bodies.

* **Tests**
  * Added coverage for request and response compatibility transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->