### PR TITLE
fix(home): use inline loading spinner for asset table

### DIFF
--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -287,7 +287,7 @@
 		<div class="mx-auto max-w-5xl">
 			{#if isVaultLoading}
 				<div class="flex w-full items-center justify-center py-16">
-					<LoadingSpinner variant="fullscreen" size="lg" text="Loading assets..." />
+					<LoadingSpinner variant="inline" size="lg" text="Loading assets..." />
 				</div>
 			{:else if vaultsError}
 				<div class="flex w-full items-center justify-center py-16 text-sm text-down">


### PR DESCRIPTION
## Problem

On the homepage, the asset-table loading spinner rendered with a mismatched, lighter background that stood out as an ugly full-height column behind the "Loading assets…" spinner.

<img width="400" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

## Cause

The section used `<LoadingSpinner variant="fullscreen" ... />`. The `fullscreen` variant hardcodes `bg-surface-1` and `h-screen` on its container — it's designed to cover a whole viewport on genuine full-page loads (trade page, proofs layout). Dropped inside the `max-w-5xl` asset-table section, that painted a lighter, full-height box behind the spinner.

## Fix

Switch to `variant="inline"` — the variant every other embedded loader in the app already uses (orders table, dashboard, charts). It has no background and no forced height, so the spinner now sits transparently over the page's own gradient. The multicolor ring itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the “Loading assets…” indicator to display inline instead of occupying the full screen.
  * Preserved the large spinner size and loading message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->