### PR TITLE
feat(api): add v2 swap calldata client

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -67,6 +67,25 @@ export interface ApiSwapCalldataResponse {
 	approvals: ApiApproval[];
 }
 
+export type ApiSwapCalldataMode = 'buyUpTo' | 'spendExact' | 'spendUpTo';
+
+interface ApiSwapCalldataV2RequestCommon {
+	taker: string;
+	inputToken: string;
+	outputToken: string;
+	mode: ApiSwapCalldataMode;
+	amount: string;
+	denomination?: 'wrapped' | 'unwrapped';
+}
+
+export type ApiSwapCalldataV2Request = ApiSwapCalldataV2RequestCommon &
+	({ priceCap: string; slippageBps?: never } | { priceCap?: never; slippageBps: number });
+
+export interface ApiSwapCalldataV2Response extends ApiSwapCalldataResponse {
+	denomination: 'wrapped' | 'unwrapped';
+	resolvedPriceCap: string;
+}
+
 // ============================================================================
 // Order Types
 // ============================================================================
@@ -402,6 +421,21 @@ export async function apiGetSwapCalldata(
 ): Promise<ApiSwapCalldataResponse> {
 	assertBrowser('apiGetSwapCalldata');
 	return fetchJson<ApiSwapCalldataResponse>(apiUrl('/v1/swap/calldata'), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(request)
+	});
+}
+
+/**
+ * Fetch ready-to-send v2 swap calldata. The API resolves optional slippage
+ * through SDK quotes and returns the fixed cap to reuse after approvals.
+ */
+export async function apiGetSwapCalldataV2(
+	request: ApiSwapCalldataV2Request
+): Promise<ApiSwapCalldataV2Response> {
+	assertBrowser('apiGetSwapCalldataV2');
+	return fetchJson<ApiSwapCalldataV2Response>(apiUrl('/v2/swap/calldata'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(request)

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -79,7 +79,8 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 	{ method: 'GET', pattern: /^v1\/trades\/taker\/[^/]+$/ },
 	{ method: 'POST', pattern: /^v1\/trades\/query$/ },
 	{ method: 'POST', pattern: /^v1\/swap\/quote$/ },
-	{ method: 'POST', pattern: /^v1\/swap\/calldata$/ }
+	{ method: 'POST', pattern: /^v1\/swap\/calldata$/ },
+	{ method: 'POST', pattern: /^v2\/swap\/calldata$/ }
 ];
 
 function matchProxyRoute(method: string, pathSuffix: string): { cache?: string } | null {

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -100,6 +100,43 @@ describe('/api/st0x proxy', () => {
 		);
 	});
 
+	it('allows POST /v2/swap/calldata and forwards slippage without caching', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					to: '0xOrderbook',
+					data: '0x1234',
+					value: '0x0',
+					estimatedInput: '100',
+					denomination: 'wrapped',
+					resolvedPriceCap: '2.02',
+					approvals: []
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const body = JSON.stringify({
+			taker: '0xTaker',
+			inputToken: '0xIn',
+			outputToken: '0xOut',
+			mode: 'spendUpTo',
+			amount: '100',
+			slippageBps: 100
+		});
+
+		const response = await POST(proxyEvent('POST', 'v2/swap/calldata', body));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v2/swap/calldata?page=1',
+			expect.objectContaining({ method: 'POST' })
+		);
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(await new Response(init.body).text()).toBe(body);
+	});
+
 	it('allows cached wrap-ratio endpoints', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ data: [], errors: [] }), {

--- a/tests/lib/api/st0xApi.test.ts
+++ b/tests/lib/api/st0xApi.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiGetSwapCalldataV2 } from '$lib/api/st0xApi';
+
+describe('st0x API client', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('posts v2 swap calldata requests through the authenticated proxy', async () => {
+		const responseBody = {
+			to: '0x0000000000000000000000000000000000000001',
+			data: '0x1234',
+			value: '0x0',
+			estimatedInput: '100',
+			denomination: 'wrapped' as const,
+			resolvedPriceCap: '2.02',
+			approvals: []
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(responseBody), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = await apiGetSwapCalldataV2({
+			taker: '0x0000000000000000000000000000000000000002',
+			inputToken: '0x0000000000000000000000000000000000000003',
+			outputToken: '0x0000000000000000000000000000000000000004',
+			mode: 'spendUpTo',
+			amount: '100',
+			slippageBps: 100
+		});
+
+		expect(result).toEqual(responseBody);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/st0x/v2/swap/calldata',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({
+					taker: '0x0000000000000000000000000000000000000002',
+					inputToken: '0x0000000000000000000000000000000000000003',
+					outputToken: '0x0000000000000000000000000000000000000004',
+					mode: 'spendUpTo',
+					amount: '100',
+					slippageBps: 100
+				})
+			})
+		);
+	});
+});


### PR DESCRIPTION
## Chained PRs

- Website stack 1 of 2
- Child: [#237](https://github.com/SARKEX/st0x/pull/237)
- Requires REST stack: [#158](https://github.com/ST0x-Technology/st0x.rest.api/pull/158) → [#159](https://github.com/ST0x-Technology/st0x.rest.api/pull/159)

## Motivation

The website needs a typed path to the REST v2 swap-calldata endpoint before market execution can stop constructing calldata in the browser.

## Solution

- Add typed request/response support for the v2 swap-calldata endpoint, including the `priceCap`/`slippageBps` exclusive request shapes.
- Allow the v2 POST route through the website API proxy.
- Add client and proxy coverage for request serialization, response handling, and route restrictions.

## Checks

- `bun run check`
- `bun run lint-check`
- `bun run format-check`
- `bun run test --run`
- `bun run build`

## Linear

Website client portion of [RAI-741](https://linear.app/makeitrain/issue/RAI-741/migrate-web-client-market-orders-to-api-built-calldata)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-user support for generating v2 swap calldata with multiple swap modes.
  * Enhanced v2 requests with slippage/price-cap inputs and optional denomination details.
  * Exposed a new v2 swap-calldata API path through the existing application proxy.
* **Tests**
  * Added tests verifying v2 proxy forwarding (including request body) and ensuring responses don’t include caching headers.
  * Added API client test coverage for correct request construction and typed response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->