### PR TITLE
fix(pricing): throttle public price fanout

### DIFF
--- a/src/lib/components/PythOracleRow.svelte
+++ b/src/lib/components/PythOracleRow.svelte
@@ -54,7 +54,7 @@
 		Boolean(tokenAddress);
 	$: error = (() => {
 		if (!tokenAddress) return 'Token missing address';
-		if (midpointState?.status === 'error') return 'Failed to fetch price data';
+		if (midpointState?.status === 'error' && !entry) return 'Failed to fetch price data';
 		return null;
 	})();
 	// Only render a price when we have a real one (live or cached). A one-sided book resolves

--- a/src/lib/config/publicPrices.ts
+++ b/src/lib/config/publicPrices.ts
@@ -1,4 +1,9 @@
-export const PUBLIC_PRICES_TTL_SECONDS = 5 * 60;
+/**
+ * A price refresh fans out to 27 token endpoints against a 60-request rolling
+ * 60-second per-key limit. Ninety seconds keeps normal refresh bursts in
+ * separate limiter windows while reserving capacity for interactive traffic.
+ */
+export const PUBLIC_PRICES_TTL_SECONDS = 90;
 export const PUBLIC_PRICES_REFRESH_INTERVAL_MS = PUBLIC_PRICES_TTL_SECONDS * 1_000;
 export const PUBLIC_PRICES_CACHE_CONTROL = `public, s-maxage=${PUBLIC_PRICES_TTL_SECONDS}, stale-while-revalidate=${
 	PUBLIC_PRICES_TTL_SECONDS * 3

--- a/src/lib/config/publicPrices.ts
+++ b/src/lib/config/publicPrices.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_PRICES_TTL_SECONDS = 5 * 60;
+export const PUBLIC_PRICES_REFRESH_INTERVAL_MS = PUBLIC_PRICES_TTL_SECONDS * 1_000;
+export const PUBLIC_PRICES_CACHE_CONTROL = `public, s-maxage=${PUBLIC_PRICES_TTL_SECONDS}, stale-while-revalidate=${
+	PUBLIC_PRICES_TTL_SECONDS * 3
+}`;

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -159,7 +159,6 @@ export const TOKENS: CategorizedToken[] = [
 		priceFeedId: '',
 		// priceFeedId removed — Pyth no longer supports this feed ID.
 		// Using a hardcoded fallback until a replacement feed is wired up.
-		fallbackPrice: 82.5,
 		category: 'ST0x',
 		tradingViewSymbol: 'AMEX:SPYM',
 		tradingViewMarket: 'america',
@@ -316,7 +315,6 @@ export const TOKENS: CategorizedToken[] = [
 		name: 'Wrapped Space Exploration Technologies Corp. ST0x',
 		logoUrl: '/images/SPCX.svg',
 		priceFeedId: '',
-		fallbackPrice: 145.3,
 		category: 'ST0x',
 		tradingViewSymbol: 'NASDAQ:SPCX',
 		tradingViewMarket: 'america',
@@ -345,9 +343,6 @@ export const TOKENS: CategorizedToken[] = [
 		name: 'Wrapped Roundhill Memory ETF ST0x',
 		logoUrl: '/images/roundhill.png',
 		priceFeedId: '',
-		// Pyth does not publish a DRAM feed. Use TradingView's latest close observed
-		// on 2026-07-13 until a replacement feed is wired up.
-		fallbackPrice: 63.04,
 		category: 'ST0x',
 		tradingViewSymbol: 'CBOE:DRAM',
 		tradingViewMarket: 'america',
@@ -390,8 +385,6 @@ export const TOKENS: CategorizedToken[] = [
 		name: 'Wrapped SK hynix Inc. ADR ST0x',
 		logoUrl: '/images/SKHY.png',
 		priceFeedId: '',
-		// Pyth does not yet publish an SKHY feed. Use the $149 IPO price until one is available.
-		fallbackPrice: 149,
 		category: 'ST0x',
 		tradingViewSymbol: 'NASDAQ:SKHY',
 		tradingViewMarket: 'america',

--- a/src/lib/queries/midpointPrices.test.ts
+++ b/src/lib/queries/midpointPrices.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchMidpointPrices } from '$lib/queries/midpointPrices';
+import type { MidpointPrice } from '$lib/utils/midpointPrice';
+
+describe('fetchMidpointPrices', () => {
+	it('returns prices for the requested network', async () => {
+		const price: MidpointPrice = {
+			price: 123.45,
+			bid: 123,
+			ask: 123.9,
+			source: 'live',
+			asOf: 1
+		};
+		const fetchFn = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						prices: { '8453': { '0xtoken': price } }
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+		) as unknown as typeof fetch;
+
+		await expect(fetchMidpointPrices(8453, fetchFn)).resolves.toEqual({ '0xtoken': price });
+	});
+
+	it('rejects a rate-limited refresh instead of replacing cached prices with an empty map', async () => {
+		const fetchFn = vi.fn(
+			async () => new Response(null, { status: 429 })
+		) as unknown as typeof fetch;
+
+		await expect(fetchMidpointPrices(8453, fetchFn)).rejects.toThrow(
+			'Public prices request failed (429)'
+		);
+	});
+});

--- a/src/lib/queries/midpointPrices.ts
+++ b/src/lib/queries/midpointPrices.ts
@@ -13,6 +13,18 @@ interface PublicPricesResponse {
 	prices: Record<string, Record<string, MidpointPrice>>;
 }
 
+export async function fetchMidpointPrices(
+	networkId: number,
+	fetchFn: typeof fetch = fetch
+): Promise<Record<string, MidpointPrice>> {
+	const response = await fetchFn('/api/public/prices');
+	if (!response.ok) {
+		throw new Error(`Public prices request failed (${response.status})`);
+	}
+	const data: PublicPricesResponse = await response.json();
+	return data.prices?.[String(networkId)] ?? {};
+}
+
 /**
  * Query for displayable token prices (bid/ask midpoints) from the public prices endpoint.
  * Returns a map of lowercased canonical token address -> price for the current network.
@@ -26,12 +38,10 @@ export function createMidpointPricesQuery(network: Network | null) {
 		refetchInterval: PUBLIC_PRICES_REFRESH_INTERVAL_MS,
 		refetchOnWindowFocus: false,
 		refetchIntervalInBackground: false,
+		retry: false,
 		queryFn: async () => {
 			if (!network) return {};
-			const res = await fetch('/api/public/prices');
-			if (!res.ok) return {};
-			const data: PublicPricesResponse = await res.json();
-			return data.prices?.[String(network.id)] ?? {};
+			return fetchMidpointPrices(network.id);
 		}
 	});
 }

--- a/src/lib/queries/midpointPrices.ts
+++ b/src/lib/queries/midpointPrices.ts
@@ -2,6 +2,7 @@ import { createQuery } from '@tanstack/svelte-query';
 import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
 import { getTokenByAnyAddress } from '$lib/config/network';
+import { PUBLIC_PRICES_REFRESH_INTERVAL_MS } from '$lib/config/publicPrices';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 
 export type { MidpointPrice };
@@ -21,7 +22,10 @@ export function createMidpointPricesQuery(network: Network | null) {
 	return createQuery<Record<string, MidpointPrice>>({
 		queryKey: ['midpointPrices', network?.id],
 		enabled: Boolean(browser && network),
-		refetchInterval: 15_000,
+		staleTime: PUBLIC_PRICES_REFRESH_INTERVAL_MS,
+		refetchInterval: PUBLIC_PRICES_REFRESH_INTERVAL_MS,
+		refetchOnWindowFocus: false,
+		refetchIntervalInBackground: false,
 		queryFn: async () => {
 			if (!network) return {};
 			const res = await fetch('/api/public/prices');

--- a/src/lib/server/publicPricesCache.test.ts
+++ b/src/lib/server/publicPricesCache.test.ts
@@ -17,10 +17,10 @@ describe('public prices cache', () => {
 		vi.useRealTimers();
 	});
 
-	it('uses a five-minute shared and browser refresh window', () => {
-		expect(PUBLIC_PRICES_TTL_SECONDS).toBe(300);
-		expect(PUBLIC_PRICES_REFRESH_INTERVAL_MS).toBe(300_000);
-		expect(PUBLIC_PRICES_CACHE_CONTROL).toBe('public, s-maxage=300, stale-while-revalidate=900');
+	it('uses a 90-second shared and browser refresh window', () => {
+		expect(PUBLIC_PRICES_TTL_SECONDS).toBe(90);
+		expect(PUBLIC_PRICES_REFRESH_INTERVAL_MS).toBe(90_000);
+		expect(PUBLIC_PRICES_CACHE_CONTROL).toBe('public, s-maxage=90, stale-while-revalidate=270');
 	});
 
 	it('does not repeat the expensive computation when Redis is unavailable', async () => {

--- a/src/lib/server/publicPricesCache.test.ts
+++ b/src/lib/server/publicPricesCache.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/kv', () => ({
+	getKv: vi.fn(async () => null)
+}));
+
+import { clearPublicPricesMemoryCache, getCachedPublicPrices } from '$lib/server/publicPricesCache';
+import {
+	PUBLIC_PRICES_CACHE_CONTROL,
+	PUBLIC_PRICES_REFRESH_INTERVAL_MS,
+	PUBLIC_PRICES_TTL_SECONDS
+} from '$lib/config/publicPrices';
+
+describe('public prices cache', () => {
+	beforeEach(() => {
+		clearPublicPricesMemoryCache();
+		vi.useRealTimers();
+	});
+
+	it('uses a five-minute shared and browser refresh window', () => {
+		expect(PUBLIC_PRICES_TTL_SECONDS).toBe(300);
+		expect(PUBLIC_PRICES_REFRESH_INTERVAL_MS).toBe(300_000);
+		expect(PUBLIC_PRICES_CACHE_CONTROL).toBe('public, s-maxage=300, stale-while-revalidate=900');
+	});
+
+	it('does not repeat the expensive computation when Redis is unavailable', async () => {
+		const compute = vi.fn(async () => ({ success: true, prices: {} }));
+
+		const first = await getCachedPublicPrices(compute, (result) => result.success);
+		const second = await getCachedPublicPrices(compute, (result) => result.success);
+
+		expect(first).toEqual(second);
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('does not retain an unsuccessful result in memory', async () => {
+		const compute = vi
+			.fn<[], Promise<{ success: boolean }>>()
+			.mockResolvedValueOnce({ success: false })
+			.mockResolvedValueOnce({ success: true });
+
+		await getCachedPublicPrices(compute, (result) => result.success);
+		await getCachedPublicPrices(compute, (result) => result.success);
+
+		expect(compute).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/server/publicPricesCache.ts
+++ b/src/lib/server/publicPricesCache.ts
@@ -1,0 +1,47 @@
+import {
+	PUBLIC_PRICES_REFRESH_INTERVAL_MS,
+	PUBLIC_PRICES_TTL_SECONDS
+} from '$lib/config/publicPrices';
+import { CACHE_KEYS, withConditionalCache } from '$lib/server/cache';
+
+interface MemoryEntry<T> {
+	value: T;
+	expiresAt: number;
+}
+
+let memoryEntry: MemoryEntry<unknown> | null = null;
+
+/**
+ * Cache public prices in Redis and in-process.
+ *
+ * Redis remains the cross-instance source of truth. The one-entry memory layer
+ * prevents a missing or temporarily unavailable Redis connection from turning
+ * every client poll into a full REST order-book fanout.
+ */
+export async function getCachedPublicPrices<T>(
+	compute: () => Promise<T>,
+	shouldCache: (result: T) => boolean
+): Promise<T> {
+	const now = Date.now();
+	if (memoryEntry && memoryEntry.expiresAt > now) {
+		return memoryEntry.value as T;
+	}
+
+	const value = await withConditionalCache(
+		CACHE_KEYS.publicPrices(),
+		compute,
+		shouldCache,
+		PUBLIC_PRICES_TTL_SECONDS
+	);
+	if (shouldCache(value)) {
+		memoryEntry = {
+			value,
+			expiresAt: Date.now() + PUBLIC_PRICES_REFRESH_INTERVAL_MS
+		};
+	}
+	return value;
+}
+
+export function clearPublicPricesMemoryCache(): void {
+	memoryEntry = null;
+}

--- a/src/lib/server/st0xOrderFetcher.test.ts
+++ b/src/lib/server/st0xOrderFetcher.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createServerOrderFetcher, St0xOrdersRateLimitError } from '$lib/server/st0xOrderFetcher';
+
+describe('createServerOrderFetcher', () => {
+	it('builds an authenticated paginated orders request', async () => {
+		const fetchMock = vi
+			.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>()
+			.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						orders: [],
+						pagination: {
+							page: 1,
+							pageSize: 50,
+							totalOrders: 0,
+							totalPages: 0,
+							hasMore: false
+						}
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			);
+		const fetchFn = fetchMock as unknown as typeof fetch;
+		const fetchOrders = createServerOrderFetcher({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic credentials',
+			fetchFn
+		});
+
+		await fetchOrders('0xToken', { page: 1, pageSize: 50 });
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/orders/token/0xToken?page=1&pageSize=50',
+			expect.objectContaining({
+				headers: {
+					Authorization: 'Basic credentials',
+					Accept: 'application/json'
+				},
+				signal: expect.any(AbortSignal)
+			})
+		);
+	});
+
+	it('stops the remaining fanout after the first 429', async () => {
+		const fetchMock = vi
+			.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ error: 'rate limited' }), {
+					status: 429,
+					headers: { 'Content-Type': 'application/json' }
+				})
+			);
+		const fetchFn = fetchMock as unknown as typeof fetch;
+		const fetchOrders = createServerOrderFetcher({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic credentials',
+			fetchFn
+		});
+
+		await expect(fetchOrders('0xFirst', { page: 1, pageSize: 50 })).rejects.toBeInstanceOf(
+			St0xOrdersRateLimitError
+		);
+		await expect(fetchOrders('0xSecond', { page: 1, pageSize: 50 })).rejects.toBeInstanceOf(
+			St0xOrdersRateLimitError
+		);
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/server/st0xOrderFetcher.ts
+++ b/src/lib/server/st0xOrderFetcher.ts
@@ -1,0 +1,60 @@
+import type { OrdersByTokenFetcher } from '$lib/api/orders';
+import type { ApiOrdersListResponse } from '$lib/api/st0xApi';
+
+export class St0xOrdersRateLimitError extends Error {
+	constructor(message = 'ST0x orders API rate limit reached') {
+		super(message);
+		this.name = 'St0xOrdersRateLimitError';
+	}
+}
+
+interface ServerOrderFetcherOptions {
+	apiBase: string;
+	authHeader: string;
+	fetchFn?: typeof fetch;
+	timeoutMs?: number;
+}
+
+/**
+ * Create a REST order fetcher with a per-run rate-limit circuit breaker.
+ *
+ * A public-price refresh fans out across every configured stock token. Once one
+ * request receives 429, the shared API-key budget is exhausted, so sending the
+ * rest of that fanout only prolongs the incident. The breaker stops subsequent
+ * workers in the same refresh and lets the pricing resolver use last-known data.
+ */
+export function createServerOrderFetcher({
+	apiBase,
+	authHeader,
+	fetchFn = fetch,
+	timeoutMs = 10_000
+}: ServerOrderFetcherOptions): OrdersByTokenFetcher {
+	let rateLimited = false;
+
+	return async (tokenAddress, options) => {
+		if (rateLimited) {
+			throw new St0xOrdersRateLimitError();
+		}
+
+		const params = new URLSearchParams();
+		if (options?.page !== undefined) params.set('page', String(options.page));
+		if (options?.pageSize !== undefined) params.set('pageSize', String(options.pageSize));
+		if (options?.side) params.set('side', options.side);
+		if (options?.state) params.set('state', options.state);
+		const qs = params.toString();
+		const url = `${apiBase}/v1/orders/token/${tokenAddress}${qs ? `?${qs}` : ''}`;
+		const response = await fetchFn(url, {
+			headers: { Authorization: authHeader, Accept: 'application/json' },
+			signal: AbortSignal.timeout(timeoutMs)
+		});
+
+		if (response.status === 429) {
+			rateLimited = true;
+			throw new St0xOrdersRateLimitError();
+		}
+		if (!response.ok) {
+			throw new Error(`Orders fetch failed (${response.status}) for ${tokenAddress}`);
+		}
+		return (await response.json()) as ApiOrdersListResponse;
+	};
+}

--- a/src/routes/api/public/prices/+server.ts
+++ b/src/routes/api/public/prices/+server.ts
@@ -13,8 +13,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 import { rateLimiters, getClientIp } from '$lib/server/rateLimit';
-import { withConditionalCache, CACHE_KEYS } from '$lib/server/cache';
 import { kvGet, kvSet, KV_KEYS } from '$lib/server/kv';
+import { PUBLIC_PRICES_CACHE_CONTROL } from '$lib/config/publicPrices';
+import { getCachedPublicPrices } from '$lib/server/publicPricesCache';
+import { createServerOrderFetcher } from '$lib/server/st0xOrderFetcher';
 import {
 	networks,
 	TOKENS,
@@ -26,10 +28,8 @@ import type { Network } from '$lib/config/network';
 import {
 	fetchAndQuotePaymentTokenOrders,
 	buildTokenPriceMap,
-	type OrdersByTokenFetcher,
 	type TokenPriceSummary
 } from '$lib/api/orders';
-import type { ApiOrdersListResponse } from '$lib/api/st0xApi';
 import {
 	pickBestBidAsk,
 	resolveMidpoints,
@@ -37,9 +37,6 @@ import {
 	type MidpointPrice
 } from '$lib/utils/midpointPrice';
 import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
-
-/** Short response cache — matches the 15s client poll and shields the REST API. */
-const RESPONSE_TTL_SECONDS = 15;
 
 export interface PublicPricesResponse {
 	success: boolean;
@@ -59,26 +56,6 @@ function getApiConfig(): { apiBase: string; authHeader: string } | null {
 	return {
 		apiBase: url.replace(/\/+$/, ''),
 		authHeader: 'Basic ' + btoa(`${key}:${secret}`)
-	};
-}
-
-/** Build a server-side orders fetcher that hits the REST API directly with Basic auth. */
-function makeServerOrderFetcher(apiBase: string, authHeader: string): OrdersByTokenFetcher {
-	return async (tokenAddress, options) => {
-		const params = new URLSearchParams();
-		if (options?.page !== undefined) params.set('page', String(options.page));
-		if (options?.pageSize !== undefined) params.set('pageSize', String(options.pageSize));
-		if (options?.side) params.set('side', options.side);
-		if (options?.state) params.set('state', options.state);
-		const qs = params.toString();
-		const url = `${apiBase}/v1/orders/token/${tokenAddress}${qs ? `?${qs}` : ''}`;
-		const res = await fetch(url, {
-			headers: { Authorization: authHeader, Accept: 'application/json' }
-		});
-		if (!res.ok) {
-			throw new Error(`Orders fetch failed (${res.status}) for ${tokenAddress}`);
-		}
-		return (await res.json()) as ApiOrdersListResponse;
 	};
 }
 
@@ -115,7 +92,7 @@ async function computeNetworkPrices(
 			const quotes = await fetchAndQuotePaymentTokenOrders(
 				network.id,
 				undefined,
-				makeServerOrderFetcher(config.apiBase, config.authHeader)
+				createServerOrderFetcher(config)
 			);
 			const map = buildTokenPriceMap(quotes, paymentToken.address);
 			for (const [address, value] of map.entries()) {
@@ -191,16 +168,14 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
-		const data = await withConditionalCache<PublicPricesResponse>(
-			CACHE_KEYS.publicPrices(),
+		const data = await getCachedPublicPrices<PublicPricesResponse>(
 			computePrices,
-			(result) => result.success,
-			RESPONSE_TTL_SECONDS
+			(result) => result.success
 		);
 
 		return json(data, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=60'
+				'Cache-Control': PUBLIC_PRICES_CACHE_CONTROL
 			}
 		});
 	} catch (error) {


### PR DESCRIPTION
## What & why

`/api/public/prices` computes website display prices by calling `/v1/orders/token/{tokenAddress}` for every configured stock token. Even after the concurrency and retry fixes on `main`, the 15-second cache/refresh window can generate at least 27 upstream order requests per refresh (about 108 requests/minute before pagination) against a shared 60 requests/minute API-key budget.

The REST API allows 60 requests per API key in a rolling 60-second window. At the old 15-second cadence, two 27-request refreshes consume 54 requests and the third refresh begins hitting `429` responses roughly 30 seconds in. This is a temporary production hotfix until the REST API's aggregate pricing endpoint is ready.

## Implementation

- Cache the complete public-price response for 90 seconds in Redis, in-process, and at the CDN edge.
- Keep stale CDN data available for 270 seconds while a refresh runs.
- Align the browser query with the 90-second window and disable focus/background refreshes.
- Preserve the last successful browser price data when a refresh fails, without automatic retry bursts.
- Add an in-process fallback so missing or unavailable Redis does not turn every request into a new full order-book fan-out.
- Add a 10-second timeout to each upstream orders request.
- Open a per-refresh circuit breaker after the first upstream `429`, preventing remaining queued token requests from continuing to consume the exhausted key budget.
- Preserve the existing last-known midpoint fallback when the upstream is unavailable or rate limited.

## Tradeoff

Public display midpoints can normally be up to 90 seconds old during this hotfix. Trade execution remains protected by its own fresh liquidity and execution checks. The temporary window should be removed when the aggregate REST pricing endpoint replaces this website-side fan-out.

## Validation

- `nix develop -c npm run check` — 0 errors and 0 warnings.
- `nix develop -c npm test -- --run` — 69 files passed; 774 tests passed, 1 skipped.
- `nix develop -c npm run lint-check`
- `nix develop -c npm run format-check`
- Focused hotfix regression tests — 7 passed, including `429` retention and circuit-breaker coverage.
- `nix develop -c env CSRF_SECRET=<local-build-placeholder> BASE_RPC_URL=https://example.invalid npm run build`
- Local runtime reproduction with production REST credentials:
  - cold `/api/public/prices`: full computation completed successfully;
  - immediate repeat: `200` in ~5 ms from the fallback cache;
  - response cache behavior verified locally; the updated header is `Cache-Control: public, s-maxage=90, stale-while-revalidate=270`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resilient caching for public token prices, including stale-while-revalidate behavior.
  * Improved price refresh timing and reduced unnecessary background or focus-based refreshes.
  * Added rate-limit handling for order requests, allowing the app to use last-known pricing when appropriate.

* **Bug Fixes**
  * Improved error messaging when price data is unavailable.
  * Removed outdated fallback prices for selected tokens.
  * Prevented unsuccessful price results from being retained in memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->