### PR TITLE
feat(trades): use REST batch queries for public activity

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -222,6 +222,32 @@ export interface ApiTradesBatchResponse {
 	totalCount: number;
 }
 
+export interface ApiTradesOrderHashesQueryRequest {
+	orderHashes: string[];
+	tokenAddresses?: string[];
+	chainId?: number;
+	startTime?: number;
+	endTime?: number;
+	denomination?: 'wrapped' | 'unwrapped';
+	page?: never;
+	pageSize?: never;
+}
+
+export interface ApiTradesTokensQueryRequest {
+	orderHashes?: never;
+	tokenAddresses: string[];
+	chainId: number;
+	startTime: number;
+	endTime: number;
+	page?: number;
+	pageSize?: number;
+	denomination?: 'wrapped' | 'unwrapped';
+}
+
+export type ApiTradesQueryRequest = ApiTradesOrderHashesQueryRequest | ApiTradesTokensQueryRequest;
+
+export type ApiTradesQueryResponse = ApiTradesBatchResponse | ApiTradesByAddressResponse;
+
 // ============================================================================
 // Token Proof Types
 // ============================================================================
@@ -629,16 +655,40 @@ export async function apiGetOrdersByOwner(
 }
 
 /**
+ * Fetch trades through the REST batch query. The overloads preserve the legacy
+ * grouped order-hash response while exposing the paginated token-set mode.
+ */
+export function apiQueryTrades(
+	request: ApiTradesOrderHashesQueryRequest,
+	signal?: AbortSignal
+): Promise<ApiTradesBatchResponse>;
+export function apiQueryTrades(
+	request: ApiTradesTokensQueryRequest,
+	signal?: AbortSignal
+): Promise<ApiTradesByAddressResponse>;
+export function apiQueryTrades(
+	request: ApiTradesQueryRequest,
+	signal?: AbortSignal
+): Promise<ApiTradesQueryResponse>;
+export async function apiQueryTrades(
+	request: ApiTradesQueryRequest,
+	signal?: AbortSignal
+): Promise<ApiTradesQueryResponse> {
+	assertBrowser('apiQueryTrades');
+	return fetchJson<ApiTradesQueryResponse>(apiUrl('/v1/trades/query'), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(request),
+		signal
+	});
+}
+
+/**
  * Fetch trades for multiple orders in a single query request.
  * Used to compute filled amounts for a user's deployed orders.
  */
 export async function apiGetTradesBatch(orderHashes: string[]): Promise<ApiTradesBatchResponse> {
-	assertBrowser('apiGetTradesBatch');
-	return fetchJson<ApiTradesBatchResponse>(apiUrl('/v1/trades/query'), {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ orderHashes })
-	});
+	return apiQueryTrades({ orderHashes });
 }
 
 /**

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -63,7 +63,7 @@ const computeLocks = new Map<string, Promise<unknown>>();
 export async function withCache<T>(
 	key: string,
 	fn: () => Promise<T>,
-	ttlSeconds = DEFAULT_TTL_SECONDS
+	ttlSeconds: number | ((value: T) => number) = DEFAULT_TTL_SECONDS
 ): Promise<T> {
 	// Try to get from cache first (cache failures are non-fatal)
 	try {
@@ -85,11 +85,14 @@ export async function withCache<T>(
 	const computePromise = (async () => {
 		try {
 			const result = await fn();
+			const resolvedTtlSeconds = typeof ttlSeconds === 'function' ? ttlSeconds(result) : ttlSeconds;
 			// Cache set failure is non-fatal - just log and continue
-			try {
-				await cacheSet(key, result, ttlSeconds);
-			} catch (cacheError) {
-				console.warn('[Cache] Set failed:', cacheError);
+			if (resolvedTtlSeconds > 0) {
+				try {
+					await cacheSet(key, result, resolvedTtlSeconds);
+				} catch (cacheError) {
+					console.warn('[Cache] Set failed:', cacheError);
+				}
 			}
 			return result;
 		} finally {

--- a/src/lib/server/publicTradeActivity.test.ts
+++ b/src/lib/server/publicTradeActivity.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiTradeByAddress } from '$lib/api/st0xApi';
+import { networks } from '$lib/config/network';
+import { getAllTokensByNetwork } from '$lib/config/tokens';
+import {
+	computePublicTradeActivity,
+	fetchNetworkTrades,
+	tradeActivityWindow
+} from '$lib/server/publicTradeActivity';
+
+function fixtureContext() {
+	const network = networks.find((candidate) => candidate.defaultPaymentToken?.address);
+	if (!network?.defaultPaymentToken) throw new Error('Expected a configured payment-token network');
+	const asset = getAllTokensByNetwork(network.chainId)[0];
+	if (!asset) throw new Error('Expected a configured stock token');
+	return { network, asset, quote: network.defaultPaymentToken };
+}
+
+function trade(
+	txHash: string,
+	inputAddress: string,
+	outputAddress: string,
+	inputAmount: string,
+	outputAmount: string
+): ApiTradeByAddress {
+	return {
+		txHash,
+		inputAmount,
+		outputAmount,
+		inputToken: { address: inputAddress, symbol: 'IN', decimals: 18 },
+		outputToken: { address: outputAddress, symbol: 'OUT', decimals: 6 },
+		orderHash: null,
+		timestamp: 1_000,
+		blockNumber: 1
+	};
+}
+
+describe('public trade activity', () => {
+	it('uses deterministic five-minute time windows', () => {
+		expect(tradeActivityWindow(1_000_500)).toEqual(tradeActivityWindow(1_000_799));
+		expect(tradeActivityWindow(1_000_800)).not.toEqual(tradeActivityWindow(1_000_799));
+	});
+
+	it('collects one sequential token-set pagination stream per network', async () => {
+		const { network } = fixtureContext();
+		const firstTrade = trade('0x1', '0x1', '0x2', '1', '2');
+		const secondTrade = trade('0x2', '0x2', '0x3', '2', '3');
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce({
+				trades: [firstTrade],
+				pagination: {
+					page: 1,
+					pageSize: 50,
+					totalTrades: 2,
+					totalPages: 2,
+					hasMore: true
+				}
+			})
+			.mockResolvedValueOnce({
+				trades: [secondTrade],
+				pagination: {
+					page: 2,
+					pageSize: 50,
+					totalTrades: 2,
+					totalPages: 2,
+					hasMore: false
+				}
+			});
+		const range = { from: 1_000, to: 2_000 };
+
+		await expect(fetchNetworkTrades(network, range, fetchPage)).resolves.toEqual([
+			firstTrade,
+			secondTrade
+		]);
+		expect(fetchPage).toHaveBeenCalledTimes(2);
+		const firstRequest = fetchPage.mock.calls[0][0];
+		const secondRequest = fetchPage.mock.calls[1][0];
+		expect(firstRequest).toEqual(
+			expect.objectContaining({
+				chainId: network.chainId,
+				startTime: range.from,
+				endTime: range.to,
+				page: 1,
+				pageSize: 50,
+				denomination: 'wrapped'
+			})
+		);
+		expect(secondRequest).toEqual(expect.objectContaining({ page: 2 }));
+		expect(firstRequest.tokenAddresses.length).toBeGreaterThan(0);
+		expect(firstRequest.tokenAddresses).toEqual([...new Set(firstRequest.tokenAddresses)].sort());
+		expect(firstRequest.tokenAddresses).not.toContain(
+			network.defaultPaymentToken?.address.toLowerCase()
+		);
+		expect(secondRequest.tokenAddresses).toEqual(firstRequest.tokenAddresses);
+	});
+
+	it('returns an empty complete page without further requests', async () => {
+		const { network } = fixtureContext();
+		const fetchPage = vi.fn().mockResolvedValue({
+			trades: [],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalTrades: 0,
+				totalPages: 0,
+				hasMore: false
+			}
+		});
+
+		await expect(
+			fetchNetworkTrades(network, { from: 1_000, to: 2_000 }, fetchPage)
+		).resolves.toEqual([]);
+		expect(fetchPage).toHaveBeenCalledOnce();
+	});
+
+	it('rejects the whole snapshot when a later page fails', async () => {
+		const { network } = fixtureContext();
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce({
+				trades: [trade('0x1', '0x1', '0x2', '1', '2')],
+				pagination: {
+					page: 1,
+					pageSize: 50,
+					totalTrades: 51,
+					totalPages: 2,
+					hasMore: true
+				}
+			})
+			.mockRejectedValueOnce(new Error('upstream failed'));
+
+		await expect(
+			fetchNetworkTrades(network, { from: 1_000, to: 2_000 }, fetchPage)
+		).rejects.toThrow('upstream failed');
+	});
+
+	it('preserves the public aggregate contract for batch trades', async () => {
+		const { network, asset, quote } = fixtureContext();
+		const response = {
+			trades: [trade('0x1', asset.address, quote.address, '2', '100')],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalTrades: 1,
+				totalPages: 1,
+				hasMore: false
+			}
+		};
+		const fetchPage = vi.fn().mockResolvedValue(response);
+
+		const result = await computePublicTradeActivity(fetchPage, 1_000_500, [network]);
+
+		expect(result.success).toBe(true);
+		expect(result.range).toEqual(tradeActivityWindow(1_000_500));
+		expect(result.totals).toEqual({ tradingVolume: 100, totalTrades: 1 });
+		expect(result.networks).toHaveLength(1);
+		expect(result.networks[0]).toEqual(
+			expect.objectContaining({
+				chainId: network.chainId,
+				networkId: network.id,
+				tradingVolume: 100,
+				totalTrades: 1
+			})
+		);
+		expect(
+			result.networks[0].tokens.find((row) => row.address === asset.address.toLowerCase())
+		).toEqual(
+			expect.objectContaining({
+				inVolume: 2,
+				outVolume: 0,
+				totalVolume: 2,
+				quoteVolume: 100,
+				trades: 1
+			})
+		);
+	});
+});

--- a/src/lib/server/publicTradeActivity.ts
+++ b/src/lib/server/publicTradeActivity.ts
@@ -1,0 +1,232 @@
+import type { ApiTradeByAddress } from '$lib/api/st0xApi';
+import type { Network } from '$lib/config/network';
+import { networks } from '$lib/config/network';
+import { getAllTokensByNetwork } from '$lib/config/tokens';
+import type { ServerTradesQueryFetcher } from '$lib/server/st0xTradesFetcher';
+import { normalizeAddress } from '$lib/utils/tokenMath';
+import { bucketTimestamp, TRADE_WINDOW_BUCKET_SECONDS } from '$lib/utils/timeWindow';
+
+const WINDOW_SECONDS = 30 * 24 * 60 * 60;
+const PAGE_SIZE = 50;
+const MAX_PAGES = 1_000;
+
+export interface TokenTradingRow {
+	address: string;
+	symbol?: string;
+	name?: string;
+	logoUrl?: string;
+	inVolume: number;
+	outVolume: number;
+	totalVolume: number;
+	quoteVolume: number;
+	trades: number;
+}
+
+export interface NetworkTradeStats {
+	chainId: number;
+	networkId: number;
+	tradingVolume: number;
+	totalTrades: number;
+	tokens: TokenTradingRow[];
+}
+
+interface PublicTradeActivityBase {
+	range: { from: number; to: number };
+	totals: {
+		tradingVolume: number;
+		totalTrades: number;
+	};
+	networks: NetworkTradeStats[];
+}
+
+export interface PublicTradeActivitySnapshot extends PublicTradeActivityBase {
+	success: true;
+}
+
+export interface PublicTradeActivityFailure extends PublicTradeActivityBase {
+	success: false;
+}
+
+export type PublicTradeActivityResponse = PublicTradeActivitySnapshot | PublicTradeActivityFailure;
+
+type AnalyzedApiTrade = {
+	txHash: string;
+	assetAddress: string;
+	side: 'bid' | 'ask';
+	tokens: number;
+	quote: number;
+};
+
+export function tradeActivityWindow(epochSeconds: number): { from: number; to: number } {
+	const to = bucketTimestamp(epochSeconds, TRADE_WINDOW_BUCKET_SECONDS);
+	return { from: to - WINDOW_SECONDS, to };
+}
+
+function networkTokenAddresses(network: Network): string[] {
+	const paymentTokenAddress = normalizeAddress(network.defaultPaymentToken?.address ?? '');
+	return Array.from(
+		new Set(
+			getAllTokensByNetwork(network.chainId)
+				.map((token) => normalizeAddress(token.address))
+				.filter((address): address is string => Boolean(address))
+				.filter((address) => address !== paymentTokenAddress)
+		)
+	).sort();
+}
+
+export async function fetchNetworkTrades(
+	network: Network,
+	range: { from: number; to: number },
+	fetchPage: ServerTradesQueryFetcher
+): Promise<ApiTradeByAddress[]> {
+	const tokenAddresses = networkTokenAddresses(network);
+	if (tokenAddresses.length === 0) return [];
+
+	const trades: ApiTradeByAddress[] = [];
+	let page = 1;
+	let hasMore = true;
+	while (hasMore && page <= MAX_PAGES) {
+		const response = await fetchPage({
+			chainId: network.chainId,
+			tokenAddresses,
+			startTime: range.from,
+			endTime: range.to,
+			page,
+			pageSize: PAGE_SIZE,
+			denomination: 'wrapped'
+		});
+		trades.push(...response.trades);
+		hasMore = response.pagination.hasMore;
+		page++;
+	}
+	if (hasMore) {
+		throw new Error(`Batch trades pagination exceeded ${MAX_PAGES} pages`);
+	}
+	return trades;
+}
+
+export function analyzeApiTrades(
+	trades: ApiTradeByAddress[],
+	quoteTokenAddress: string
+): AnalyzedApiTrade[] {
+	const quoteAddr = normalizeAddress(quoteTokenAddress);
+	if (!quoteAddr) return [];
+
+	const analyzed: AnalyzedApiTrade[] = [];
+	for (const trade of trades) {
+		const inputAddr = normalizeAddress(trade.inputToken.address);
+		const outputAddr = normalizeAddress(trade.outputToken.address);
+		if (!inputAddr || !outputAddr) continue;
+
+		const inputAmount = Math.abs(Number.parseFloat(trade.inputAmount));
+		const outputAmount = Math.abs(Number.parseFloat(trade.outputAmount));
+		if (!Number.isFinite(inputAmount) || !Number.isFinite(outputAmount)) continue;
+		if (inputAmount <= 0 || outputAmount <= 0) continue;
+
+		if (inputAddr === quoteAddr) {
+			analyzed.push({
+				txHash: trade.txHash,
+				assetAddress: outputAddr,
+				side: 'ask',
+				tokens: outputAmount,
+				quote: inputAmount
+			});
+		} else if (outputAddr === quoteAddr) {
+			analyzed.push({
+				txHash: trade.txHash,
+				assetAddress: inputAddr,
+				side: 'bid',
+				tokens: inputAmount,
+				quote: outputAmount
+			});
+		}
+	}
+	return analyzed;
+}
+
+export function aggregateNetwork(
+	network: Network,
+	analyzed: AnalyzedApiTrade[]
+): NetworkTradeStats {
+	const networkTokens = getAllTokensByNetwork(network.chainId);
+	const seenTx = new Set<string>();
+	let tradingVolume = 0;
+
+	type TokenTradingAccumulator = Omit<TokenTradingRow, 'trades'> & {
+		transactions: Set<string>;
+	};
+	const rows = new Map<string, TokenTradingAccumulator>();
+	for (const token of networkTokens) {
+		const address = normalizeAddress(token.address);
+		if (!address) continue;
+		rows.set(address, {
+			address,
+			symbol: token.symbol,
+			name: token.name,
+			logoUrl: token.logoUrl,
+			inVolume: 0,
+			outVolume: 0,
+			totalVolume: 0,
+			quoteVolume: 0,
+			transactions: new Set<string>()
+		});
+	}
+
+	for (const entry of analyzed) {
+		const address = normalizeAddress(entry.assetAddress);
+		if (!address) continue;
+		const row = rows.get(address);
+		if (!row) continue;
+
+		const isNewTx = !entry.txHash || !seenTx.has(entry.txHash);
+		if (entry.txHash) seenTx.add(entry.txHash);
+		if (isNewTx) tradingVolume += entry.quote;
+
+		if (entry.side === 'bid') row.inVolume += entry.tokens;
+		else row.outVolume += entry.tokens;
+		row.totalVolume += entry.tokens;
+
+		if (entry.txHash && !row.transactions.has(entry.txHash)) {
+			row.transactions.add(entry.txHash);
+			row.quoteVolume += entry.quote;
+		}
+	}
+
+	const tokens = Array.from(rows.values())
+		.map(({ transactions, ...row }) => ({ ...row, trades: transactions.size }))
+		.sort((a, b) => b.trades - a.trades || a.address.localeCompare(b.address));
+
+	return {
+		chainId: network.chainId,
+		networkId: network.id,
+		tradingVolume,
+		totalTrades: seenTx.size,
+		tokens
+	};
+}
+
+export async function computePublicTradeActivity(
+	fetchPage: ServerTradesQueryFetcher,
+	epochSeconds = Math.floor(Date.now() / 1000),
+	configuredNetworks: Network[] = networks
+): Promise<PublicTradeActivitySnapshot> {
+	const range = tradeActivityWindow(epochSeconds);
+	const perNetwork = await Promise.all(
+		configuredNetworks.map(async (network) => {
+			const trades = await fetchNetworkTrades(network, range, fetchPage);
+			const quoteTokenAddress = network.defaultPaymentToken?.address;
+			if (!quoteTokenAddress) return aggregateNetwork(network, []);
+			return aggregateNetwork(network, analyzeApiTrades(trades, quoteTokenAddress));
+		})
+	);
+
+	return {
+		success: true,
+		range,
+		totals: {
+			tradingVolume: perNetwork.reduce((sum, network) => sum + network.tradingVolume, 0),
+			totalTrades: perNetwork.reduce((sum, network) => sum + network.totalTrades, 0)
+		},
+		networks: perNetwork
+	};
+}

--- a/src/lib/server/publicTradeActivityCache.test.ts
+++ b/src/lib/server/publicTradeActivityCache.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getKvMock } = vi.hoisted(() => ({
+	getKvMock: vi.fn()
+}));
+
+vi.mock('$lib/server/kv', () => ({
+	getKv: getKvMock
+}));
+
+import {
+	clearPublicTradeActivityMemoryCache,
+	getCachedPublicTradeActivity,
+	publicTradeActivityCacheControl
+} from '$lib/server/publicTradeActivityCache';
+import type { PublicTradeActivitySnapshot } from '$lib/server/publicTradeActivity';
+
+function snapshot(
+	totalTrades = 0,
+	to = Math.floor(Date.now() / 1_000)
+): PublicTradeActivitySnapshot {
+	return {
+		success: true,
+		range: { from: to - 30 * 24 * 60 * 60, to },
+		totals: { tradingVolume: 0, totalTrades },
+		networks: []
+	};
+}
+
+describe('public trade activity cache', () => {
+	beforeEach(() => {
+		clearPublicTradeActivityMemoryCache();
+		vi.useRealTimers();
+		getKvMock.mockReset();
+		getKvMock.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces concurrent cold computations', async () => {
+		let resolveCompute: ((value: PublicTradeActivitySnapshot) => void) | undefined;
+		const compute = vi.fn(
+			() =>
+				new Promise<PublicTradeActivitySnapshot>((resolve) => {
+					resolveCompute = resolve;
+				})
+		);
+		const first = getCachedPublicTradeActivity(compute);
+		const second = getCachedPublicTradeActivity(compute);
+
+		await vi.waitFor(() => expect(compute).toHaveBeenCalledOnce());
+		const complete = snapshot();
+		resolveCompute?.(complete);
+		await expect(Promise.all([first, second])).resolves.toEqual([complete, complete]);
+	});
+
+	it('reuses a complete response during the fresh window without Redis', async () => {
+		const compute = vi.fn(async () => snapshot());
+
+		await getCachedPublicTradeActivity(compute);
+		await getCachedPublicTradeActivity(compute);
+
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('anchors the primary Redis TTL to the snapshot window', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T01:00:00Z'));
+		const set = vi.fn();
+		getKvMock.mockResolvedValue({ get: vi.fn(async () => null), set, del: vi.fn() });
+		const complete = snapshot(2, Math.floor(Date.now() / 1_000) - 120);
+
+		await getCachedPublicTradeActivity(async () => complete);
+
+		expect(set).toHaveBeenCalledWith('cache:public:trade-activity', JSON.stringify(complete), {
+			EX: 3_480
+		});
+	});
+
+	it('serves the last complete response when a refresh fails', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		const complete = snapshot(2);
+		await getCachedPublicTradeActivity(async () => complete);
+		vi.advanceTimersByTime(60 * 60 * 1_000 + 1);
+
+		await expect(
+			getCachedPublicTradeActivity(async () => {
+				throw new Error('upstream failed');
+			})
+		).resolves.toEqual(complete);
+	});
+
+	it('memoizes a cold Redis stale hit for a bounded retry window', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T01:00:01Z'));
+		const retained = snapshot(2, Math.floor(Date.now() / 1_000) - 60 * 60 - 1);
+		const get = vi.fn(async (key: string) =>
+			key.endsWith(':stale') ? JSON.stringify(retained) : null
+		);
+		getKvMock.mockResolvedValue({ get, set: vi.fn(), del: vi.fn() });
+		const compute = vi.fn(async () => {
+			throw new Error('upstream failed');
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).resolves.toEqual(retained);
+		await expect(getCachedPublicTradeActivity(compute)).resolves.toEqual(retained);
+
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('does not serve in-memory stale data beyond its retained TTL', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		await getCachedPublicTradeActivity(async () => snapshot());
+		vi.advanceTimersByTime(6 * 60 * 60 * 1_000 + 1);
+
+		await expect(
+			getCachedPublicTradeActivity(async () => {
+				throw new Error('upstream failed');
+			})
+		).rejects.toThrow('upstream failed');
+	});
+
+	it('bounds shared HTTP caching by the snapshot stale horizon', () => {
+		const to = 10_000;
+
+		expect(publicTradeActivityCacheControl(snapshot(0, to), to)).toBe(
+			'public, s-maxage=3600, stale-while-revalidate=18000'
+		);
+		expect(publicTradeActivityCacheControl(snapshot(0, to), to + 3_601)).toBe(
+			'public, s-maxage=60, must-revalidate'
+		);
+		expect(publicTradeActivityCacheControl(snapshot(0, to), to + 21_601)).toBe('no-store');
+	});
+});

--- a/src/lib/server/publicTradeActivityCache.ts
+++ b/src/lib/server/publicTradeActivityCache.ts
@@ -1,0 +1,103 @@
+import type { PublicTradeActivitySnapshot } from '$lib/server/publicTradeActivity';
+import { cacheGet, cacheSet, CACHE_KEYS, CACHE_TTL, withCache } from '$lib/server/cache';
+
+const STALE_TTL_SECONDS = CACHE_TTL.VERY_LONG;
+const STALE_RETRY_SECONDS = 60;
+const staleCacheKey = () => `${CACHE_KEYS.publicTradeActivity()}:stale`;
+
+interface MemoryEntry {
+	value: PublicTradeActivitySnapshot;
+	reuseUntil: number;
+	staleUntil: number;
+}
+
+let memoryEntry: MemoryEntry | null = null;
+
+function snapshotExpiresAt(snapshot: PublicTradeActivitySnapshot, ttlSeconds: number): number {
+	return snapshot.range.to * 1_000 + ttlSeconds * 1_000;
+}
+
+function snapshotTtlSeconds(snapshot: PublicTradeActivitySnapshot, ttlSeconds: number): number {
+	return Math.floor((snapshotExpiresAt(snapshot, ttlSeconds) - Date.now()) / 1_000);
+}
+
+function retainForRetry(
+	value: PublicTradeActivitySnapshot,
+	now: number,
+	staleUntil: number
+): PublicTradeActivitySnapshot {
+	memoryEntry = {
+		value,
+		reuseUntil: Math.min(now + STALE_RETRY_SECONDS * 1_000, staleUntil),
+		staleUntil
+	};
+	return value;
+}
+
+export function publicTradeActivityCacheControl(
+	snapshot: PublicTradeActivitySnapshot,
+	epochSeconds = Math.floor(Date.now() / 1_000)
+): string {
+	const age = Math.max(0, epochSeconds - snapshot.range.to);
+	const staleRemaining = STALE_TTL_SECONDS - age;
+	if (staleRemaining <= 0) return 'no-store';
+
+	const freshRemaining = CACHE_TTL.LONG - age;
+	if (freshRemaining > 0) {
+		const sharedTtl = Math.max(1, Math.floor(freshRemaining));
+		const staleWhileRevalidate = Math.max(0, Math.floor(staleRemaining) - sharedTtl);
+		return `public, s-maxage=${sharedTtl}, stale-while-revalidate=${staleWhileRevalidate}`;
+	}
+
+	const retryTtl = Math.max(1, Math.min(STALE_RETRY_SECONDS, Math.floor(staleRemaining)));
+	return `public, s-maxage=${retryTtl}, must-revalidate`;
+}
+
+/**
+ * Return a fresh cached activity snapshot, or the last complete retained
+ * snapshot when a refresh fails. Failed and partial computations are never
+ * written as fresh or stale cache entries.
+ */
+export async function getCachedPublicTradeActivity(
+	compute: () => Promise<PublicTradeActivitySnapshot>
+): Promise<PublicTradeActivitySnapshot> {
+	const now = Date.now();
+	if (memoryEntry && memoryEntry.reuseUntil > now) {
+		return memoryEntry.value;
+	}
+
+	try {
+		const value = await withCache(CACHE_KEYS.publicTradeActivity(), compute, (snapshot) =>
+			snapshotTtlSeconds(snapshot, CACHE_TTL.LONG)
+		);
+		const staleUntil = snapshotExpiresAt(value, STALE_TTL_SECONDS);
+		const retainedTtl = snapshotTtlSeconds(value, STALE_TTL_SECONDS);
+		memoryEntry = {
+			value,
+			reuseUntil: snapshotExpiresAt(value, CACHE_TTL.LONG),
+			staleUntil
+		};
+		if (retainedTtl > 0) {
+			await cacheSet(staleCacheKey(), value, retainedTtl);
+		}
+		return value;
+	} catch (error) {
+		const failedAt = Date.now();
+		if (memoryEntry && memoryEntry.staleUntil > failedAt) {
+			return retainForRetry(memoryEntry.value, failedAt, memoryEntry.staleUntil);
+		}
+		memoryEntry = null;
+		const retained = await cacheGet<PublicTradeActivitySnapshot>(staleCacheKey());
+		if (retained !== null) {
+			const staleUntil = snapshotExpiresAt(retained, STALE_TTL_SECONDS);
+			if (staleUntil > failedAt) {
+				return retainForRetry(retained, failedAt, staleUntil);
+			}
+		}
+		throw error;
+	}
+}
+
+export function clearPublicTradeActivityMemoryCache(): void {
+	memoryEntry = null;
+}

