### PR TITLE
feat(orderbook): use REST batch queries for global liquidity

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -11,6 +11,7 @@ import {
 	DEFAULT_PAYMENT_TOKENS,
 	getDefaultPaymentTokenForNetwork
 } from '$lib/config/network';
+import type { CategorizedToken } from '$lib/config/network';
 import { describeQuote, normalizeAddress } from '$lib/utils/tokenMath';
 import type { Token } from '$lib/types';
 import { Float } from '@rainlanguage/float';
@@ -27,6 +28,7 @@ import {
 import {
 	apiGetOrdersByToken,
 	apiGetOrdersByOwner,
+	apiQueryOrders,
 	type ApiOrderSummary,
 	type ApiOrdersListResponse
 } from '$lib/api/st0xApi';
@@ -48,6 +50,8 @@ export type OrdersByTokenFetcher = (
 		state?: 'active' | 'inactive' | 'all';
 	}
 ) => Promise<ApiOrdersListResponse>;
+
+export type OrdersQueryFetcher = typeof apiQueryOrders;
 
 export const buildTokenPriceMap = (quotes: ProcessedQuote[], quoteAddressRaw: string) =>
 	buildTokenPriceMapBase(quotes, quoteAddressRaw, describeQuote);
@@ -216,7 +220,11 @@ function convertApiOrderToProcessedQuote(
 function resolveNetworkTokens(
 	networkId: number,
 	overridePaymentToken?: Token
-): { paymentToken: Token; stockTokens: Token[]; allTokens: Token[] } {
+): {
+	paymentToken: Token;
+	stockTokens: CategorizedToken[];
+	allTokens: Token[];
+} {
 	if (!networks.some((n) => n.id === networkId)) {
 		throw new Error(`Network with id ${networkId} not found`);
 	}
@@ -236,11 +244,68 @@ function resolveNetworkTokens(
 	return { paymentToken, stockTokens, allTokens: [paymentToken, ...stockTokens] };
 }
 
-/**
- * Fetches all orders for all stock tokens via the REST API and converts them to ProcessedQuotes.
- * The REST API handles server-side quoting and caching.
- */
-export async function fetchAndQuotePaymentTokenOrders(
+interface CollectOrderPagesOptions {
+	fetchPage: (page: number) => Promise<ApiOrdersListResponse>;
+	paymentToken: Token;
+	allTokens: Token[];
+	networkId: number;
+	partialFailureMessage: (page: number) => string;
+	paginationCapMessage: string;
+	allowPartialResults: boolean;
+	signal?: AbortSignal;
+}
+
+async function collectProcessedOrderPages({
+	fetchPage,
+	paymentToken,
+	allTokens,
+	networkId,
+	partialFailureMessage,
+	paginationCapMessage,
+	allowPartialResults,
+	signal
+}: CollectOrderPagesOptions): Promise<ProcessedQuote[]> {
+	const processedQuotes: ProcessedQuote[] = [];
+	const seen = new Set<string>();
+	let page = 1;
+	let hasMore = true;
+
+	while (hasMore && page <= MAX_ORDER_PAGES) {
+		try {
+			const response = await fetchPage(page);
+			for (const order of response.orders) {
+				const quote = convertApiOrderToProcessedQuote(
+					order,
+					paymentToken.address,
+					allTokens,
+					networkId
+				);
+				if (!quote) continue;
+				const orderKey = `${order.orderbookId.toLowerCase()}:${order.orderHash.toLowerCase()}`;
+				if (seen.has(orderKey)) continue;
+				seen.add(orderKey);
+				processedQuotes.push(quote);
+			}
+			hasMore = response.pagination.hasMore;
+			page++;
+		} catch (error) {
+			if (signal?.aborted || !allowPartialResults || processedQuotes.length === 0) throw error;
+			console.warn(partialFailureMessage(page), error);
+			hasMore = false;
+		}
+	}
+
+	if (hasMore) {
+		if (!allowPartialResults) {
+			throw new Error(paginationCapMessage);
+		}
+		console.warn(paginationCapMessage);
+	}
+
+	return processedQuotes;
+}
+
+export async function fetchAndQuotePaymentTokenOrdersByToken(
 	networkId: number = 8453,
 	overridePaymentToken?: Token,
 	fetchOrders: OrdersByTokenFetcher = apiGetOrdersByToken
@@ -290,6 +355,55 @@ export async function fetchAndQuotePaymentTokenOrders(
 	}
 
 	return processedQuotes;
+}
+
+/**
+ * Fetches all orders for the stock-token catalog through one paginated batch
+ * request stream and converts them to ProcessedQuotes.
+ */
+export async function fetchAndQuotePaymentTokenOrders(
+	networkId: number = 8453,
+	overridePaymentToken?: Token,
+	signal?: AbortSignal,
+	fetchOrders: OrdersQueryFetcher = apiQueryOrders
+): Promise<ProcessedQuote[]> {
+	const { paymentToken, stockTokens, allTokens } = resolveNetworkTokens(
+		networkId,
+		overridePaymentToken
+	);
+	const tokenAddresses = Array.from(
+		new Set(
+			stockTokens
+				.flatMap((token) => [token.address, token.legacyAddress])
+				.filter((address): address is string => Boolean(address))
+				.map((address) => address.toLowerCase())
+		)
+	).sort();
+	if (tokenAddresses.length === 0) return [];
+
+	// Underlying unwrapped assets are not orderbook execution tokens. Query the
+	// current wrapped and legacy tradable addresses only.
+	return collectProcessedOrderPages({
+		fetchPage: (page) =>
+			fetchOrders(
+				{
+					chainId: networkId,
+					tokenAddresses,
+					state: 'active',
+					page,
+					pageSize: 50,
+					denomination: 'wrapped'
+				},
+				signal
+			),
+		paymentToken,
+		allTokens,
+		networkId,
+		partialFailureMessage: (page) => `[orders] Batch page ${page} failed; using partial orderbook:`,
+		paginationCapMessage: `[orders] Hit pagination cap (${MAX_ORDER_PAGES} batch pages)`,
+		allowPartialResults: false,
+		signal
+	});
 }
 
 /**
@@ -347,40 +461,14 @@ export async function fetchAndQuoteTokenOrders(
 ) {
 	const { paymentToken, allTokens } = resolveNetworkTokens(networkId, overridePaymentToken);
 
-	const processedQuotes: ProcessedQuote[] = [];
-	const seen = new Set<string>();
-	let page = 1;
-	let hasMore = true;
-	while (hasMore && page <= MAX_ORDER_PAGES) {
-		try {
-			const response = await apiGetOrdersByToken(tokenAddress, { page, pageSize: 50 });
-			for (const order of response.orders) {
-				if (seen.has(order.orderHash)) continue;
-				seen.add(order.orderHash);
-				const quote = convertApiOrderToProcessedQuote(
-					order,
-					paymentToken.address,
-					allTokens,
-					networkId
-				);
-				if (quote) processedQuotes.push(quote);
-			}
-			hasMore = response.pagination.hasMore;
-			page++;
-		} catch (error) {
-			if (processedQuotes.length === 0) throw error;
-			console.warn(
-				`[orders] Page ${page} fetch failed for token ${tokenAddress}; using partial orderbook:`,
-				error
-			);
-			hasMore = false;
-		}
-	}
-	if (hasMore) {
-		console.warn(
-			`[orders] Hit pagination cap (${MAX_ORDER_PAGES} pages) for token ${tokenAddress}`
-		);
-	}
-
-	return processedQuotes;
+	return collectProcessedOrderPages({
+		fetchPage: (page) => apiGetOrdersByToken(tokenAddress, { page, pageSize: 50 }),
+		paymentToken,
+		allTokens,
+		networkId,
+		partialFailureMessage: (page) =>
+			`[orders] Page ${page} fetch failed for token ${tokenAddress}; using partial orderbook:`,
+		paginationCapMessage: `[orders] Hit pagination cap (${MAX_ORDER_PAGES} pages) for token ${tokenAddress}`,
+		allowPartialResults: true
+	});
 }

--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -138,6 +138,19 @@ export interface ApiOrdersListResponse {
 	pagination: ApiOrdersPagination;
 }
 
+export interface ApiOrdersQueryRequest {
+	chainId: number;
+	tokenAddresses: string[];
+	ownerAddresses?: string[];
+	raindexAddresses?: string[];
+	orderHash?: string;
+	state?: 'active' | 'inactive' | 'all';
+	side?: 'input' | 'output';
+	page?: number;
+	pageSize?: number;
+	denomination?: 'wrapped' | 'unwrapped';
+}
+
 // ============================================================================
 // Trade Types
 // ============================================================================
@@ -416,6 +429,22 @@ export async function apiGetOrdersByToken(
 		state: options?.state
 	});
 	return fetchJson<ApiOrdersListResponse>(url);
+}
+
+/**
+ * Fetch a bounded page of orders matching a token set.
+ */
+export async function apiQueryOrders(
+	request: ApiOrdersQueryRequest,
+	signal?: AbortSignal
+): Promise<ApiOrdersListResponse> {
+	assertBrowser('apiQueryOrders');
+	return fetchJson<ApiOrdersListResponse>(apiUrl('/v1/orders/query'), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(request),
+		signal
+	});
 }
 
 /**

--- a/src/lib/clients/http.test.ts
+++ b/src/lib/clients/http.test.ts
@@ -88,4 +88,36 @@ describe('fetchJson structured errors', () => {
 			publicMessage: 'Bad Gateway'
 		});
 	});
+
+	it('does not retry an aborted request', async () => {
+		const abort = new Error('aborted');
+		abort.name = 'AbortError';
+		const fetchFn = vi.fn().mockRejectedValue(abort);
+		const controller = new AbortController();
+
+		await expect(
+			fetchJson('/api/st0x/v1/orders/query', {
+				fetchFn,
+				signal: controller.signal
+			})
+		).rejects.toBe(abort);
+		expect(fetchFn).toHaveBeenCalledOnce();
+	});
+
+	it('cancels a retry delay before another request is sent', async () => {
+		const controller = new AbortController();
+		const fetchFn = vi.fn().mockImplementation(async () => {
+			controller.abort();
+			return new Response('{}', { status: 502 });
+		});
+
+		await expect(
+			fetchJson('/api/st0x/v1/orders/query', {
+				fetchFn,
+				retryDelayMs: 10_000,
+				signal: controller.signal
+			})
+		).rejects.toMatchObject({ name: 'AbortError' });
+		expect(fetchFn).toHaveBeenCalledOnce();
+	});
 });

--- a/src/lib/clients/http.ts
+++ b/src/lib/clients/http.ts
@@ -62,8 +62,31 @@ export function isRateLimitError(error: unknown): boolean {
 	);
 }
 
-async function delay(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+function abortError(): Error {
+	const error = new Error('The operation was aborted');
+	error.name = 'AbortError';
+	return error;
+}
+
+async function delay(ms: number, signal?: AbortSignal | null): Promise<void> {
+	if (!signal) {
+		await new Promise((resolve) => setTimeout(resolve, ms));
+		return;
+	}
+	if (signal.aborted) throw abortError();
+
+	await new Promise<void>((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timeout);
+			signal.removeEventListener('abort', onAbort);
+			reject(abortError());
+		};
+		const timeout = setTimeout(() => {
+			signal.removeEventListener('abort', onAbort);
+			resolve();
+		}, ms);
+		signal.addEventListener('abort', onAbort, { once: true });
+	});
 }
 
 function parseErrorEnvelope(text: string): ErrorEnvelope | null {
@@ -123,6 +146,7 @@ async function fetchWithRetry<T>(
 	let lastError: unknown;
 
 	while (attempt <= retries) {
+		if (requestInit.signal?.aborted) throw abortError();
 		try {
 			const response = await fetchFn(url, requestInit);
 			const text = await response.text();
@@ -131,7 +155,10 @@ async function fetchWithRetry<T>(
 				// Only retry on selected status codes
 				if (defaultRetryableStatuses.has(response.status) && attempt < retries) {
 					attempt += 1;
-					await delay(retryDelayFor(httpError, retryDelayMs * Math.pow(2, attempt - 1)));
+					await delay(
+						retryDelayFor(httpError, retryDelayMs * Math.pow(2, attempt - 1)),
+						requestInit.signal
+					);
 					continue;
 				}
 				throw httpError;
@@ -143,6 +170,9 @@ async function fetchWithRetry<T>(
 			);
 		} catch (error) {
 			lastError = error;
+			if (requestInit.signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+				throw error;
+			}
 			if (isHttpError(error)) {
 				break;
 			}
@@ -150,7 +180,7 @@ async function fetchWithRetry<T>(
 				break;
 			}
 			attempt += 1;
-			await delay(retryDelayMs * Math.pow(2, attempt - 1));
+			await delay(retryDelayMs * Math.pow(2, attempt - 1), requestInit.signal);
 		}
 	}
 

--- a/src/lib/queries/orderbook.ts
+++ b/src/lib/queries/orderbook.ts
@@ -79,11 +79,11 @@ export function createOrderbookQuotesQuery(
 		// interval already keeps this fresh. Disabled to cut load on the upstream.
 		refetchOnWindowFocus: false,
 		refetchIntervalInBackground: false,
-		queryFn: async () => {
+		queryFn: async ({ signal }) => {
 			if (!network) {
 				return { summary: {}, quotes: [] };
 			}
-			const quotes = await fetchAndQuotePaymentTokenOrders(network.id);
+			const quotes = await fetchAndQuotePaymentTokenOrders(network.id, undefined, signal);
 			const summary = buildSummaryFromQuotes(quotes, network.id);
 			return { summary, quotes };
 		}

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -86,6 +86,7 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 		pattern: /^v1\/orders\/token\/[^/]+$/,
 		cache: 'public, s-maxage=5, stale-while-revalidate=120'
 	},
+	{ method: 'POST', pattern: /^v1\/orders\/query$/ },
 	{
 		method: 'GET',
 		pattern: /^v1\/trades\/token\/[^/]+$/,

--- a/tests/lib/api/orders.test.ts
+++ b/tests/lib/api/orders.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Float } from '@rainlanguage/float';
 import { fetchAndQuotePaymentTokenOrders, fetchAndQuoteTokenOrders } from '$lib/api/orders';
-import { apiGetOrdersByToken, type ApiOrderSummary } from '$lib/api/st0xApi';
+import { HttpError } from '$lib/clients/http';
+import { apiGetOrdersByToken, apiQueryOrders, type ApiOrderSummary } from '$lib/api/st0xApi';
 
 vi.mock('$lib/api/st0xApi', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/st0xApi')>();
 	return {
 		...actual,
-		apiGetOrdersByToken: vi.fn()
+		apiGetOrdersByToken: vi.fn(),
+		apiQueryOrders: vi.fn()
 	};
 });
 
@@ -65,6 +67,11 @@ function mockOrders(orders: ApiOrderSummary[]) {
 	});
 }
 
+beforeEach(() => {
+	vi.mocked(apiGetOrdersByToken).mockReset();
+	vi.mocked(apiQueryOrders).mockReset();
+});
+
 describe('fetchAndQuoteTokenOrders', () => {
 	it('uses REST maxOutput rather than outputVaultBalance', async () => {
 		mockOrders([orderSummary({ maxOutput: '2.5', outputVaultBalance: '100' })]);
@@ -121,32 +128,162 @@ describe('fetchAndQuoteTokenOrders', () => {
 });
 
 describe('fetchAndQuotePaymentTokenOrders', () => {
-	it('propagates REST failures when no usable quotes remain', async () => {
-		vi.mocked(apiGetOrdersByToken).mockReset();
-		vi.mocked(apiGetOrdersByToken).mockRejectedValue(new Error('REST unavailable'));
+	it('queries the normalized wrapped and legacy catalog in one batch request', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [orderSummary()],
+			pagination: { page: 1, pageSize: 50, totalOrders: 1, totalPages: 1, hasMore: false }
+		});
+
+		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
+
+		expect(quotes).toHaveLength(1);
+		expect(apiQueryOrders).toHaveBeenCalledOnce();
+		const request = vi.mocked(apiQueryOrders).mock.calls[0][0];
+		expect(request).toMatchObject({
+			chainId: 8453,
+			state: 'active',
+			page: 1,
+			pageSize: 50,
+			denomination: 'wrapped'
+		});
+		expect(request.tokenAddresses).toContain(stockToken.address.toLowerCase());
+		expect(request.tokenAddresses).toContain('0x2289249984f1fa2ce86c4e8867e7eb819ea7df95');
+		expect(request.tokenAddresses).toEqual([...new Set(request.tokenAddresses)].sort());
+	});
+
+	it('deduplicates overlapping pages by normalized order hash and preserves page order', async () => {
+		vi.mocked(apiQueryOrders)
+			.mockResolvedValueOnce({
+				orders: [orderSummary({ orderHash: '0x-order-a' })],
+				pagination: { page: 1, pageSize: 50, totalOrders: 3, totalPages: 2, hasMore: true }
+			})
+			.mockResolvedValueOnce({
+				orders: [
+					orderSummary({ orderHash: '0X-ORDER-A' }),
+					orderSummary({ orderHash: '0x-order-b' })
+				],
+				pagination: { page: 2, pageSize: 50, totalOrders: 3, totalPages: 2, hasMore: false }
+			});
+
+		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
+
+		expect(quotes.map((quote) => quote.orderHash)).toEqual(['0x-order-a', '0x-order-b']);
+		expect(vi.mocked(apiQueryOrders).mock.calls.map(([request]) => request.page)).toEqual([1, 2]);
+	});
+
+	it('keeps identical hashes from different orderbooks and ignores only usable duplicates', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [
+				orderSummary({
+					orderHash: '0x-shared',
+					orderbookId: '0x-orderbook-a',
+					ioRatio: '-',
+					maxOutput: null
+				}),
+				orderSummary({ orderHash: '0x-shared', orderbookId: '0x-orderbook-a' }),
+				orderSummary({ orderHash: '0X-SHARED', orderbookId: '0x-orderbook-b' })
+			],
+			pagination: { page: 1, pageSize: 50, totalOrders: 3, totalPages: 1, hasMore: false }
+		});
+
+		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
+
+		expect(quotes.map((quote) => quote.orderbookId)).toEqual(['0x-orderbook-a', '0x-orderbook-b']);
+	});
+
+	it('returns an empty book without issuing token-specific requests', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [],
+			pagination: { page: 1, pageSize: 50, totalOrders: 0, totalPages: 0, hasMore: false }
+		});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).resolves.toEqual([]);
+		expect(apiGetOrdersByToken).not.toHaveBeenCalled();
+	});
+
+	it('keeps usable quotes when another batch order has no live quote', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [
+				orderSummary({ orderHash: '0x-usable' }),
+				orderSummary({ orderHash: '0x-unquoted', ioRatio: '-', maxOutput: null })
+			],
+			pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 1, hasMore: false }
+		});
+
+		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
+
+		expect(quotes.map((quote) => quote.orderHash)).toEqual(['0x-usable']);
+	});
+
+	it('propagates a first-page REST failure', async () => {
+		vi.mocked(apiQueryOrders).mockRejectedValueOnce(new Error('REST unavailable'));
 
 		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
 			'REST unavailable'
 		);
 	});
 
-	it('returns quotes from successful tokens when another token request fails', async () => {
-		vi.mocked(apiGetOrdersByToken).mockReset();
-		vi.mocked(apiGetOrdersByToken)
+	it('propagates a 429 without issuing another request', async () => {
+		const rateLimitError = new HttpError({
+			status: 429,
+			code: 'RATE_LIMITED',
+			requestId: 'request-429',
+			publicMessage: 'Too many requests',
+			retryAfter: '5'
+		});
+		vi.mocked(apiQueryOrders).mockRejectedValueOnce(rateLimitError);
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toBe(rateLimitError);
+		expect(apiQueryOrders).toHaveBeenCalledOnce();
+	});
+
+	it('rejects a later-page failure instead of replacing a complete cached book', async () => {
+		vi.mocked(apiQueryOrders)
 			.mockResolvedValueOnce({
 				orders: [orderSummary()],
-				pagination: { page: 1, pageSize: 50, totalOrders: 1, totalPages: 1, hasMore: false }
+				pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: true }
 			})
-			.mockRejectedValue(new Error('token unavailable'));
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+			.mockRejectedValueOnce(new Error('page 2 unavailable'));
 
-		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
-
-		expect(quotes).toHaveLength(1);
-		expect(warn).toHaveBeenCalledWith(
-			'[orders] Token fetch failed; using partial orderbook:',
-			expect.any(Error)
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'page 2 unavailable'
 		);
-		warn.mockRestore();
+	});
+
+	it('rejects a batch response that exceeds the safety page cap', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValue({
+			orders: [orderSummary()],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalOrders: 5_001,
+				totalPages: 101,
+				hasMore: true
+			}
+		});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'Hit pagination cap'
+		);
+		expect(apiQueryOrders).toHaveBeenCalledTimes(100);
+	});
+
+	it('propagates cancellation instead of returning earlier pages as complete', async () => {
+		const controller = new AbortController();
+		const abortError = new DOMException('Aborted', 'AbortError');
+		vi.mocked(apiQueryOrders)
+			.mockResolvedValueOnce({
+				orders: [orderSummary()],
+				pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: true }
+			})
+			.mockImplementationOnce(async () => {
+				controller.abort();
+				throw abortError;
+			});
+
+		await expect(
+			fetchAndQuotePaymentTokenOrders(8453, paymentToken, controller.signal)
+		).rejects.toBe(abortError);
+		expect(vi.mocked(apiQueryOrders).mock.calls[1][1]).toBe(controller.signal);
 	});
 });

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -87,6 +87,45 @@ describe('/api/st0x proxy', () => {
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
+	it('allows POST /v1/orders/query without unsafe URI-only shared caching', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					orders: [],
+					pagination: {
+						page: 1,
+						pageSize: 50,
+						totalOrders: 0,
+						totalPages: 0,
+						hasMore: false
+					}
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const body = JSON.stringify({
+			chainId: 8453,
+			tokenAddresses: ['0xToken'],
+			page: 1,
+			pageSize: 50
+		});
+
+		const response = await POST(proxyEvent('POST', 'v1/orders/query', body));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/orders/query?page=1',
+			expect.objectContaining({ method: 'POST' })
+		);
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(await new Response(init.body).text()).toBe(body);
+	});
+
 	it('allows POST /v1/swap/calldata without caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ to: '0xOrderbook', data: '0x', value: '0', approvals: [] }), {

--- a/tests/lib/api/st0xApi.test.ts
+++ b/tests/lib/api/st0xApi.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiGetSwapCalldataV2, apiGetSwapQuoteV2 } from '$lib/api/st0xApi';
+import { apiGetSwapCalldataV2, apiGetSwapQuoteV2, apiQueryOrders } from '$lib/api/st0xApi';
 
 describe('st0x API client', () => {
 	beforeEach(() => {
@@ -88,6 +88,45 @@ describe('st0x API client', () => {
 			expect.objectContaining({
 				method: 'POST',
 				body: JSON.stringify(request)
+			})
+		);
+	});
+
+	it('posts the API-owned batch request to the proxy', async () => {
+		const response = {
+			orders: [],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalOrders: 0,
+				totalPages: 0,
+				hasMore: false
+			}
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(response), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const request = {
+			chainId: 8453,
+			tokenAddresses: ['0xabc'],
+			state: 'active' as const,
+			page: 1,
+			pageSize: 50,
+			denomination: 'wrapped' as const
+		};
+		const signal = new AbortController().signal;
+
+		await expect(apiQueryOrders(request, signal)).resolves.toEqual(response);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/st0x/v1/orders/query',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify(request),
+				signal
 			})
 		);
 	});


### PR DESCRIPTION
## Depends on

- REST batch-order API and incomplete-quote fallback: https://github.com/ST0x-Technology/st0x.rest.api/pull/166

## Motivation

Global orderbook consumers, including Platform Metrics, fetched each stock token through a separate REST request stream. That fanout amplified latency and pressure on the shared API rate-limit budget.

## Solution

- Add an API-owned website DTO and client for `POST /v1/orders/query`.
- Query the normalized wrapped and legacy execution-token catalog through one bounded batch pagination stream per network.
- Keep one TanStack orderbook cache entry per network and propagate cancellation through HTTP retries and retry delays.
- Preserve executable quote conversion, payment-token matching, and the existing token-specific routes used by trade pages.
- Deduplicate usable orders by normalized Raindex/orderbook ID plus order hash so overlapping pages cannot duplicate liquidity and identical hashes from distinct orderbooks remain distinct.
- Reject incomplete batch snapshots on page failure or pagination-cap exhaustion so TanStack keeps the last complete orderbook.
- Allow the batch POST through the server-only authenticated proxy without adding unsafe shared URI-only caching. Canonical body-aware caching and stampede protection remain in the REST API; the browser retains the result in TanStack.
- Keep the recurring public-prices migration explicitly deferred to the cache-isolation stack branch (RAI-1563).

## Validation

- [x] `nix develop -c npm test -- --run` — 76 files passed; 833 tests passed, 1 skipped
- [x] `nix develop -c npm run svelte-lint-format-check` — Svelte check, ESLint, and Prettier clean
- [x] `nix develop -c npm run test:integration` — integration suite loaded successfully; the single Anvil-fork test skipped because local fork credentials were not configured
- [x] `nix develop -c git diff --check`
- [x] Two-pass staged local review — final pass found no actionable issues
- [x] Bruno against the local REST service — `POST /v1/orders/query` returned 200 with no duplicate hashes
- [x] Manual in-app browser smoke test with both services local — Platform Metrics rendered live values through `/api/st0x/v1/orders/query`

The local live dataset required two request pages because the stable REST contract caps order pages at 50. This remains one sequential batch stream for the network, replacing the former per-token fanout.

Fixes RAI-1564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster batch querying for active orders across supported payment tokens.
  * Added pagination, duplicate removal, and partial-result handling for order quotes.
  * Added cancellation support for order searches and retry operations.
  * Enabled the orders query API through the application proxy.

* **Bug Fixes**
  * Prevented cancelled requests from being retried.
  * Improved handling of overlapping or unusable order results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->