### PR TITLE
hotfix - pricing

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -24,10 +24,29 @@ import {
 	type TokenPriceSummary,
 	walkOrderbook
 } from '$lib/utils/orderbook';
-import { apiGetOrdersByToken, type ApiOrderSummary } from '$lib/api/st0xApi';
+import {
+	apiGetOrdersByToken,
+	type ApiOrderSummary,
+	type ApiOrdersListResponse
+} from '$lib/api/st0xApi';
 
 export type { ProcessedQuote, TokenPriceSummary };
 export { OrderV4_ABI, normalizeOrderData, walkOrderbook };
+
+/**
+ * Fetches one page of orders for a token. Defaults to the browser proxy client
+ * (`apiGetOrdersByToken`); server callers inject a fetcher that hits the REST API directly
+ * so the same quoting pipeline can run server-side (e.g. the public prices endpoint).
+ */
+export type OrdersByTokenFetcher = (
+	tokenAddress: string,
+	options?: {
+		page?: number;
+		pageSize?: number;
+		side?: 'input' | 'output';
+		state?: 'active' | 'inactive' | 'all';
+	}
+) => Promise<ApiOrdersListResponse>;
 
 export const buildTokenPriceMap = (quotes: ProcessedQuote[], quoteAddressRaw: string) =>
 	buildTokenPriceMapBase(quotes, quoteAddressRaw, describeQuote);