--- a/src/lib/server/st0xTradesFetcher.test.ts
+++ b/src/lib/server/st0xTradesFetcher.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createServerTradesQueryFetcher } from '$lib/server/st0xTradesFetcher';
+
+describe('createServerTradesQueryFetcher', () => {
+	it('posts an authenticated token-set query', async () => {
+		const responseBody = {
+			trades: [],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalTrades: 0,
+				totalPages: 0,
+				hasMore: false
+			}
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(responseBody), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		const fetchTrades = createServerTradesQueryFetcher({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic credentials',
+			fetchFn: fetchMock as unknown as typeof fetch
+		});
+		const request = {
+			chainId: 8453,
+			tokenAddresses: ['0xabc'],
+			startTime: 1_000,
+			endTime: 2_000,
+			page: 1,
+			pageSize: 50
+		};
+
+		await expect(fetchTrades(request)).resolves.toEqual(responseBody);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/trades/query',
+			expect.objectContaining({
+				method: 'POST',
+				headers: {
+					Authorization: 'Basic credentials',
+					Accept: 'application/json',
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(request),
+				signal: expect.any(AbortSignal)
+			})
+		);
+	});
+
+	it('rejects an unsuccessful page instead of returning partial data', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('failed', { status: 502 }));
+		const fetchTrades = createServerTradesQueryFetcher({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic credentials',
+			fetchFn: fetchMock as unknown as typeof fetch
+		});
+
+		await expect(
+			fetchTrades({
+				chainId: 8453,
+				tokenAddresses: ['0xabc'],
+				startTime: 1_000,
+				endTime: 2_000
+			})
+		).rejects.toThrow('Batch trades fetch failed (502)');
+	});
+});

--- a/src/lib/server/st0xTradesFetcher.ts
+++ b/src/lib/server/st0xTradesFetcher.ts
@@ -1,0 +1,36 @@
+import type { ApiTradesByAddressResponse, ApiTradesTokensQueryRequest } from '$lib/api/st0xApi';
+
+export type ServerTradesQueryFetcher = (
+	request: ApiTradesTokensQueryRequest
+) => Promise<ApiTradesByAddressResponse>;
+
+interface ServerTradesFetcherOptions {
+	apiBase: string;
+	authHeader: string;
+	fetchFn?: typeof fetch;
+	timeoutMs?: number;
+}
+
+export function createServerTradesQueryFetcher({
+	apiBase,
+	authHeader,
+	fetchFn = fetch,
+	timeoutMs = 15_000
+}: ServerTradesFetcherOptions): ServerTradesQueryFetcher {
+	return async (request) => {
+		const response = await fetchFn(`${apiBase}/v1/trades/query`, {
+			method: 'POST',
+			headers: {
+				Authorization: authHeader,
+				Accept: 'application/json',
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify(request),
+			signal: AbortSignal.timeout(timeoutMs)
+		});
+		if (!response.ok) {
+			throw new Error(`Batch trades fetch failed (${response.status})`);
+		}
+		return (await response.json()) as ApiTradesByAddressResponse;
+	};
+}

--- a/src/routes/api/public/trade-activity/+server.ts
+++ b/src/routes/api/public/trade-activity/+server.ts
@@ -1,300 +1,41 @@
-// Public API endpoint for aggregated 30-day trade activity across all networks.
-// Pre-computes per-network totals and per-token breakdowns server-side so the
-// platform-metrics page can render from a single cached response instead of
-// 5k+ trades of client-side aggregation.
-//
-// Fetches from the st0x REST API per-token, then aggregates server-side.
+import { env } from '$env/dynamic/private';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { env } from '$env/dynamic/private';
+import {
+	computePublicTradeActivity,
+	type PublicTradeActivityResponse,
+	type PublicTradeActivitySnapshot,
+	tradeActivityWindow
+} from '$lib/server/publicTradeActivity';
+import {
+	getCachedPublicTradeActivity,
+	publicTradeActivityCacheControl
+} from '$lib/server/publicTradeActivityCache';
 import { rateLimiters, getClientIp } from '$lib/server/rateLimit';
-import { withConditionalCache, CACHE_KEYS, CACHE_TTL } from '$lib/server/cache';
-import { networks, TOKENS, CRYPTO_TOKENS } from '$lib/config/network';
-import type { Network } from '$lib/config/network';
-import { normalizeAddress } from '$lib/utils/tokenMath';
-import { bucketTimestamp, TRADE_WINDOW_BUCKET_SECONDS } from '$lib/utils/timeWindow';
-import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
-import type { ApiTradeByAddress, ApiTradesByAddressResponse } from '$lib/api/st0xApi';
+import { createServerTradesQueryFetcher } from '$lib/server/st0xTradesFetcher';
 
-const WINDOW_SECONDS = 30 * 24 * 60 * 60; // 30 days
+export type {
+	NetworkTradeStats,
+	PublicTradeActivityResponse,
+	TokenTradingRow
+} from '$lib/server/publicTradeActivity';
 
-export interface TokenTradingRow {
-	address: string;
-	symbol?: string;
-	name?: string;
-	logoUrl?: string;
-	inVolume: number;
-	outVolume: number;
-	totalVolume: number;
-	quoteVolume: number;
-	trades: number;
-}
-
-export interface NetworkTradeStats {
-	chainId: number;
-	networkId: number;
-	tradingVolume: number;
-	totalTrades: number;
-	tokens: TokenTradingRow[];
-}
-
-export interface PublicTradeActivityResponse {
-	success: boolean;
-	range: { from: number; to: number };
-	totals: {
-		tradingVolume: number;
-		totalTrades: number;
-	};
-	networks: NetworkTradeStats[];
-}
-
-// ============================================================================
-// Server-side REST API fetch (bypasses the browser-only proxy)
-// ============================================================================
-
-function getApiConfig(): { apiBase: string; authHeader: string } | null {
+function getApiConfig(): { apiBase: string; authHeader: string } {
 	const url = env.ST0X_API_URL;
 	const key = env.ST0X_API_KEY;
 	const secret = env.ST0X_API_SECRET;
-	if (!url || !key || !secret) return null;
+	if (!url || !key || !secret) {
+		throw new Error('REST API not configured');
+	}
 	return {
 		apiBase: url.replace(/\/+$/, ''),
 		authHeader: 'Basic ' + btoa(`${key}:${secret}`)
 	};
 }
 
-async function fetchTradesForToken(
-	apiBase: string,
-	authHeader: string,
-	tokenAddress: string,
-	from: number,
-	to: number
-): Promise<ApiTradeByAddress[]> {
-	const allTrades: ApiTradeByAddress[] = [];
-	let page = 1;
-
-	while (page <= 50) {
-		const params = new URLSearchParams({
-			page: String(page),
-			pageSize: '200',
-			startTime: String(from),
-			endTime: String(to)
-		});
-		const url = `${apiBase}/v1/trades/token/${tokenAddress}?${params}`;
-		const res = await fetch(url, {
-			headers: { Authorization: authHeader, Accept: 'application/json' }
-		});
-		if (!res.ok) break;
-		const data: ApiTradesByAddressResponse = await res.json();
-		allTrades.push(...(data.trades ?? []));
-		if (!data.pagination?.hasMore) break;
-		page++;
-	}
-
-	return allTrades;
-}
-
-async function fetchNetworkTradesFromApi(
-	network: Network,
-	from: number,
-	to: number
-): Promise<ApiTradeByAddress[]> {
-	const config = getApiConfig();
-	if (!config) throw new Error('REST API not configured');
-
-	const canonicalTokens = [...TOKENS, ...CRYPTO_TOKENS].filter(
-		(t) => t.chainId === network.chainId
-	);
-
-	const results = await Promise.allSettled(
-		canonicalTokens.map((token) =>
-			fetchTradesForToken(config.apiBase, config.authHeader, token.address, from, to)
-		)
-	);
-
-	// Dedup across tokens (same trade may appear for both input and output token queries)
-	const seen = new Set<string>();
-	const allTrades: ApiTradeByAddress[] = [];
-
-	for (const result of results) {
-		if (result.status !== 'fulfilled') continue;
-		for (const trade of result.value) {
-			const key = `${trade.txHash}-${trade.orderHash ?? ''}-${trade.inputToken.address}`;
-			if (!seen.has(key)) {
-				seen.add(key);
-				allTrades.push(trade);
-			}
-		}
-	}
-
-	return allTrades;
-}
-
-// ============================================================================
-// Trade analysis (simplified for REST API response format)
-// ============================================================================
-
-type AnalyzedApiTrade = {
-	txHash: string;
-	assetAddress: string;
-	side: 'bid' | 'ask';
-	tokens: number;
-	quote: number;
-};
-
-function analyzeApiTrades(
-	trades: ApiTradeByAddress[],
-	quoteTokenAddress: string
-): AnalyzedApiTrade[] {
-	const quoteAddr = normalizeAddress(quoteTokenAddress);
-	if (!quoteAddr) return [];
-
-	const analyzed: AnalyzedApiTrade[] = [];
-
-	for (const trade of trades) {
-		const inputAddr = normalizeAddress(trade.inputToken.address);
-		const outputAddr = normalizeAddress(trade.outputToken.address);
-		if (!inputAddr || !outputAddr) continue;
-
-		const inputAmount = Math.abs(parseFloat(trade.inputAmount));
-		const outputAmount = Math.abs(parseFloat(trade.outputAmount));
-		if (!Number.isFinite(inputAmount) || !Number.isFinite(outputAmount)) continue;
-		if (inputAmount <= 0 || outputAmount <= 0) continue;
-
-		let side: 'bid' | 'ask';
-		let tokens: number;
-		let quote: number;
-		let assetAddress: string;
-
-		if (inputAddr === quoteAddr) {
-			// ASK: quote token goes in, asset comes out
-			side = 'ask';
-			tokens = outputAmount;
-			quote = inputAmount;
-			assetAddress = outputAddr;
-		} else if (outputAddr === quoteAddr) {
-			// BID: asset goes in, quote token comes out
-			side = 'bid';
-			tokens = inputAmount;
-			quote = outputAmount;
-			assetAddress = inputAddr;
-		} else {
-			continue;
-		}
-
-		analyzed.push({ txHash: trade.txHash, assetAddress, side, tokens, quote });
-	}
-
-	return analyzed;
-}
-
-function aggregateNetwork(network: Network, analyzed: AnalyzedApiTrade[]): NetworkTradeStats {
-	const canonicalTokens = new Set<string>(
-		[...TOKENS, ...CRYPTO_TOKENS]
-			.filter((t) => t.chainId === network.chainId)
-			.map((t) => normalizeAddress(t.address))
-			.filter((addr): addr is string => Boolean(addr))
-	);
-
-	const seenTx = new Set<string>();
-	let tradingVolume = 0;
-
-	const rows = new Map<string, TokenTradingRow & { transactions: Set<string> }>();
-	for (const token of [...TOKENS, ...CRYPTO_TOKENS].filter((t) => t.chainId === network.chainId)) {
-		const addr = normalizeAddress(token.address);
-		if (!addr) continue;
-		rows.set(addr, {
-			address: addr,
-			symbol: token.symbol,
-			name: token.name,
-			logoUrl: token.logoUrl,
-			inVolume: 0,
-			outVolume: 0,
-			totalVolume: 0,
-			quoteVolume: 0,
-			trades: 0,
-			transactions: new Set<string>()
-		});
-	}
-
-	for (const entry of analyzed) {
-		const addr = normalizeAddress(entry.assetAddress);
-		if (!addr || !canonicalTokens.has(addr)) continue;
-
-		const isNewTx = !entry.txHash || !seenTx.has(entry.txHash);
-		if (entry.txHash) seenTx.add(entry.txHash);
-		if (isNewTx) tradingVolume += entry.quote;
-
-		const row = rows.get(addr);
-		if (!row) continue;
-
-		if (entry.side === 'bid') {
-			row.inVolume += entry.tokens;
-		} else if (entry.side === 'ask') {
-			row.outVolume += entry.tokens;
-		}
-		row.totalVolume += entry.tokens;
-
-		if (entry.txHash && !row.transactions.has(entry.txHash)) {
-			row.transactions.add(entry.txHash);
-			row.quoteVolume += entry.quote;
-		}
-	}
-
-	const tokens: TokenTradingRow[] = Array.from(rows.values())
-		.map(({ transactions, ...rest }) => ({
-			...rest,
-			trades: transactions.size
-		}))
-		.sort((a, b) => b.trades - a.trades);
-
-	return {
-		chainId: network.chainId,
-		networkId: network.id,
-		tradingVolume,
-		totalTrades: seenTx.size,
-		tokens
-	};
-}
-
-async function computeTradeActivity(): Promise<PublicTradeActivityResponse> {
-	// Bucket the window edge so the per-token upstream fan-out reuses one cache
-	// key across recomputes instead of cache-busting on every second.
-	const now = bucketTimestamp(Math.floor(Date.now() / 1000), TRADE_WINDOW_BUCKET_SECONDS);
-	const from = now - WINDOW_SECONDS;
-
-	const perNetwork = await Promise.all(
-		networks.map(async (network) => {
-			try {
-				const trades = await fetchNetworkTradesFromApi(network, from, now);
-				const quoteTokenAddress = network.defaultPaymentToken?.address;
-				if (!quoteTokenAddress) return aggregateNetwork(network, []);
-				const analyzed = analyzeApiTrades(trades, quoteTokenAddress);
-				return aggregateNetwork(network, analyzed);
-			} catch (error) {
-				logQueryFailure({
-					kind: 'public_endpoint_network_failed',
-					endpoint: 'public-trade-activity',
-					network: network.name,
-					error: errorMessage(error)
-				});
-				return aggregateNetwork(network, []);
-			}
-		})
-	);
-
-	const totalVolume = perNetwork.reduce((sum, n) => sum + n.tradingVolume, 0);
-	const totalTrades = perNetwork.reduce((sum, n) => sum + n.totalTrades, 0);
-
-	return {
-		success: true,
-		range: { from, to: now },
-		totals: {
-			tradingVolume: totalVolume,
-			totalTrades
-		},
-		networks: perNetwork
-	};
+async function computeTradeActivity(): Promise<PublicTradeActivitySnapshot> {
+	const fetchTrades = createServerTradesQueryFetcher(getApiConfig());
+	return computePublicTradeActivity(fetchTrades);
 }
 
 export const GET: RequestHandler = async ({ request }) => {
@@ -316,25 +57,20 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
-		const data = await withConditionalCache<PublicTradeActivityResponse>(
-			CACHE_KEYS.publicTradeActivity(),
-			computeTradeActivity,
-			(result) => result.success && result.totals.tradingVolume > 0,
-			CACHE_TTL.LONG
-		);
-
+		const data = await getCachedPublicTradeActivity(computeTradeActivity);
 		return json(data, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400'
+				'Cache-Control': publicTradeActivityCacheControl(data)
 			}
 		});
 	} catch (error) {
 		console.error('[Public TradeActivity] Error:', error);
 		const now = Math.floor(Date.now() / 1000);
+		const range = tradeActivityWindow(now);
 		return json(
 			{
 				success: false,
-				range: { from: now - WINDOW_SECONDS, to: now },
+				range,
 				totals: { tradingVolume: 0, totalTrades: 0 },
 				networks: []
 			} satisfies PublicTradeActivityResponse,

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -126,6 +126,47 @@ describe('/api/st0x proxy', () => {
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
+	it('allows POST /v1/trades/query without unsafe URI-only shared caching', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					trades: [],
+					pagination: {
+						page: 1,
+						pageSize: 50,
+						totalTrades: 0,
+						totalPages: 0,
+						hasMore: false
+					}
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const body = JSON.stringify({
+			chainId: 8453,
+			tokenAddresses: ['0xToken'],
+			startTime: 1_000,
+			endTime: 2_000,
+			page: 1,
+			pageSize: 50
+		});
+
+		const response = await POST(proxyEvent('POST', 'v1/trades/query', body));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.example.test/v1/trades/query?page=1',
+			expect.objectContaining({ method: 'POST' })
+		);
+		const init = fetchMock.mock.calls[0][1] as RequestInit;
+		expect(await new Response(init.body).text()).toBe(body);
+	});
+
 	it('allows POST /v1/swap/calldata without caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ to: '0xOrderbook', data: '0x', value: '0', approvals: [] }), {

--- a/tests/lib/api/st0xApi.test.ts
+++ b/tests/lib/api/st0xApi.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiGetSwapCalldataV2, apiGetSwapQuoteV2, apiQueryOrders } from '$lib/api/st0xApi';
+import {
+	apiGetSwapCalldataV2,
+	apiGetSwapQuoteV2,
+	apiGetTradesBatch,
+	apiQueryOrders,
+	apiQueryTrades
+} from '$lib/api/st0xApi';
 
 describe('st0x API client', () => {
 	beforeEach(() => {
@@ -127,6 +133,69 @@ describe('st0x API client', () => {
 				method: 'POST',
 				body: JSON.stringify(request),
 				signal
+			})
+		);
+	});
+
+	it('posts token-set trade queries and returns the paginated response', async () => {
+		const response = {
+			trades: [],
+			pagination: {
+				page: 1,
+				pageSize: 50,
+				totalTrades: 0,
+				totalPages: 0,
+				hasMore: false
+			}
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(response), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const request = {
+			chainId: 8453,
+			tokenAddresses: ['0xabc'],
+			startTime: 1_000,
+			endTime: 2_000,
+			page: 1,
+			pageSize: 50,
+			denomination: 'wrapped' as const
+		};
+		const signal = new AbortController().signal;
+
+		await expect(apiQueryTrades(request, signal)).resolves.toEqual(response);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/st0x/v1/trades/query',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify(request),
+				signal
+			})
+		);
+	});
+
+	it('preserves the existing grouped order-hash batch contract', async () => {
+		const response = {
+			tradesByOrderHash: [{ orderHash: '0xhash', trades: [] }],
+			totalCount: 0
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(response), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(apiGetTradesBatch(['0xhash'])).resolves.toEqual(response);
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/st0x/v1/trades/query',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ orderHashes: ['0xhash'] })
 			})
 		);
 	});