@@ -189,7 +208,8 @@ function resolveNetworkTokens(
  */
 export async function fetchAndQuotePaymentTokenOrders(
 	networkId: number = 8453,
-	overridePaymentToken?: PythToken
+	overridePaymentToken?: PythToken,
+	fetchOrders: OrdersByTokenFetcher = apiGetOrdersByToken
 ) {
 	const { paymentToken, stockTokens, allTokens } = resolveNetworkTokens(
 		networkId,
@@ -204,7 +224,7 @@ export async function fetchAndQuotePaymentTokenOrders(
 			let page = 1;
 			let hasMore = true;
 			while (hasMore && page <= MAX_ORDER_PAGES) {
-				const response = await apiGetOrdersByToken(token.address, { page, pageSize: 50 });
+				const response = await fetchOrders(token.address, { page, pageSize: 50 });
 				for (const order of response.orders) {
 					if (seen.has(order.orderHash)) continue;
 					seen.add(order.orderHash);

--- a/src/lib/components/PythOracleRow.svelte
+++ b/src/lib/components/PythOracleRow.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import { currentNetwork, oracleQuotes } from '$lib/stores';
-	import type { OracleQuote } from '$lib/queries/oracleQuotes';
+	import { currentNetwork } from '$lib/stores';
 	import type { PythToken } from '$lib/types';
 	import type { TradingViewQuote } from '$lib/api/tradingview';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
-	import { createOracleQuotesQuery } from '$lib/queries/oracleQuotes';
+	import { createMidpointPricesQuery, getMidpointPrice } from '$lib/queries/midpointPrices';
 
 	type CommonToken = Partial<PythToken> & {
 		symbol?: string;
@@ -16,14 +15,13 @@
 	export let tokenQuotes: TradingViewQuote[] = [];
 
 	let tokenAddress = '';
-	let oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
-	let oracleQuotesState:
-		| import('@tanstack/query-core').QueryObserverResult<Record<string, OracleQuote>, Error>
+	let midpointQuery = createMidpointPricesQuery($currentNetwork);
+	let midpointState:
+		| import('@tanstack/query-core').QueryObserverResult<
+				Record<string, import('$lib/queries/midpointPrices').MidpointPrice>,
+				Error
+		  >
 		| null = null;
-	let oracleEntry: OracleQuote | undefined;
-	let oracleLoading = false;
-	let oracleError: string | null = null;
-	let priceData: { price: number | null; confidence: number | null } | null = null;
 
 	function normalizeSymbol(sym?: string) {
 		if (!sym) return undefined;
@@ -48,40 +46,35 @@
 	$: quote = tokenQuotes.find((q) => matchesQuote(q, token?.symbol, token?.tradingViewSymbol));
 	$: quotePrice = quote?.close ?? null;
 	$: tokenAddress = token?.address?.toLowerCase?.() ?? '';
-	$: oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
-	$: oracleQuotesState = $oracleQuotesQuery ?? null;
-	$: oracleEntry = tokenAddress ? $oracleQuotes[tokenAddress] : undefined;
-	$: oracleLoading =
-		(oracleQuotesState?.fetchStatus === 'fetching' || oracleQuotesState?.status === 'pending') &&
+	$: midpointQuery = createMidpointPricesQuery($currentNetwork);
+	$: midpointState = $midpointQuery ?? null;
+	$: entry = getMidpointPrice(midpointState?.data, tokenAddress);
+	$: loading =
+		(midpointState?.fetchStatus === 'fetching' || midpointState?.status === 'pending') &&
 		Boolean(tokenAddress);
-	$: oracleError = (() => {
+	$: error = (() => {
 		if (!tokenAddress) return 'Token missing address';
-		if (oracleQuotesState?.status === 'error') {
-			return 'Failed to fetch oracle data';
-		}
-		if (oracleQuotesState?.status === 'success' && !oracleEntry) {
-			return 'Oracle data unavailable';
-		}
+		if (midpointState?.status === 'error') return 'Failed to fetch price data';
 		return null;
 	})();
-	$: priceData = oracleEntry
-		? {
-				price: oracleEntry.price ?? null,
-				confidence: oracleEntry.confidence ?? null
-			}
-		: null;
+	// Only render a price when we have a real one (live or cached). A one-sided book resolves
+	// to `unavailable` (price null) and must show N/A — never a fabricated midpoint.
+	$: priceData =
+		entry && entry.price != null
+			? { price: entry.price, bid: entry.bid, ask: entry.ask, source: entry.source }
+			: null;
 </script>
 
 <!-- Unified Table Row (responsive) -->
 <tr>
-	{#if oracleLoading}
+	{#if loading}
 		<td class="px-2 py-1" colspan="4">
 			<div class="flex items-center justify-center">
 				<LoadingSpinner size="sm" text="" showText={false} />
 			</div>
 		</td>
-	{:else if oracleError}
-		<td class="px-2 py-1 text-red-400" colspan="4">{oracleError}</td>
+	{:else if error}
+		<td class="px-2 py-1 text-red-400" colspan="4">{error}</td>
 	{:else if priceData}
 		<td class="px-2 py-1">
 			<ExternalLink
@@ -90,14 +83,19 @@
 				className="underline"
 			/>
 		</td>
-		<td class="px-2 py-1 text-right">
-			{#if typeof priceData.price === 'number'}
-				${priceData.price.toFixed(5)}
-			{/if}
+		<td
+			class="px-2 py-1 text-right"
+			title={priceData.source === 'cached'
+				? 'Last known midpoint (market closed or one-sided book)'
+				: ''}
+		>
+			${priceData.price.toFixed(5)}{#if priceData.source === 'cached'}<span class="text-text-3">
+					*</span
+				>{/if}
 		</td>
-		<td class="px-2 py-1 text-right">
-			{#if typeof priceData.confidence === 'number'}
-				± {priceData.confidence.toFixed(5)}
+		<td class="whitespace-nowrap px-2 py-1 text-right text-text-2">
+			{#if priceData.bid != null && priceData.ask != null}
+				${priceData.bid.toFixed(4)} / ${priceData.ask.toFixed(4)}
 			{/if}
 		</td>
 		<td class="px-2 py-1 text-right text-text-2">
@@ -107,7 +105,7 @@
 		</td>
 	{:else}
 		<td class="px-2 py-1" colspan="4">
-			<div class="text-sm text-text-2">Oracle data unavailable</div>
+			<div class="text-sm text-text-2">Price unavailable</div>
 		</td>
 	{/if}
 </tr>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,8 +4,7 @@
 	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
 	import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptVault';
 	import { formatUnits } from 'viem';
-	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
-	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
+	import { createMidpointPricesQuery, getMidpointPrice } from '$lib/queries/midpointPrices';
 	import Icon from '$lib/components/ui/Icon.svelte';
 
 	export let visible: boolean = false; // controlled by parent
@@ -21,8 +20,11 @@
 		price: number;
 		dollarVolume: number;
 	};
-	let priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
-	$: priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
+	// Displayed price is the bid/ask midpoint from the public prices endpoint (falls back to
+	// the last known price when a book is one-sided, else 0 → N/A). Matches sft.address to the
+	// canonical token so wrapped/legacy variants resolve.
+	let midpointPricesQuery = createMidpointPricesQuery($currentNetwork);
+	$: midpointPricesQuery = createMidpointPricesQuery($currentNetwork);
 
 	let sortedAssets: AssetWithMetrics[] = [];
 
@@ -34,11 +36,7 @@
 		? [...$sfts]
 				.map<AssetWithMetrics>((sft) => {
 					const totalVolume = BigInt(sft.activityVolume ?? '0');
-					// Use token config symbol for price lookup so legacy symbols (e.g. tSTOX) resolve to the wrapped token's price feed (wtSTOX / AMEX:SPLG)
-					const tokenInfo = findApiTokenByAnyAddress(apiTokens, sft.address);
-					const symbolForPrice = tokenInfo?.symbol ?? sft.symbol;
-					const quote = findQuoteForSymbol(symbolForPrice, $priceFeedsQuery?.data ?? [], apiTokens);
-					const price = quote?.close ?? 0;
+					const price = getMidpointPrice($midpointPricesQuery?.data, sft.address)?.price ?? 0;
 					const volumeInShares = parseFloat(formatUnits(totalVolume, 18));
 					const dollarVolume = volumeInShares * price;
 					return { ...sft, dollarVolume, price };

--- a/src/lib/components/orders/ActiveLiquidity.svelte
+++ b/src/lib/components/orders/ActiveLiquidity.svelte
@@ -21,7 +21,6 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
-	import { createOracleQuotesQuery } from '$lib/queries/oracleQuotes';
 
 	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId ?? $currentNetwork?.id);
 	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
@@ -60,9 +59,7 @@
 	let maxTradeAmount: bigint = 0n;
 	let initialIo: string = '0';
 	let priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
-	let oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
 	$: priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
-	$: oracleQuotesQuery = createOracleQuotesQuery($currentNetwork);
 
 	// errors
 	let minTradeAmountError: boolean = false;
@@ -349,7 +346,7 @@
 				<h4 class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-text-2">Prices</h4>
 				{#if !hasValidPriceFeedId(selectedToken1) && !hasValidPriceFeedId(selectedToken2)}
 					<div class="py-6 text-center text-sm text-text-2">No price feed data available</div>
-				{:else if !$priceFeedsQuery?.data?.length || !$oracleQuotesQuery?.data}
+				{:else if !$priceFeedsQuery?.data?.length}
 					<div class="flex justify-center py-6">
 						<LoadingSpinner size="sm" text="Loading price data..." />
 					</div>
@@ -364,11 +361,11 @@
 									>
 									<th
 										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
-										>Oracle Price</th
+										>Mid Price</th
 									>
 									<th
 										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
-										>Price Certainty</th
+										>Bid / Ask</th
 									>
 									<th
 										class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"

--- a/src/lib/components/orders/FolioStrategy.svelte
+++ b/src/lib/components/orders/FolioStrategy.svelte
@@ -484,11 +484,11 @@
 								>
 								<th
 									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
-									>Oracle Price</th
+									>Mid Price</th
 								>
 								<th
 									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"
-									>Price Certainty</th
+									>Bid / Ask</th
 								>
 								<th
 									class="px-2 py-1 text-right text-[11px] font-medium uppercase tracking-wide text-text-3"

--- a/src/lib/queries/midpointPrices.ts
+++ b/src/lib/queries/midpointPrices.ts
@@ -1,0 +1,57 @@
+import { createQuery } from '@tanstack/svelte-query';
+import { browser } from '$app/environment';
+import type { Network } from '$lib/config/network';
+import { getTokenByAnyAddress } from '$lib/config/network';
+import type { MidpointPrice } from '$lib/utils/midpointPrice';
+
+export type { MidpointPrice };
+
+/** Shape returned by GET /api/public/prices (kept in sync with the endpoint). */
+interface PublicPricesResponse {
+	success: boolean;
+	prices: Record<string, Record<string, MidpointPrice>>;
+}
+
+/**
+ * Query for displayable token prices (bid/ask midpoints) from the public prices endpoint.
+ * Returns a map of lowercased canonical token address -> price for the current network.
+ * Shared across the sidebar, homepage table and strategy price tables via its query key.
+ */
+export function createMidpointPricesQuery(network: Network | null) {
+	return createQuery<Record<string, MidpointPrice>>({
+		queryKey: ['midpointPrices', network?.id],
+		enabled: Boolean(browser && network),
+		refetchInterval: 15_000,
+		queryFn: async () => {
+			if (!network) return {};
+			const res = await fetch('/api/public/prices');
+			if (!res.ok) return {};
+			const data: PublicPricesResponse = await res.json();
+			return data.prices?.[String(network.id)] ?? {};
+		}
+	});
+}
+
+/**
+ * Resolve a token's midpoint price, matching wrapped/unwrapped/legacy address variants.
+ * The endpoint keys prices by the canonical (wrapped) address, so callers can pass any
+ * variant (e.g. an SFT's unwrapped address) and still get a hit.
+ */
+export function getMidpointPrice(
+	map: Record<string, MidpointPrice> | undefined,
+	tokenAddress: string | null | undefined
+): MidpointPrice | undefined {
+	if (!map || !tokenAddress) return undefined;
+	const direct = map[tokenAddress.toLowerCase()];
+	if (direct) return direct;
+	const token = getTokenByAnyAddress(tokenAddress);
+	if (token?.address) {
+		const byCanonical = map[token.address.toLowerCase()];
+		if (byCanonical) return byCanonical;
+	}
+	if (token?.legacyAddress) {
+		const byLegacy = map[token.legacyAddress.toLowerCase()];
+		if (byLegacy) return byLegacy;
+	}
+	return undefined;
+}

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -174,7 +174,9 @@ export const CACHE_KEYS = {
 	// Public TVL cache (aggregate only, no wallet data)
 	publicTvl: () => 'cache:public:tvl',
 	// Public trade activity cache (aggregate 30-day metrics)
-	publicTradeActivity: () => 'cache:public:trade-activity'
+	publicTradeActivity: () => 'cache:public:trade-activity',
+	// Public midpoint prices cache (bid/ask midpoints for all networks, short TTL)
+	publicPrices: () => 'cache:public:prices'
 } as const;
 
 // TTL constants (in seconds)

--- a/src/lib/server/kv.ts
+++ b/src/lib/server/kv.ts
@@ -81,6 +81,9 @@ export const KV_KEYS = {
 	wallet: (address: string) => `wallets:${address.toLowerCase()}`,
 	codeWallets: (code: string) => `code_wallets:${code.toUpperCase()}`,
 	allCodes: () => 'access_codes:__all__',
+	// Last-known midpoint prices per network (no TTL — the fallback when a book is
+	// one-sided or the market is closed). Keyed by lowercased canonical token address.
+	midpointLastKnown: (networkId: number) => `prices:last-known:${networkId}`,
 	// Snapshot keys
 	snapshotBlocks: () => 'snapshots:blocks', // List of all snapshot block records
 	snapshotBlocksByDate: (date: string) => `snapshots:date:${date}`, // Blocks for a specific date (YYYY-MM-DD)

--- a/src/lib/utils/midpointPrice.ts
+++ b/src/lib/utils/midpointPrice.ts
@@ -1,0 +1,156 @@
+/**
+ * Midpoint price resolution — the single home of the "never show a wrong price" rule.
+ *
+ * The displayed price for the sidebar, homepage table and strategy price tables is the
+ * midpoint of the best bid and best ask, `(bid + ask) / 2`. A midpoint is only ever
+ * derived when BOTH sides of the book are present and positive. When one side is zero,
+ * missing, or non-finite (market closed, thin book) we must NEVER fabricate a live price —
+ * a one-sided midpoint would be badly wrong. Instead we fall back to the last valid
+ * midpoint we cached, and failing that we surface N/A.
+ *
+ * This module is pure (no I/O). The endpoint feeds it live bid/ask and the persisted
+ * last-known map, and persists the returned `nextLastKnown` back to KV.
+ */
+
+export type PriceSource = 'live' | 'cached' | 'unavailable';
+
+export interface MidpointPrice {
+	/** Midpoint price in payment-token units per asset token, or null when unavailable. */
+	price: number | null;
+	bid: number | null;
+	ask: number | null;
+	source: PriceSource;
+	/** Epoch ms the price was captured from a live two-sided book, or null when unavailable. */
+	asOf: number | null;
+}
+
+/** Last valid two-sided midpoint, persisted (no expiry) as the fallback for a token. */
+export interface LastKnownMidpoint {
+	mid: number;
+	bid: number;
+	ask: number;
+	updatedAt: number;
+}
+
+export interface TokenBidAsk {
+	/** Canonical token address (any casing — normalized internally). */
+	address: string;
+	bid?: number;
+	ask?: number;
+}
+
+/**
+ * Merge a token's bid/ask across its address variants (wrapped + legacy). Mirrors the
+ * orderbook aggregation rule: best bid is the highest, best ask is the lowest, and only
+ * strictly-positive finite values count.
+ */
+export function pickBestBidAsk(entries: Array<{ bid?: number; ask?: number } | undefined>): {
+	bid?: number;
+	ask?: number;
+} {
+	let bid: number | undefined;
+	let ask: number | undefined;
+	for (const entry of entries) {
+		if (!entry) continue;
+		if (typeof entry.bid === 'number' && Number.isFinite(entry.bid) && entry.bid > 0) {
+			bid = bid === undefined ? entry.bid : Math.max(bid, entry.bid);
+		}
+		if (typeof entry.ask === 'number' && Number.isFinite(entry.ask) && entry.ask > 0) {
+			ask = ask === undefined ? entry.ask : Math.min(ask, entry.ask);
+		}
+	}
+	return { bid, ask };
+}
+
+/** A midpoint may only be derived when both sides are present and strictly positive. */
+export function isValidTwoSided(
+	bid: number | undefined | null,
+	ask: number | undefined | null
+): boolean {
+	return (
+		typeof bid === 'number' &&
+		Number.isFinite(bid) &&
+		bid > 0 &&
+		typeof ask === 'number' &&
+		Number.isFinite(ask) &&
+		ask > 0
+	);
+}
+
+/**
+ * Resolve a single token's displayable price from its live book and cached fallback.
+ *
+ * @returns the price to display plus the last-known entry to persist. For live prices the
+ * entry is refreshed; otherwise the existing `lastKnown` is returned unchanged (or undefined).
+ */
+export function resolveMidpoint(
+	bidAsk: { bid?: number; ask?: number } | undefined,
+	lastKnown: LastKnownMidpoint | undefined,
+	now: number
+): { price: MidpointPrice; nextLastKnown: LastKnownMidpoint | undefined } {
+	const bid = bidAsk?.bid;
+	const ask = bidAsk?.ask;
+
+	if (isValidTwoSided(bid, ask)) {
+		const mid = (bid! + ask!) / 2;
+		const entry: LastKnownMidpoint = { mid, bid: bid!, ask: ask!, updatedAt: now };
+		return {
+			price: { price: mid, bid: bid!, ask: ask!, source: 'live', asOf: now },
+			nextLastKnown: entry
+		};
+	}
+
+	if (lastKnown) {
+		return {
+			price: {
+				price: lastKnown.mid,
+				bid: lastKnown.bid,
+				ask: lastKnown.ask,
+				source: 'cached',
+				asOf: lastKnown.updatedAt
+			},
+			nextLastKnown: lastKnown
+		};
+	}
+
+	return {
+		price: { price: null, bid: null, ask: null, source: 'unavailable', asOf: null },
+		nextLastKnown: undefined
+	};
+}
+
+/**
+ * Resolve a batch of tokens. Returns the per-address price map, the next last-known map to
+ * persist, and how many tokens resolved to a fresh live price (so the caller can skip the
+ * KV write entirely when nothing new was learned — avoids clobbering history on a transient
+ * upstream/KV failure).
+ */
+export function resolveMidpoints(
+	tokens: TokenBidAsk[],
+	lastKnown: Record<string, LastKnownMidpoint>,
+	now: number
+): {
+	prices: Record<string, MidpointPrice>;
+	nextLastKnown: Record<string, LastKnownMidpoint>;
+	liveCount: number;
+} {
+	const prices: Record<string, MidpointPrice> = {};
+	const nextLastKnown: Record<string, LastKnownMidpoint> = { ...lastKnown };
+	let liveCount = 0;
+
+	for (const token of tokens) {
+		const addr = token.address.toLowerCase();
+		const { price, nextLastKnown: entry } = resolveMidpoint(
+			{ bid: token.bid, ask: token.ask },
+			lastKnown[addr],
+			now
+		);
+		prices[addr] = price;
+		if (price.source === 'live' && entry) {
+			liveCount += 1;
+			nextLastKnown[addr] = entry;
+		}
+	}
+
+	return { prices, nextLastKnown, liveCount };
+}

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -5,8 +5,7 @@
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import TokenDisplay from '$lib/components/ui/TokenDisplay.svelte';
 	import { createApiTokensQuery, findApiTokenByAnyAddress } from '$lib/queries/tokens';
-	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
-	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
+	import { createMidpointPricesQuery, getMidpointPrice } from '$lib/queries/midpointPrices';
 	import { formatUnits } from 'viem';
 	import { goto } from '$app/navigation';
 	import Table from '$lib/components/ui/table/Table.svelte';
@@ -67,9 +66,9 @@
 	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
 	$: apiTokens = $apiTokensQuery.data ?? [];
 
-	// Price feeds query — same source the sidebar uses for symbol-based price lookup
-	let priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
-	$: priceFeedsQuery = createPriceFeedsQuery($currentNetwork);
+	// Displayed price is the bid/ask midpoint — same source the sidebar uses, keyed by address.
+	let midpointPricesQuery = createMidpointPricesQuery($currentNetwork);
+	$: midpointPricesQuery = createMidpointPricesQuery($currentNetwork);
 
 	function formatBaseUnitAmount(value: string | null | undefined): string {
 		const amount = toBigInt(value);
@@ -138,15 +137,12 @@
 	$: {
 		if ($sfts && $sfts.length) {
 			const rows: TokenRow[] = [];
-			const priceQuotes = $priceFeedsQuery?.data ?? [];
+			const midpointPrices = $midpointPricesQuery?.data;
 			for (const sft of $sfts) {
-				// Resolve token info (handles wrapped/unwrapped/legacy address variants),
-				// then use symbol-based lookup against the priceFeeds query — same pattern
-				// the sidebar uses so home/sidebar stay consistent.
-				const tokenInfo = findApiTokenByAnyAddress(apiTokens, sft.address);
-				const symbolForPrice = tokenInfo?.symbol ?? sft.symbol;
-				const quote = findQuoteForSymbol(symbolForPrice, priceQuotes, apiTokens);
-				const price = quote?.close ?? null;
+				// Displayed price is the bid/ask midpoint (falls back to last known, else N/A).
+				// getMidpointPrice resolves wrapped/unwrapped/legacy address variants so home and
+				// sidebar stay consistent. Market cap below is derived from this same price.
+				const price = getMidpointPrice(midpointPrices, sft.address)?.price ?? null;
 
 				rows.push({
 					id: sft.id,

--- a/src/routes/api/public/prices/+server.ts
+++ b/src/routes/api/public/prices/+server.ts
@@ -1,0 +1,210 @@
+// Public API endpoint for displayable token prices.
+//
+// The displayed price for the sidebar, homepage table and strategy price tables is the
+// midpoint of the best bid and best ask, computed server-side from live orders using the
+// same (trusted) quoting pipeline the trade UI uses. A midpoint is only ever derived from a
+// two-sided book; when a side is missing/zero (market closed, thin book) we fall back to the
+// last valid midpoint persisted in KV, and failing that we return null (the UI shows N/A).
+// The hard rule "never show a one-sided midpoint" lives in resolveMidpoints().
+//
+// Fetches from the st0x REST API server-side (bypassing the browser-only proxy), mirroring
+// /api/public/trade-activity.
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import { rateLimiters, getClientIp } from '$lib/server/rateLimit';
+import { withConditionalCache, CACHE_KEYS } from '$lib/server/cache';
+import { kvGet, kvSet, KV_KEYS } from '$lib/server/kv';
+import {
+	networks,
+	TOKENS,
+	getDefaultPaymentTokenForNetwork,
+	DEFAULT_PAYMENT_TOKENS,
+	getTokenByAnyAddress
+} from '$lib/config/network';
+import type { Network } from '$lib/config/network';
+import {
+	fetchAndQuotePaymentTokenOrders,
+	buildTokenPriceMap,
+	type OrdersByTokenFetcher,
+	type TokenPriceSummary
+} from '$lib/api/orders';
+import type { ApiOrdersListResponse } from '$lib/api/st0xApi';
+import {
+	pickBestBidAsk,
+	resolveMidpoints,
+	type LastKnownMidpoint,
+	type MidpointPrice
+} from '$lib/utils/midpointPrice';
+import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
+
+/** Short response cache — matches the 15s client poll and shields the REST API. */
+const RESPONSE_TTL_SECONDS = 15;
+
+export interface PublicPricesResponse {
+	success: boolean;
+	/** networkId (stringified) -> lowercased canonical token address -> price. */
+	prices: Record<string, Record<string, MidpointPrice>>;
+}
+
+// ============================================================================
+// Server-side REST API fetch (bypasses the browser-only proxy)
+// ============================================================================
+
+function getApiConfig(): { apiBase: string; authHeader: string } | null {
+	const url = env.ST0X_API_URL;
+	const key = env.ST0X_API_KEY;
+	const secret = env.ST0X_API_SECRET;
+	if (!url || !key || !secret) return null;
+	return {
+		apiBase: url.replace(/\/+$/, ''),
+		authHeader: 'Basic ' + btoa(`${key}:${secret}`)
+	};
+}
+
+/** Build a server-side orders fetcher that hits the REST API directly with Basic auth. */
+function makeServerOrderFetcher(apiBase: string, authHeader: string): OrdersByTokenFetcher {
+	return async (tokenAddress, options) => {
+		const params = new URLSearchParams();
+		if (options?.page !== undefined) params.set('page', String(options.page));
+		if (options?.pageSize !== undefined) params.set('pageSize', String(options.pageSize));
+		if (options?.side) params.set('side', options.side);
+		if (options?.state) params.set('state', options.state);
+		const qs = params.toString();
+		const url = `${apiBase}/v1/orders/token/${tokenAddress}${qs ? `?${qs}` : ''}`;
+		const res = await fetch(url, {
+			headers: { Authorization: authHeader, Accept: 'application/json' }
+		});
+		if (!res.ok) {
+			throw new Error(`Orders fetch failed (${res.status}) for ${tokenAddress}`);
+		}
+		return (await res.json()) as ApiOrdersListResponse;
+	};
+}
+
+// ============================================================================
+// Per-network midpoint computation
+// ============================================================================
+
+/** All lowercased addresses (wrapped + legacy) that represent a configured token. */
+function tokenVariantAddresses(tokenAddress: string): string[] {
+	const canonical = tokenAddress.toLowerCase();
+	const variants = new Set<string>([canonical]);
+	const resolved = getTokenByAnyAddress(tokenAddress);
+	if (resolved?.address) variants.add(resolved.address.toLowerCase());
+	if (resolved?.legacyAddress) variants.add(resolved.legacyAddress.toLowerCase());
+	return [...variants];
+}
+
+async function computeNetworkPrices(
+	network: Network,
+	now: number
+): Promise<Record<string, MidpointPrice>> {
+	const paymentToken =
+		getDefaultPaymentTokenForNetwork(network.id) ?? DEFAULT_PAYMENT_TOKENS[network.id];
+	const stockTokens = TOKENS.filter(
+		(token) => token.chainId === network.chainId && token.category === 'ST0x'
+	);
+
+	// Live bid/ask summary (best-effort). On any failure the summary stays empty and every
+	// token falls back to its cached last-known midpoint.
+	const summary: Record<string, TokenPriceSummary> = {};
+	const config = getApiConfig();
+	if (config && paymentToken?.address) {
+		try {
+			const quotes = await fetchAndQuotePaymentTokenOrders(
+				network.id,
+				undefined,
+				makeServerOrderFetcher(config.apiBase, config.authHeader)
+			);
+			const map = buildTokenPriceMap(quotes, paymentToken.address);
+			for (const [address, value] of map.entries()) {
+				summary[address.toLowerCase()] = value;
+			}
+		} catch (error) {
+			logQueryFailure({
+				kind: 'public_endpoint_network_failed',
+				endpoint: 'public-prices',
+				network: network.name,
+				error: errorMessage(error)
+			});
+		}
+	}
+
+	// Merge each configured token's bid/ask across its address variants → canonical key.
+	const tokens = stockTokens.map((token) => {
+		const { bid, ask } = pickBestBidAsk(
+			tokenVariantAddresses(token.address).map((v) => summary[v])
+		);
+		return { address: token.address.toLowerCase(), bid, ask };
+	});
+
+	// Resolve with the hard rule against the persisted fallback, then persist — but only when
+	// at least one token produced a fresh live price. Skipping the write when nothing is live
+	// avoids clobbering history during a transient upstream/market-closed window.
+	const lastKnown =
+		(await kvGet<Record<string, LastKnownMidpoint>>(KV_KEYS.midpointLastKnown(network.id))) ?? {};
+	const { prices, nextLastKnown, liveCount } = resolveMidpoints(tokens, lastKnown, now);
+	if (liveCount > 0) {
+		await kvSet(KV_KEYS.midpointLastKnown(network.id), nextLastKnown);
+	}
+
+	return prices;
+}
+
+async function computePrices(): Promise<PublicPricesResponse> {
+	const now = Date.now();
+	const entries = await Promise.all(
+		networks.map(async (network) => {
+			try {
+				return [String(network.id), await computeNetworkPrices(network, now)] as const;
+			} catch (error) {
+				logQueryFailure({
+					kind: 'public_endpoint_network_failed',
+					endpoint: 'public-prices',
+					network: network.name,
+					error: errorMessage(error)
+				});
+				return [String(network.id), {} as Record<string, MidpointPrice>] as const;
+			}
+		})
+	);
+	return { success: true, prices: Object.fromEntries(entries) };
+}
+
+export const GET: RequestHandler = async ({ request }) => {
+	const clientIp = getClientIp(request);
+	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
+
+	if (!rateLimit.allowed) {
+		return json(
+			{ success: false, error: 'Rate limit exceeded. Please try again later.' },
+			{
+				status: 429,
+				headers: {
+					'Retry-After': String(Math.ceil((rateLimit.resetAt - Date.now()) / 1000)),
+					'X-RateLimit-Remaining': String(rateLimit.remaining),
+					'X-RateLimit-Reset': String(rateLimit.resetAt)
+				}
+			}
+		);
+	}
+
+	try {
+		const data = await withConditionalCache<PublicPricesResponse>(
+			CACHE_KEYS.publicPrices(),
+			computePrices,
+			(result) => result.success,
+			RESPONSE_TTL_SECONDS
+		);
+
+		return json(data, {
+			headers: {
+				'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=60'
+			}
+		});
+	} catch (error) {
+		console.error('[Public Prices] Error:', error);
+		return json({ success: false, prices: {} } satisfies PublicPricesResponse, { status: 500 });
+	}
+};

--- a/tests/lib/utils/midpointPrice.test.ts
+++ b/tests/lib/utils/midpointPrice.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isValidTwoSided,
+	pickBestBidAsk,
+	resolveMidpoint,
+	resolveMidpoints,
+	type LastKnownMidpoint
+} from '$lib/utils/midpointPrice';
+
+describe('pickBestBidAsk', () => {
+	it('merges variant entries taking the highest bid and lowest ask, ignoring blanks', () => {
+		const merged = pickBestBidAsk([
+			{ bid: 100, ask: 105 },
+			{ bid: 101, ask: 104 }, // better on both sides
+			{ ask: 106 }, // worse ask ignored
+			undefined,
+			{ bid: 0, ask: -1 } // non-positive ignored
+		]);
+		expect(merged).toEqual({ bid: 101, ask: 104 });
+	});
+
+	it('returns undefined sides when no positive values exist', () => {
+		expect(pickBestBidAsk([{ bid: 0 }, undefined, {}])).toEqual({ bid: undefined, ask: undefined });
+	});
+});
+
+describe('isValidTwoSided', () => {
+	it('is true only when both bid and ask are finite and positive', () => {
+		expect(isValidTwoSided(10, 11)).toBe(true);
+		expect(isValidTwoSided(0, 11)).toBe(false);
+		expect(isValidTwoSided(10, 0)).toBe(false);
+		expect(isValidTwoSided(-1, 11)).toBe(false);
+		expect(isValidTwoSided(10, undefined)).toBe(false);
+		expect(isValidTwoSided(undefined, 11)).toBe(false);
+		expect(isValidTwoSided(NaN, 11)).toBe(false);
+		expect(isValidTwoSided(10, Infinity)).toBe(false);
+	});
+});
+
+describe('resolveMidpoint', () => {
+	const NOW = 1_700_000_000_000;
+
+	it('returns a live midpoint when both sides are present and positive', () => {
+		const { price, nextLastKnown } = resolveMidpoint({ bid: 100, ask: 102 }, undefined, NOW);
+		expect(price.source).toBe('live');
+		expect(price.price).toBe(101);
+		expect(price.bid).toBe(100);
+		expect(price.ask).toBe(102);
+		expect(price.asOf).toBe(NOW);
+		expect(nextLastKnown).toEqual({ mid: 101, bid: 100, ask: 102, updatedAt: NOW });
+	});
+
+	it('never derives a live price when one side is zero — falls back to last known', () => {
+		const lastKnown: LastKnownMidpoint = { mid: 50, bid: 49, ask: 51, updatedAt: 123 };
+		const { price, nextLastKnown } = resolveMidpoint({ bid: 0, ask: 102 }, lastKnown, NOW);
+		expect(price.source).toBe('cached');
+		expect(price.price).toBe(50);
+		expect(price.bid).toBe(49);
+		expect(price.ask).toBe(51);
+		expect(price.asOf).toBe(123);
+		// last known is preserved unchanged (we learned nothing new)
+		expect(nextLastKnown).toBe(lastKnown);
+	});
+
+	it('falls back to last known when a side is missing entirely', () => {
+		const lastKnown: LastKnownMidpoint = { mid: 50, bid: 49, ask: 51, updatedAt: 123 };
+		const { price } = resolveMidpoint({ ask: 102 }, lastKnown, NOW);
+		expect(price.source).toBe('cached');
+		expect(price.price).toBe(50);
+	});
+
+	it('returns unavailable (N/A) when invalid and there is no cached price', () => {
+		const { price, nextLastKnown } = resolveMidpoint({ bid: 0 }, undefined, NOW);
+		expect(price.source).toBe('unavailable');
+		expect(price.price).toBeNull();
+		expect(price.asOf).toBeNull();
+		expect(nextLastKnown).toBeUndefined();
+	});
+
+	it('still returns a midpoint for a crossed book (both sides positive)', () => {
+		const { price } = resolveMidpoint({ bid: 103, ask: 101 }, undefined, NOW);
+		expect(price.source).toBe('live');
+		expect(price.price).toBe(102);
+	});
+});
+
+describe('resolveMidpoints', () => {
+	const NOW = 1_700_000_000_000;
+
+	it('resolves each token, updates only live tokens in nextLastKnown, and counts live tokens', () => {
+		const lastKnown: Record<string, LastKnownMidpoint> = {
+			'0xaaa': { mid: 10, bid: 9, ask: 11, updatedAt: 1 },
+			'0xbbb': { mid: 20, bid: 19, ask: 21, updatedAt: 2 }
+		};
+		const tokens = [
+			{ address: '0xAAA', bid: 100, ask: 102 }, // live (mixed-case addr should normalize)
+			{ address: '0xbbb', bid: 0, ask: 21 }, // invalid → cached fallback
+			{ address: '0xccc' } // invalid, no history → unavailable
+		];
+
+		const { prices, nextLastKnown, liveCount } = resolveMidpoints(tokens, lastKnown, NOW);
+
+		expect(prices['0xaaa'].source).toBe('live');
+		expect(prices['0xaaa'].price).toBe(101);
+		expect(prices['0xbbb'].source).toBe('cached');
+		expect(prices['0xbbb'].price).toBe(20);
+		expect(prices['0xccc'].source).toBe('unavailable');
+		expect(prices['0xccc'].price).toBeNull();
+
+		expect(liveCount).toBe(1);
+		// live token updated
+		expect(nextLastKnown['0xaaa']).toEqual({ mid: 101, bid: 100, ask: 102, updatedAt: NOW });
+		// cached token's history preserved unchanged
+		expect(nextLastKnown['0xbbb']).toEqual(lastKnown['0xbbb']);
+		// unavailable token gains no history entry
+		expect(nextLastKnown['0xccc']).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What & why

The sidebar price and the "oracle price" were showing a buggy/undesired value. This replaces them with the **midpoint of the best bid and ask** — the value we trust — across three surfaces:

- **Sidebar** price
- **Homepage table** price (and market cap, which is derived from it)
- **Strategy "Oracle Price" rows** (`FolioStrategy`, `ActiveLiquidity`) — column relabeled **"Oracle Price" → "Mid Price"** and **"Price Certainty" → "Bid / Ask"**

## How it works

- **New endpoint `GET /api/public/prices`** computes midpoints server-side by reusing the exact trusted quoting pipeline (`fetchAndQuotePaymentTokenOrders` → `describeQuote` → `buildTokenPriceMap`). A server-side order fetcher is injected into `fetchAndQuotePaymentTokenOrders` (Basic auth to the REST API, same pattern as `/api/public/trade-activity`).
- **Read-through cache of the last valid midpoint** in Redis KV (`prices:last-known:{networkId}`, no expiry) — so when the market is closed / a book is one-sided we serve the last good price instead of a wrong one. The KV write is skipped when nothing is live, so a transient blip can't clobber history. A short (15s) response cache shields the REST API.
- **The hard rule lives in one pure, unit-tested function** (`resolveMidpoints`): a midpoint is derived **only** when both bid and ask are finite and > 0. One-sided/zero/missing → last known price → else **N/A**. It never fabricates a price from half a book.

## Notes

- **SPYM** now follows the same midpoint rule (N/A if it has no two-sided book) rather than its old liquidity-monitor special-case — flagged for follow-up if we want to restore it.
- Requires `ST0X_API_URL` / `ST0X_API_KEY` / `ST0X_API_SECRET` + `REDIS_URL` (already used by trade-activity / snapshots). Without them the endpoint degrades to N/A gracefully.

## Testing

- TDD unit tests for `resolveMidpoint` / `resolveMidpoints` / `pickBestBidAsk` (9 tests).
- Full unit suite green (pre-existing `@rainlanguage/raindex` load failures are environmental, unrelated).
- `svelte-check` clean on touched files; ESLint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public midpoint pricing for tokens, including bid/ask values and live or cached price indicators.
  * Updated asset lists, sidebars, and liquidity tables to display midpoint and bid/ask pricing.
  * Added cached last-known prices for periods when live market data is unavailable.
  * Added flexible order retrieval for payment-token order quotes.

* **Bug Fixes**
  * Improved price fallback behavior and replaced misleading unavailable-price messages.
  * Added address-aware price resolution for supported token variants.

* **Tests**
  * Added coverage for midpoint validation, caching, fallbacks, normalization, and live-price updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->