### PR DESCRIPTION
## Depends on

- Parent website batch-order PR: https://github.com/SARKEX/st0x/pull/246
- REST batch-query API and incomplete-response hardening: https://github.com/ST0x-Technology/st0x.rest.api/pull/166

## Motivation

Public trade activity fetched each catalog token separately. That fanout made request count and latency grow with the token catalog and consumed the shared REST rate-limit budget.

## Solution

- Add API-owned website DTOs for the coherent `POST /v1/trades/query` contract while preserving the legacy grouped order-hash helper.
- Query the normalized token catalog through one sequential bounded pagination stream per network, excluding each network payment token from the OR-filter so unrelated payment-token trades are not selected.
- Preserve the existing 30-day totals and per-token aggregation while keeping deterministic five-minute windows and stable output ordering.
- Treat page, network, and pagination-cap failures atomically; incomplete computations are never cached as complete snapshots.
- Add Redis and in-process caching with shared stampede protection. Freshness is anchored to the snapshot window, retained complete stale snapshots are bounded to six hours, and failed refreshes retry after at most 60 seconds.
- Bound HTTP `s-maxage` and stale behavior to the same six-hour snapshot horizon.
- Keep `GET /v1/trades/token/:address`, the browser proxy, and current order-hash batch behavior compatible.

## Validation

- [x] `nix develop -c bunx vitest run` — 79 files passed; 850 tests passed, 1 skipped
- [x] `nix develop -c npm run svelte-lint-format-check` — Svelte check, ESLint, and Prettier clean
- [x] `nix develop -c npm run test:integration` — suite loaded successfully; the single Anvil-fork test skipped because local fork credentials were not configured
- [x] `nix develop -c git diff --check`
- [x] Simplification pass plus two-round staged local review — all actionable findings fixed
- [x] Live local REST and website smoke test — complete 4,219-trade snapshot across 34 catalog tokens; immediate response was byte-identical and served in 1.7 ms

The REST contract caps trade pages at 50, so large datasets use sequential pages within one network stream. Request count is independent of token catalog size and no per-token request fanout remains.

Fixes RAI-1565