### PR TITLE
fix(api): isolate and retain public REST caches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,20 @@ PUBLIC_DYNAMIC_ENVIRONMENT_ID=
 
 PUBLIC_POSTHOG_KEY=
 
+# ST0x REST service traffic
+ST0X_API_URL=
+# General authenticated website proxy, registry, and orderbook traffic.
+ST0X_API_KEY=
+ST0X_API_SECRET=
+# Dedicated public trade-activity refresh budget. Configure both values in production.
+# If both are absent, the general pair is used only as a rollout fallback.
+ST0X_ACTIVITY_API_KEY=
+ST0X_ACTIVITY_API_SECRET=
+# Dedicated public-price refresh budget. Configure both values in production.
+# If both are absent, the general pair is used only as a rollout fallback.
+ST0X_PRICES_API_KEY=
+ST0X_PRICES_API_SECRET=
+
 # Liquidity monitor (SPYM price source)
 
 # Observability — Sentry (errors)

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,46 @@
+# Website REST service traffic
+
+## Credentials and request budgets
+
+Production should provision three REST credentials:
+
+- `ST0X_API_KEY` / `ST0X_API_SECRET` for the authenticated browser proxy,
+  registry, and global orderbook.
+- `ST0X_ACTIVITY_API_KEY` / `ST0X_ACTIVITY_API_SECRET` for public trade
+  activity refreshes.
+- `ST0X_PRICES_API_KEY` / `ST0X_PRICES_API_SECRET` for public midpoint-price
+  refreshes.
+
+Each dedicated pair falls back to the general pair only when both of its values
+are absent, which allows a staged deployment. A partially configured dedicated
+pair fails closed.
+
+REST authentication and per-key rate limiting run before the REST response
+cache. The selected accounting policy is therefore that every request reaching
+REST, including a REST response-cache hit, consumes one request from that key.
+Website memory, Redis, TanStack, and edge-cache hits do not reach REST and
+consume no REST budget. Separate credentials keep public-price, activity, and
+general website traffic from exhausting each other's API-side allowance.
+
+## Cache and retry policy
+
+- Public prices are fresh for 90 seconds. The last complete payload is retained
+  for six hours and served when a refresh fails. Failed or partial refreshes
+  never replace it.
+- A REST `429` is not retried immediately. The price cache honors
+  `Retry-After` before revalidation; browser price queries wait for the next
+  scheduled refresh. Bounded browser retries remain enabled for network and
+  server failures other than `429`.
+- Public trade activity retains only complete snapshots for six hours.
+  A cold refresh requests up to 500 trades per bounded REST page and uses a
+  distributed Redis single-flight lock so separate website instances do not
+  duplicate the pagination stream. The complete refresh aborts after 90 seconds.
+- REST `Retry-After` cooldowns for price and activity refreshes are stored in
+  Redis so they apply consistently across website instances.
+- `GET /v1/tokens` is cached at the website edge for five minutes, with a
+  one-hour stale-while-revalidate window.
+
+Public-price REST failures emit structured `[monitor]` events with
+`endpoint=public-prices`, `credentialLabel`, and status `429` when applicable.
+The cache and fetcher tests enforce the regression threshold: concurrent cold
+requests coalesce, and no second REST refresh occurs before `Retry-After`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 ### SToX
+
+Operational configuration for website-to-REST traffic is documented in
+[OPERATIONS.md](./OPERATIONS.md).

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -36,21 +36,6 @@ import {
 export type { ProcessedQuote, TokenPriceSummary };
 export { OrderV4_ABI, normalizeOrderData, walkOrderbook };
 
-/**
- * Fetches one page of orders for a token. Defaults to the browser proxy client
- * (`apiGetOrdersByToken`); server callers inject a fetcher that hits the REST API directly
- * so the same quoting pipeline can run server-side (e.g. the public prices endpoint).
- */
-export type OrdersByTokenFetcher = (
-	tokenAddress: string,
-	options?: {
-		page?: number;
-		pageSize?: number;
-		side?: 'input' | 'output';
-		state?: 'active' | 'inactive' | 'all';
-	}
-) => Promise<ApiOrdersListResponse>;
-
 export type OrdersQueryFetcher = typeof apiQueryOrders;
 
 export const buildTokenPriceMap = (quotes: ProcessedQuote[], quoteAddressRaw: string) =>
@@ -58,40 +43,6 @@ export const buildTokenPriceMap = (quotes: ProcessedQuote[], quoteAddressRaw: st
 
 /** Safety cap to prevent infinite pagination loops from a buggy API response */
 const MAX_ORDER_PAGES = 100;
-
-/**
- * Max number of tokens fetched concurrently in the payment-token fan-out.
- * The book has ~29 stock-token address variants; firing them all at once (the previous
- * behaviour) overwhelmed the shared upstream and tripped its rate limit. A small pool
- * keeps throughput high while staying under the upstream's budget.
- */
-const ORDER_FETCH_CONCURRENCY = 5;
-
-/**
- * Run `worker` over `items` with at most `limit` in flight at once. Never rejects —
- * mirrors Promise.allSettled semantics so one failing token can't abort the rest.
- */
-async function runWithConcurrency<T>(
-	items: T[],
-	limit: number,
-	worker: (item: T) => Promise<void>
-): Promise<PromiseSettledResult<void>[]> {
-	const results: PromiseSettledResult<void>[] = new Array(items.length);
-	let cursor = 0;
-	const runner = async () => {
-		while (cursor < items.length) {
-			const index = cursor++;
-			try {
-				await worker(items[index]);
-				results[index] = { status: 'fulfilled', value: undefined };
-			} catch (reason) {
-				results[index] = { status: 'rejected', reason };
-			}
-		}
-	};
-	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, runner));
-	return results;
-}
 
 function getTokenMetadata(address: string, tokens: Token[]) {
 	const token = tokens.find((t) => t.address.toLowerCase() === address.toLowerCase());
@@ -109,9 +60,9 @@ function getTokenMetadata(address: string, tokens: Token[]) {
  * and computeEmergencyRatioHex which expect hex Float format.
  *
  * Orders with no live quote (`ioRatio === '-'`, i.e. the API's on-chain `quote()`
- * call reverted) are dropped entirely. They cannot be honoured at any displayable
- * price, so showing them in the depth chart would advertise liquidity that doesn't
- * actually execute.
+ * call reverted — typically Pyth-oracle orders quoted without a signed context) are
+ * dropped entirely. They cannot be honoured at any displayable price, so showing them
+ * in the depth chart would advertise liquidity that doesn't actually execute.
  *
  * The sgOrder is created as a minimal stub with just orderHash — marketOrderExecution.ts
  * hydrates the full order from Raindex before executing.
@@ -136,7 +87,8 @@ function convertApiOrderToProcessedQuote(
 	}
 
 	if (!order.ioRatio || order.ioRatio === '-') {
-		// The on-chain quote failed, so the order cannot be honoured at the displayed price.
+		// On-chain quote() failed (e.g. Pyth-oracle order quoted without signed context).
+		// Drop the order — it cannot be honoured at the price the chart would show.
 		return null;
 	}
 	// Convert ioRatio decimal to hex Float for consumers expecting hex (e.g. computeEmergencyRatioHex)
@@ -269,10 +221,52 @@ async function collectProcessedOrderPages({
 	const seen = new Set<string>();
 	let page = 1;
 	let hasMore = true;
+	let expectedTotalOrders: number | null = null;
+	let expectedTotalPages: number | null = null;
 
 	while (hasMore && page <= MAX_ORDER_PAGES) {
 		try {
 			const response = await fetchPage(page);
+			if (!allowPartialResults) {
+				const { pagination } = response;
+				const validIntegers =
+					Number.isInteger(pagination.page) &&
+					Number.isInteger(pagination.pageSize) &&
+					Number.isInteger(pagination.totalOrders) &&
+					Number.isInteger(pagination.totalPages);
+				const calculatedTotalPages =
+					pagination.totalOrders === 0
+						? 0
+						: Math.ceil(pagination.totalOrders / pagination.pageSize);
+				const expectedPageOrders =
+					pagination.totalPages === 0
+						? 0
+						: pagination.page < pagination.totalPages
+							? pagination.pageSize
+							: pagination.totalOrders - (pagination.totalPages - 1) * pagination.pageSize;
+				const validShape =
+					validIntegers &&
+					pagination.page === page &&
+					pagination.pageSize > 0 &&
+					pagination.pageSize <= 50 &&
+					pagination.totalOrders >= 0 &&
+					pagination.totalPages >= 0 &&
+					pagination.totalPages === calculatedTotalPages &&
+					response.orders.length === expectedPageOrders &&
+					(pagination.totalPages === 0
+						? page === 1 && pagination.totalOrders === 0
+						: page <= pagination.totalPages) &&
+					pagination.hasMore === page < pagination.totalPages;
+				if (
+					!validShape ||
+					(expectedTotalOrders !== null && pagination.totalOrders !== expectedTotalOrders) ||
+					(expectedTotalPages !== null && pagination.totalPages !== expectedTotalPages)
+				) {
+					throw new Error(`[orders] Invalid or unstable batch pagination on page ${page}`);
+				}
+				expectedTotalOrders ??= pagination.totalOrders;
+				expectedTotalPages ??= pagination.totalPages;
+			}
 			for (const order of response.orders) {
 				const quote = convertApiOrderToProcessedQuote(
 					order,
@@ -300,58 +294,6 @@ async function collectProcessedOrderPages({
 			throw new Error(paginationCapMessage);
 		}
 		console.warn(paginationCapMessage);
-	}
-
-	return processedQuotes;
-}
-
-export async function fetchAndQuotePaymentTokenOrdersByToken(
-	networkId: number = 8453,
-	overridePaymentToken?: Token,
-	fetchOrders: OrdersByTokenFetcher = apiGetOrdersByToken
-) {
-	const { paymentToken, stockTokens, allTokens } = resolveNetworkTokens(
-		networkId,
-		overridePaymentToken
-	);
-
-	const processedQuotes: ProcessedQuote[] = [];
-	const seen = new Set<string>();
-
-	const results = await runWithConcurrency(stockTokens, ORDER_FETCH_CONCURRENCY, async (token) => {
-		let page = 1;
-		let hasMore = true;
-		while (hasMore && page <= MAX_ORDER_PAGES) {
-			const response = await fetchOrders(token.address, { page, pageSize: 50 });
-			for (const order of response.orders) {
-				if (seen.has(order.orderHash)) continue;
-				seen.add(order.orderHash);
-				const quote = convertApiOrderToProcessedQuote(
-					order,
-					paymentToken.address,
-					allTokens,
-					networkId
-				);
-				if (quote) processedQuotes.push(quote);
-			}
-			hasMore = response.pagination.hasMore;
-			page++;
-		}
-		if (hasMore) {
-			console.warn(
-				`[orders] Hit pagination cap (${MAX_ORDER_PAGES} pages) for token ${token.address}`
-			);
-		}
-	});
-
-	const failures = results.filter(
-		(result): result is PromiseRejectedResult => result.status === 'rejected'
-	);
-	if (failures.length > 0 && processedQuotes.length === 0) {
-		throw failures[0].reason;
-	}
-	for (const failure of failures) {
-		console.warn('[orders] Token fetch failed; using partial orderbook:', failure.reason);
 	}
 
 	return processedQuotes;

--- a/src/lib/clients/http.ts
+++ b/src/lib/clients/http.ts
@@ -121,14 +121,18 @@ function httpErrorFromResponse(response: Response, text: string): HttpError {
 	});
 }
 
-function retryDelayFor(error: HttpError, fallbackMs: number): number {
-	if (!error.retryAfter) return fallbackMs;
+export function parseRetryAfterMs(value: string | null, now = Date.now()): number | null {
+	if (!value) return null;
 
-	const seconds = Number(error.retryAfter);
+	const seconds = Number(value);
 	if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
 
-	const retryAt = Date.parse(error.retryAfter);
-	return Number.isNaN(retryAt) ? fallbackMs : Math.max(0, retryAt - Date.now());
+	const retryAt = Date.parse(value);
+	return Number.isNaN(retryAt) ? null : Math.max(0, retryAt - now);
+}
+
+function retryDelayFor(error: HttpError, fallbackMs: number): number {
+	return parseRetryAfterMs(error.retryAfter) ?? fallbackMs;
 }
 
 /**

--- a/src/lib/config/publicPrices.ts
+++ b/src/lib/config/publicPrices.ts
@@ -1,10 +1,7 @@
-/**
- * Cache the REST API's sampled market-price response across website clients.
- * The sampler runs independently in the REST service; the website only needs
- * to refresh often enough to pick up the latest completed sample.
- */
+/** Public prices are fresh for 90 seconds and retained for six hours. */
 export const PUBLIC_PRICES_TTL_SECONDS = 90;
 export const PUBLIC_PRICES_REFRESH_INTERVAL_MS = PUBLIC_PRICES_TTL_SECONDS * 1_000;
-export const PUBLIC_PRICES_CACHE_CONTROL = `public, s-maxage=${PUBLIC_PRICES_TTL_SECONDS}, stale-while-revalidate=${
-	PUBLIC_PRICES_TTL_SECONDS * 3
-}`;
+export const PUBLIC_PRICES_EDGE_STALE_SECONDS = PUBLIC_PRICES_TTL_SECONDS * 3;
+export const PUBLIC_PRICES_RETAINED_SECONDS = 6 * 60 * 60;
+export const PUBLIC_PRICES_FAILURE_RETRY_SECONDS = 30;
+export const PUBLIC_PRICES_REFRESH_TIMEOUT_MS = 90_000;

--- a/src/lib/queries/midpointPrices.test.ts
+++ b/src/lib/queries/midpointPrices.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchMidpointPrices } from '$lib/queries/midpointPrices';
+import { fetchMidpointPrices, shouldRetryMidpointPrices } from '$lib/queries/midpointPrices';
+import { HttpError } from '$lib/clients/http';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 
 describe('fetchMidpointPrices', () => {
@@ -27,11 +28,37 @@ describe('fetchMidpointPrices', () => {
 
 	it('rejects a rate-limited refresh instead of replacing cached prices with an empty map', async () => {
 		const fetchFn = vi.fn(
-			async () => new Response(null, { status: 429 })
+			async () => new Response(null, { status: 429, headers: { 'Retry-After': '60' } })
 		) as unknown as typeof fetch;
 
-		await expect(fetchMidpointPrices(8453, fetchFn)).rejects.toThrow(
-			'Public prices request failed (429)'
-		);
+		const error = await fetchMidpointPrices(8453, fetchFn).catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(HttpError);
+		expect((error as HttpError).status).toBe(429);
+		expect((error as HttpError).retryAfter).toBe('60');
+		expect(fetchFn).toHaveBeenCalledOnce();
+	});
+});
+
+describe('shouldRetryMidpointPrices', () => {
+	it('defers 429s to the scheduled refresh and bounds other retries', () => {
+		const rateLimited = new HttpError({
+			status: 429,
+			code: 'RATE_LIMITED',
+			requestId: null,
+			publicMessage: 'Too many requests',
+			retryAfter: '60'
+		});
+		const unavailable = new HttpError({
+			status: 503,
+			code: 'UPSTREAM_UNAVAILABLE',
+			requestId: null,
+			publicMessage: 'Unavailable',
+			retryAfter: null
+		});
+
+		expect(shouldRetryMidpointPrices(0, rateLimited)).toBe(false);
+		expect(shouldRetryMidpointPrices(0, unavailable)).toBe(true);
+		expect(shouldRetryMidpointPrices(2, unavailable)).toBe(false);
 	});
 });

--- a/src/lib/queries/midpointPrices.ts
+++ b/src/lib/queries/midpointPrices.ts
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import type { Network } from '$lib/config/network';
 import { getTokenByAnyAddress } from '$lib/config/network';
 import { PUBLIC_PRICES_REFRESH_INTERVAL_MS } from '$lib/config/publicPrices';
+import { fetchJson, isRateLimitError } from '$lib/clients/http';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 
 export type { MidpointPrice };
@@ -13,15 +14,18 @@ interface PublicPricesResponse {
 	prices: Record<string, Record<string, MidpointPrice>>;
 }
 
+export function shouldRetryMidpointPrices(failureCount: number, error: unknown): boolean {
+	return !isRateLimitError(error) && failureCount < 2;
+}
+
 export async function fetchMidpointPrices(
 	networkId: number,
 	fetchFn: typeof fetch = fetch
 ): Promise<Record<string, MidpointPrice>> {
-	const response = await fetchFn('/api/public/prices');
-	if (!response.ok) {
-		throw new Error(`Public prices request failed (${response.status})`);
-	}
-	const data: PublicPricesResponse = await response.json();
+	const data = await fetchJson<PublicPricesResponse>('/api/public/prices', {
+		fetchFn,
+		retries: 0
+	});
 	return data.prices?.[String(networkId)] ?? {};
 }
 
@@ -38,7 +42,11 @@ export function createMidpointPricesQuery(network: Network | null) {
 		refetchInterval: PUBLIC_PRICES_REFRESH_INTERVAL_MS,
 		refetchOnWindowFocus: false,
 		refetchIntervalInBackground: false,
-		retry: false,
+		// A 429 waits for the next scheduled refresh; retrying it would consume
+		// more of an already exhausted budget. Short 5xx/network failures get a
+		// bounded recovery attempt so a cold load is not empty for 90 seconds.
+		retry: shouldRetryMidpointPrices,
+		retryDelay: (attemptIndex) => Math.min(1_000 * 2 ** attemptIndex, 10_000),
 		queryFn: async () => {
 			if (!network) return {};
 			return fetchMidpointPrices(network.id);

--- a/src/lib/server/cache.test.ts
+++ b/src/lib/server/cache.test.ts
@@ -1,15 +1,25 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
-// No Redis in tests → getKv resolves to null, so every call takes the
-// "cache miss → compute" path. That's exactly the cold path where a
-// stampede would occur.
-vi.mock('$lib/server/kv', () => ({
-	getKv: vi.fn(async () => null)
+const { getKvMock } = vi.hoisted(() => ({
+	getKvMock: vi.fn()
 }));
 
-import { withConditionalCache } from './cache';
+vi.mock('$lib/server/kv', () => ({
+	getKv: getKvMock
+}));
+
+import { withCache, withConditionalCache } from './cache';
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe('withConditionalCache — stampede protection', () => {
+	beforeEach(() => {
+		getKvMock.mockReset();
+		getKvMock.mockResolvedValue(null);
+	});
+
 	it('runs the computation only once for concurrent calls with the same key', async () => {
 		let calls = 0;
 		const fn = async () => {
@@ -60,5 +70,91 @@ describe('withConditionalCache — stampede protection', () => {
 		};
 		await expect(withConditionalCache('throw-key', ok, () => true, 60)).resolves.toBe('recovered');
 		expect(ran).toBe(true);
+	});
+});
+
+describe('withCache — distributed stampede protection', () => {
+	beforeEach(() => {
+		getKvMock.mockReset();
+	});
+
+	it('waits for the shared result when another instance owns the lock', async () => {
+		const shared = { value: 42 };
+		const get = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(shared));
+		const client = {
+			get,
+			set: vi.fn(async () => null),
+			del: vi.fn(),
+			eval: vi.fn()
+		};
+		getKvMock.mockResolvedValue(client);
+		const compute = vi.fn(async () => ({ value: 99 }));
+
+		await expect(
+			withCache('distributed-wait', compute, 60, () => true, {
+				lockTtlMs: 1_000,
+				waitTimeoutMs: 500,
+				pollMs: 10
+			})
+		).resolves.toEqual(shared);
+
+		expect(compute).not.toHaveBeenCalled();
+		expect(client.set).toHaveBeenCalledWith('distributed-wait:compute-lock', expect.any(String), {
+			NX: true,
+			PX: 1_000
+		});
+		expect(client.eval).not.toHaveBeenCalled();
+	});
+
+	it('writes a complete result before releasing an acquired shared lock', async () => {
+		const events: string[] = [];
+		const client = {
+			get: vi.fn(async () => null),
+			set: vi.fn(async (_key: string, _value: string, options: Record<string, unknown>) => {
+				if ('NX' in options) {
+					events.push('lock');
+					return 'OK';
+				}
+				events.push('cache');
+				return 'OK';
+			}),
+			del: vi.fn(),
+			eval: vi.fn(async () => {
+				events.push('release');
+				return 1;
+			})
+		};
+		getKvMock.mockResolvedValue(client);
+		const compute = vi.fn(async () => ({ value: 42 }));
+
+		await expect(
+			withCache('distributed-owner', compute, 60, () => true, {
+				lockTtlMs: 1_000,
+				waitTimeoutMs: 500,
+				pollMs: 10
+			})
+		).resolves.toEqual({ value: 42 });
+
+		expect(compute).toHaveBeenCalledOnce();
+		expect(events).toEqual(['lock', 'cache', 'release']);
+		expect(client.eval).toHaveBeenCalledWith(expect.any(String), {
+			keys: ['distributed-owner:compute-lock'],
+			arguments: [expect.any(String)]
+		});
+	});
+
+	it('fails open without wedging when Redis does not settle', async () => {
+		vi.useFakeTimers();
+		getKvMock.mockImplementation(() => new Promise(() => undefined));
+		const compute = vi.fn(async () => ({ value: 42 }));
+
+		const result = withCache('stalled-redis', compute, 60, () => true, {
+			lockTtlMs: 120_000,
+			waitTimeoutMs: 95_000
+		});
+		await vi.advanceTimersByTimeAsync(15_000);
+
+		await expect(result).resolves.toEqual({ value: 42 });
+		expect(compute).toHaveBeenCalledOnce();
 	});
 });

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -1,16 +1,32 @@
+import { randomUUID } from 'node:crypto';
 import { getKv } from './kv';
 
 const DEFAULT_TTL_SECONDS = 60 * 60; // 1 hour
+const CACHE_OPERATION_TIMEOUT_MS = 5_000;
+
+async function cacheOperation<T>(operation: string, promise: Promise<T>): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const deadline = new Promise<never>((_, reject) => {
+		timeout = setTimeout(
+			() => reject(new Error(`Cache ${operation} exceeded ${CACHE_OPERATION_TIMEOUT_MS}ms`)),
+			CACHE_OPERATION_TIMEOUT_MS
+		);
+	});
+	try {
+		return await Promise.race([promise, deadline]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
 
 /**
  * Simple Redis-based cache for API responses
  */
 export async function cacheGet<T>(key: string): Promise<T | null> {
-	const client = await getKv();
-	if (!client) return null;
-
 	try {
-		const cached = await client.get(key);
+		const client = await cacheOperation('connection', getKv());
+		if (!client) return null;
+		const cached = await cacheOperation('get', client.get(key));
 		if (!cached) return null;
 		return JSON.parse(cached) as T;
 	} catch (error) {
@@ -24,25 +40,40 @@ export async function cacheSet<T>(
 	value: T,
 	ttlSeconds = DEFAULT_TTL_SECONDS
 ): Promise<void> {
-	const client = await getKv();
-	if (!client) return;
-
 	try {
-		await client.set(key, JSON.stringify(value), { EX: ttlSeconds });
+		const client = await cacheOperation('connection', getKv());
+		if (!client) return;
+		await cacheOperation('set', client.set(key, JSON.stringify(value), { EX: ttlSeconds }));
 	} catch (error) {
 		console.error('[Cache] Set error:', error);
 	}
 }
 
 export async function cacheDelete(key: string): Promise<void> {
-	const client = await getKv();
-	if (!client) return;
-
 	try {
-		await client.del(key);
+		const client = await cacheOperation('connection', getKv());
+		if (!client) return;
+		await cacheOperation('delete', client.del(key));
 	} catch (error) {
 		console.error('[Cache] Delete error:', error);
 	}
+}
+
+export async function cacheCooldownRemainingMs(
+	key: string,
+	now = Date.now()
+): Promise<number | null> {
+	const cooldown = await cacheGet<{ retryUntil: number }>(key);
+	if (!cooldown || !Number.isFinite(cooldown.retryUntil) || cooldown.retryUntil <= now) return null;
+	return Math.max(1_000, cooldown.retryUntil - now);
+}
+
+export async function cacheSetCooldown(key: string, delayMs: number): Promise<void> {
+	await cacheSet(
+		key,
+		{ retryUntil: Date.now() + delayMs },
+		Math.max(1, Math.ceil(delayMs / 1_000))
+	);
 }
 
 // invalidatePublicApiCaches() and invalidateRewardsCaches() were deleted in
@@ -55,22 +86,130 @@ export async function cacheDelete(key: string): Promise<void> {
 // In-memory locks to prevent cache stampede
 const computeLocks = new Map<string, Promise<unknown>>();
 
+export interface DistributedCacheOptions {
+	lockTtlMs: number;
+	waitTimeoutMs: number;
+	pollMs?: number;
+}
+
+function wait(delayMs: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function getValidCachedValue<T>(
+	key: string,
+	isCachedValueValid: (value: T) => boolean
+): Promise<T | null> {
+	const cached = await cacheGet<T>(key);
+	if (cached !== null && isCachedValueValid(cached)) return cached;
+	if (cached !== null) await cacheDelete(key);
+	return null;
+}
+
+async function computeAndCache<T>(
+	key: string,
+	fn: () => Promise<T>,
+	ttlSeconds: number | ((value: T) => number)
+): Promise<T> {
+	const result = await fn();
+	const resolvedTtlSeconds = typeof ttlSeconds === 'function' ? ttlSeconds(result) : ttlSeconds;
+	if (resolvedTtlSeconds > 0) {
+		try {
+			await cacheSet(key, result, resolvedTtlSeconds);
+		} catch (cacheError) {
+			console.warn('[Cache] Set failed:', cacheError);
+		}
+	}
+	return result;
+}
+
+async function computeWithDistributedLock<T>(
+	key: string,
+	fn: () => Promise<T>,
+	ttlSeconds: number | ((value: T) => number),
+	isCachedValueValid: (value: T) => boolean,
+	options: DistributedCacheOptions
+): Promise<T> {
+	let client: Awaited<ReturnType<typeof getKv>>;
+	try {
+		client = await cacheOperation('connection', getKv());
+	} catch (error) {
+		console.warn('[Cache] Shared lock unavailable, computing locally:', error);
+		return computeAndCache(key, fn, ttlSeconds);
+	}
+	if (!client) return computeAndCache(key, fn, ttlSeconds);
+
+	const lockKey = `${key}:compute-lock`;
+	const token = randomUUID();
+	const pollMs = Math.max(10, options.pollMs ?? 250);
+	const waitTimeoutMs = Math.max(pollMs, options.waitTimeoutMs);
+	const lockTtlMs = Math.max(waitTimeoutMs, options.lockTtlMs);
+	const deadline = Date.now() + waitTimeoutMs;
+	let ownsLock = false;
+
+	try {
+		while (!ownsLock) {
+			try {
+				ownsLock =
+					(await cacheOperation(
+						'shared lock acquisition',
+						client.set(lockKey, token, {
+							NX: true,
+							PX: lockTtlMs
+						})
+					)) === 'OK';
+			} catch (error) {
+				console.warn('[Cache] Shared lock unavailable, computing locally:', error);
+				return computeAndCache(key, fn, ttlSeconds);
+			}
+
+			if (ownsLock) break;
+
+			const cached = await getValidCachedValue(key, isCachedValueValid);
+			if (cached !== null) return cached;
+			if (Date.now() >= deadline) {
+				throw new Error(`Timed out waiting for shared cache refresh: ${key}`);
+			}
+			await wait(Math.min(pollMs, Math.max(1, deadline - Date.now())));
+		}
+
+		const cached = await getValidCachedValue(key, isCachedValueValid);
+		if (cached !== null) return cached;
+		return await computeAndCache(key, fn, ttlSeconds);
+	} finally {
+		if (ownsLock) {
+			try {
+				await cacheOperation(
+					'shared lock release',
+					client.eval(
+						'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end',
+						{ keys: [lockKey], arguments: [token] }
+					)
+				);
+			} catch (error) {
+				console.warn('[Cache] Shared lock release failed:', error);
+			}
+		}
+	}
+}
+
 /**
  * Cache wrapper - returns cached value if available, otherwise calls fn and caches result
- * Includes stampede protection: only one computation runs at a time per key
+ * Includes process-local stampede protection and optional Redis-backed
+ * single-flight coordination across website instances.
  * Cache failures are non-fatal - function result is still returned
  */
 export async function withCache<T>(
 	key: string,
 	fn: () => Promise<T>,
-	ttlSeconds: number | ((value: T) => number) = DEFAULT_TTL_SECONDS
+	ttlSeconds: number | ((value: T) => number) = DEFAULT_TTL_SECONDS,
+	isCachedValueValid: (value: T) => boolean = () => true,
+	distributed?: DistributedCacheOptions
 ): Promise<T> {
 	// Try to get from cache first (cache failures are non-fatal)
 	try {
-		const cached = await cacheGet<T>(key);
-		if (cached !== null) {
-			return cached;
-		}
+		const cached = await getValidCachedValue(key, isCachedValueValid);
+		if (cached !== null) return cached;
 	} catch (error) {
 		console.warn('[Cache] Get failed, computing fresh:', error);
 	}
@@ -84,17 +223,9 @@ export async function withCache<T>(
 	// Start computation and store the promise
 	const computePromise = (async () => {
 		try {
-			const result = await fn();
-			const resolvedTtlSeconds = typeof ttlSeconds === 'function' ? ttlSeconds(result) : ttlSeconds;
-			// Cache set failure is non-fatal - just log and continue
-			if (resolvedTtlSeconds > 0) {
-				try {
-					await cacheSet(key, result, resolvedTtlSeconds);
-				} catch (cacheError) {
-					console.warn('[Cache] Set failed:', cacheError);
-				}
-			}
-			return result;
+			return distributed
+				? await computeWithDistributedLock(key, fn, ttlSeconds, isCachedValueValid, distributed)
+				: await computeAndCache(key, fn, ttlSeconds);
 		} finally {
 			computeLocks.delete(key);
 		}
@@ -179,7 +310,7 @@ export const CACHE_KEYS = {
 	// Public trade activity cache (aggregate 30-day metrics)
 	publicTradeActivity: () => 'cache:public:trade-activity',
 	// Public midpoint prices cache (bid/ask midpoints for all networks, short TTL)
-	publicPrices: () => 'cache:public:prices'
+	publicPrices: () => 'cache:public:prices:v2'
 } as const;
 
 // TTL constants (in seconds)

--- a/src/lib/server/marketPrices.ts
+++ b/src/lib/server/marketPrices.ts
@@ -1,18 +1,18 @@
 import { env } from '$env/dynamic/private';
 import type { ApiMarketPrice, ApiMarketPricesResponse } from '$lib/api/st0xApi';
+import { parseRetryAfterMs } from '$lib/clients/http';
+import { getSt0xPricesApiConfig } from '$lib/server/st0xApiConfig';
+import { logSt0xRequestBudget } from '$lib/server/st0xBudgetTelemetry';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 
-function getApiConfig(): { apiBase: string; authHeader: string } {
-	const url = env.ST0X_API_URL;
-	const key = env.ST0X_API_KEY;
-	const secret = env.ST0X_API_SECRET;
-	if (!url || !key || !secret) {
-		throw new Error('ST0X_API_URL, ST0X_API_KEY, and ST0X_API_SECRET must be configured');
+export class St0xMarketPricesRateLimitError extends Error {
+	readonly retryAfterMs: number | null;
+
+	constructor(retryAfterMs: number | null = null) {
+		super('ST0x market prices API rate limit reached');
+		this.name = 'St0xMarketPricesRateLimitError';
+		this.retryAfterMs = retryAfterMs;
 	}
-	return {
-		apiBase: url.replace(/\/+$/, ''),
-		authHeader: `Basic ${btoa(`${key}:${secret}`)}`
-	};
 }
 
 /**
@@ -24,7 +24,11 @@ export async function fetchMarketPrices(
 	chainId: number,
 	options?: { at?: number; timeoutMs?: number; maxAttempts?: number }
 ): Promise<ApiMarketPrice[]> {
-	const { apiBase, authHeader } = getApiConfig();
+	const config = getSt0xPricesApiConfig(env);
+	if (!config) {
+		throw new Error('ST0x public-price API credentials are not configured');
+	}
+	const { apiBase, authHeader, credentialLabel } = config;
 	const params = new URLSearchParams({ chainId: String(chainId) });
 	if (options?.at !== undefined) params.set('at', String(options.at));
 
@@ -44,12 +48,18 @@ export async function fetchMarketPrices(
 			}
 			continue;
 		}
+		logSt0xRequestBudget('v1/prices', credentialLabel, response);
 		if (response.ok) {
 			const body = (await response.json()) as ApiMarketPricesResponse;
 			return body.data;
 		}
+		if (response.status === 429) {
+			throw new St0xMarketPricesRateLimitError(
+				parseRetryAfterMs(response.headers.get('Retry-After'))
+			);
+		}
 		const error = new Error(`Market prices fetch failed (${response.status})`);
-		if (response.status !== 429 && response.status < 500) {
+		if (response.status < 500) {
 			throw error;
 		}
 		lastError = error;

--- a/src/lib/server/publicPricesCache.test.ts
+++ b/src/lib/server/publicPricesCache.test.ts
@@ -1,47 +1,372 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('$lib/server/kv', () => ({
-	getKv: vi.fn(async () => null)
+const { getKvMock } = vi.hoisted(() => ({
+	getKvMock: vi.fn()
 }));
 
-import { clearPublicPricesMemoryCache, getCachedPublicPrices } from '$lib/server/publicPricesCache';
+vi.mock('$lib/server/kv', () => ({
+	getKv: getKvMock
+}));
+
 import {
-	PUBLIC_PRICES_CACHE_CONTROL,
-	PUBLIC_PRICES_REFRESH_INTERVAL_MS,
-	PUBLIC_PRICES_TTL_SECONDS
-} from '$lib/config/publicPrices';
+	clearPublicPricesMemoryCache,
+	getCachedPublicPrices,
+	publicPricesCacheControl,
+	type PublicPricesSnapshot
+} from '$lib/server/publicPricesCache';
+import { St0xMarketPricesRateLimitError } from '$lib/server/marketPrices';
+import { networks, TOKENS } from '$lib/config/network';
+
+function snapshot(price = 100): PublicPricesSnapshot {
+	return {
+		success: true,
+		prices: Object.fromEntries(
+			networks.map((network) => [
+				String(network.id),
+				Object.fromEntries(
+					TOKENS.filter(
+						(token) => token.chainId === network.chainId && token.category === 'ST0x'
+					).map((token) => [
+						token.address.toLowerCase(),
+						{ price, bid: price - 1, ask: price + 1, source: 'live', asOf: 1 }
+					])
+				)
+			])
+		)
+	};
+}
+
+function memoryRedis() {
+	const values = new Map<string, string>();
+	return {
+		values,
+		client: {
+			get: vi.fn(async (key: string) => values.get(key) ?? null),
+			set: vi.fn(async (key: string, value: string, options: { NX?: boolean }) => {
+				if (options.NX && values.has(key)) return null;
+				values.set(key, value);
+				return 'OK';
+			}),
+			del: vi.fn(async (key: string) => (values.delete(key) ? 1 : 0)),
+			eval: vi.fn(async (_script: string, options: { keys: string[] }) => {
+				const key = options.keys[0];
+				if (key) values.delete(key);
+				return 1;
+			})
+		}
+	};
+}
 
 describe('public prices cache', () => {
 	beforeEach(() => {
 		clearPublicPricesMemoryCache();
 		vi.useRealTimers();
+		getKvMock.mockReset();
+		getKvMock.mockResolvedValue(null);
 	});
 
-	it('uses a 90-second shared and browser refresh window', () => {
-		expect(PUBLIC_PRICES_TTL_SECONDS).toBe(90);
-		expect(PUBLIC_PRICES_REFRESH_INTERVAL_MS).toBe(90_000);
-		expect(PUBLIC_PRICES_CACHE_CONTROL).toBe('public, s-maxage=90, stale-while-revalidate=270');
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
-	it('does not repeat the expensive computation when Redis is unavailable', async () => {
-		const compute = vi.fn(async () => ({ success: true, prices: {} }));
+	it('coalesces concurrent cold computations', async () => {
+		let resolveCompute: ((value: PublicPricesSnapshot) => void) | undefined;
+		const compute = vi.fn(
+			() =>
+				new Promise<PublicPricesSnapshot>((resolve) => {
+					resolveCompute = resolve;
+				})
+		);
+		const first = getCachedPublicPrices(compute);
+		const second = getCachedPublicPrices(compute);
 
-		const first = await getCachedPublicPrices(compute, (result) => result.success);
-		const second = await getCachedPublicPrices(compute, (result) => result.success);
+		await vi.waitFor(() => expect(compute).toHaveBeenCalledOnce());
+		resolveCompute?.(snapshot());
 
-		expect(first).toEqual(second);
+		const results = await Promise.all([first, second]);
+		expect(results.map((result) => result.value)).toEqual([snapshot(), snapshot()]);
+	});
+
+	it('does not repeat a fresh computation when Redis is unavailable', async () => {
+		const compute = vi.fn(async () => snapshot());
+
+		await getCachedPublicPrices(compute);
+		await getCachedPublicPrices(compute);
+
 		expect(compute).toHaveBeenCalledOnce();
 	});
 
-	it('does not retain an unsuccessful result in memory', async () => {
-		const compute = vi
-			.fn<[], Promise<{ success: boolean }>>()
-			.mockResolvedValueOnce({ success: false })
-			.mockResolvedValueOnce({ success: true });
+	it('stores separate fresh and retained Redis entries', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		const set = vi.fn(async () => 'OK');
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async () => null),
+			set,
+			del: vi.fn(),
+			eval: vi.fn()
+		});
 
-		await getCachedPublicPrices(compute, (result) => result.success);
-		await getCachedPublicPrices(compute, (result) => result.success);
+		await getCachedPublicPrices(async () => snapshot());
 
-		expect(compute).toHaveBeenCalledTimes(2);
+		expect(set).toHaveBeenCalledWith('cache:public:prices:v2', expect.any(String), { EX: 90 });
+		expect(set).toHaveBeenCalledWith('cache:public:prices:v2:stale', expect.any(String), {
+			EX: 21_600
+		});
+	});
+
+	it('does not cache an incomplete response', async () => {
+		const set = vi.fn(async (..._args: unknown[]) => 'OK');
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async () => null),
+			set,
+			del: vi.fn(),
+			eval: vi.fn()
+		});
+		const incomplete = {
+			success: true,
+			prices: {}
+		} as unknown as PublicPricesSnapshot;
+
+		await expect(getCachedPublicPrices(async () => incomplete)).rejects.toThrow(
+			'did not return a complete snapshot'
+		);
+		expect(set.mock.calls.some(([key]) => key === 'cache:public:prices:v2')).toBe(false);
+	});
+
+	it('deletes an invalid primary entry and recomputes it', async () => {
+		const invalid = JSON.stringify({ value: { success: true, prices: {} }, cachedAt: Date.now() });
+		const get = vi.fn(async (key: string) => (key.endsWith(':stale') ? null : invalid));
+		const del = vi.fn();
+		getKvMock.mockResolvedValue({
+			get,
+			set: vi.fn(async () => 'OK'),
+			del,
+			eval: vi.fn()
+		});
+		const compute = vi.fn(async () => snapshot());
+
+		const result = await getCachedPublicPrices(compute);
+
+		expect(result.value).toEqual(snapshot());
+		expect(compute).toHaveBeenCalledOnce();
+		expect(del).toHaveBeenCalledWith('cache:public:prices:v2');
+	});
+
+	it('repairs a structurally complete primary entry with an invalid midpoint', async () => {
+		const invalidSnapshot = snapshot();
+		const firstNetwork = networks[0];
+		const firstToken = TOKENS.filter(
+			(token) => token.chainId === firstNetwork.chainId && token.category === 'ST0x'
+		)[0];
+		if (!firstToken) throw new Error('Expected a configured ST0x token');
+		invalidSnapshot.prices[String(firstNetwork.id)][firstToken.address.toLowerCase()] = {
+			price: -1,
+			bid: 99,
+			ask: 101,
+			source: 'live',
+			asOf: null
+		};
+		const invalid = JSON.stringify({ value: invalidSnapshot, cachedAt: Date.now() });
+		const get = vi.fn(async (key: string) => (key.endsWith(':stale') ? null : invalid));
+		const del = vi.fn();
+		getKvMock.mockResolvedValue({
+			get,
+			set: vi.fn(async () => 'OK'),
+			del,
+			eval: vi.fn()
+		});
+		const compute = vi.fn(async () => snapshot(102));
+
+		const result = await getCachedPublicPrices(compute);
+
+		expect(result.value).toEqual(snapshot(102));
+		expect(compute).toHaveBeenCalledOnce();
+		expect(del).toHaveBeenCalledWith('cache:public:prices:v2');
+	});
+
+	it('serves the last complete response when a refresh fails', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		const complete = snapshot(101);
+		await getCachedPublicPrices(async () => complete);
+		vi.advanceTimersByTime(90_001);
+
+		const result = await getCachedPublicPrices(async () => {
+			throw new Error('upstream failed');
+		});
+
+		expect(result.value).toEqual(complete);
+		expect(result.isStale).toBe(true);
+	});
+
+	it('honors Retry-After before attempting another refresh', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		await getCachedPublicPrices(async () => snapshot());
+		vi.advanceTimersByTime(90_001);
+		const failedRefresh = vi.fn(async (): Promise<PublicPricesSnapshot> => {
+			throw new St0xMarketPricesRateLimitError(60_000);
+		});
+
+		const stale = await getCachedPublicPrices(failedRefresh);
+		await getCachedPublicPrices(failedRefresh);
+
+		expect(failedRefresh).toHaveBeenCalledOnce();
+		expect(stale.revalidateAt).toBe(Date.now() + 60_000);
+	});
+
+	it('shares a cold Retry-After cooldown across website instances', async () => {
+		const { values, client } = memoryRedis();
+		getKvMock.mockResolvedValue(client);
+		const error = new St0xMarketPricesRateLimitError(60_000);
+		const compute = vi.fn(async () => {
+			throw error;
+		});
+
+		await expect(getCachedPublicPrices(compute)).rejects.toBe(error);
+		clearPublicPricesMemoryCache();
+		await expect(getCachedPublicPrices(compute)).rejects.toMatchObject({
+			name: 'St0xMarketPricesRateLimitError',
+			retryAfterMs: expect.any(Number)
+		});
+
+		expect(compute).toHaveBeenCalledOnce();
+		expect(values.has('cache:public:prices:v2:rate-limit')).toBe(true);
+	});
+
+	it('shares generic cold failures across website instances', async () => {
+		const { values, client } = memoryRedis();
+		getKvMock.mockResolvedValue(client);
+		const compute = vi.fn(async () => {
+			throw new Error('upstream failed');
+		});
+
+		await expect(getCachedPublicPrices(compute)).rejects.toThrow('upstream failed');
+		clearPublicPricesMemoryCache();
+		await expect(getCachedPublicPrices(compute)).rejects.toThrow(
+			'cooling down after a failed attempt'
+		);
+
+		expect(compute).toHaveBeenCalledOnce();
+		expect(values.has('cache:public:prices:v2:failure')).toBe(true);
+	});
+
+	it('suppresses repeated generic failures locally when Redis writes fail', async () => {
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async () => null),
+			set: vi.fn(async (_key: string, _value: string, options: { NX?: boolean } | undefined) => {
+				if (options?.NX) return 'OK';
+				throw new Error('Redis write failed');
+			}),
+			del: vi.fn(),
+			eval: vi.fn(async () => 1)
+		});
+		const compute = vi.fn(async () => {
+			throw new Error('upstream failed');
+		});
+
+		await expect(getCachedPublicPrices(compute)).rejects.toThrow('upstream failed');
+		await expect(getCachedPublicPrices(compute)).rejects.toThrow('upstream failed');
+
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('serves retained Redis data during a shared cooldown', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:02:00Z'));
+		const retained = { value: snapshot(99), cachedAt: Date.now() - 91_000 };
+		const retryUntil = Date.now() + 60_000;
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async (key: string) => {
+				if (key.endsWith(':rate-limit')) return JSON.stringify({ retryUntil });
+				if (key.endsWith(':stale')) return JSON.stringify(retained);
+				return null;
+			}),
+			set: vi.fn(),
+			del: vi.fn(),
+			eval: vi.fn()
+		});
+		const compute = vi.fn(async () => snapshot());
+
+		const result = await getCachedPublicPrices(compute);
+		expect(result.value).toEqual(retained.value);
+		expect(result.isStale).toBe(true);
+		expect(compute).not.toHaveBeenCalled();
+	});
+
+	it('loads a retained Redis snapshot after a cold refresh failure', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:02:00Z'));
+		const retained = { value: snapshot(99), cachedAt: Date.now() - 91_000 };
+		const get = vi.fn(async (key: string) =>
+			key.endsWith(':stale') ? JSON.stringify(retained) : null
+		);
+		getKvMock.mockResolvedValue({
+			get,
+			set: vi.fn(async () => 'OK'),
+			del: vi.fn(),
+			eval: vi.fn()
+		});
+
+		const result = await getCachedPublicPrices(async () => {
+			throw new Error('upstream failed');
+		});
+
+		expect(result.value).toEqual(retained.value);
+		expect(result.isStale).toBe(true);
+	});
+
+	it('does not serve retained data beyond six hours', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		await getCachedPublicPrices(async () => snapshot());
+		vi.advanceTimersByTime(6 * 60 * 60 * 1_000 + 1);
+
+		await expect(
+			getCachedPublicPrices(async () => {
+				throw new Error('upstream failed');
+			})
+		).rejects.toThrow('upstream failed');
+	});
+
+	it('bounds HTTP caching by freshness, retry, and retained horizons', () => {
+		const cachedAt = Date.parse('2026-01-01T00:00:00Z');
+
+		expect(
+			publicPricesCacheControl(
+				{
+					value: snapshot(),
+					cachedAt,
+					isStale: false,
+					revalidateAt: cachedAt + 90_000
+				},
+				cachedAt
+			)
+		).toBe('public, s-maxage=90, stale-while-revalidate=270');
+
+		expect(
+			publicPricesCacheControl(
+				{
+					value: snapshot(),
+					cachedAt,
+					isStale: true,
+					revalidateAt: cachedAt + 151_000
+				},
+				cachedAt + 91_000
+			)
+		).toBe('public, s-maxage=60, must-revalidate');
+
+		expect(
+			publicPricesCacheControl(
+				{
+					value: snapshot(),
+					cachedAt,
+					isStale: true,
+					revalidateAt: cachedAt + 6 * 60 * 60 * 1_000 + 1_000
+				},
+				cachedAt + 6 * 60 * 60 * 1_000 + 1
+			)
+		).toBe('no-store');
 	});
 });

--- a/src/lib/server/publicPricesCache.ts
+++ b/src/lib/server/publicPricesCache.ts
@@ -1,47 +1,284 @@
 import {
-	PUBLIC_PRICES_REFRESH_INTERVAL_MS,
+	PUBLIC_PRICES_EDGE_STALE_SECONDS,
+	PUBLIC_PRICES_FAILURE_RETRY_SECONDS,
+	PUBLIC_PRICES_REFRESH_TIMEOUT_MS,
+	PUBLIC_PRICES_RETAINED_SECONDS,
 	PUBLIC_PRICES_TTL_SECONDS
 } from '$lib/config/publicPrices';
-import { CACHE_KEYS, withConditionalCache } from '$lib/server/cache';
+import { networks } from '$lib/config/network';
+import {
+	cacheCooldownRemainingMs,
+	cacheGet,
+	cacheSet,
+	cacheSetCooldown,
+	CACHE_KEYS,
+	withCache
+} from '$lib/server/cache';
+import { St0xMarketPricesRateLimitError } from '$lib/server/marketPrices';
+import type { MidpointPrice } from '$lib/utils/midpointPrice';
 
-interface MemoryEntry<T> {
-	value: T;
-	expiresAt: number;
+export interface PublicPricesSnapshot {
+	success: true;
+	prices: Record<string, Record<string, MidpointPrice>>;
 }
 
-let memoryEntry: MemoryEntry<unknown> | null = null;
+interface StoredPublicPrices {
+	value: PublicPricesSnapshot;
+	cachedAt: number;
+}
+
+export interface CachedPublicPrices {
+	value: PublicPricesSnapshot;
+	cachedAt: number;
+	isStale: boolean;
+	revalidateAt: number;
+}
+
+interface MemoryEntry extends StoredPublicPrices {
+	reuseUntil: number;
+	staleUntil: number;
+}
+
+let memoryEntry: MemoryEntry | null = null;
+let failureCooldown: { error: unknown; retryUntil: number } | null = null;
+const staleCacheKey = () => `${CACHE_KEYS.publicPrices()}:stale`;
+const rateLimitCacheKey = () => `${CACHE_KEYS.publicPrices()}:rate-limit`;
+const failureCacheKey = () => `${CACHE_KEYS.publicPrices()}:failure`;
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function isMidpointPrice(value: unknown): value is MidpointPrice {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const price = value as Partial<MidpointPrice>;
+	if (price.source === 'unavailable') {
+		return price.price === null && price.bid === null && price.ask === null && price.asOf === null;
+	}
+	if (price.source !== 'live' && price.source !== 'cached' && price.source !== 'historical') {
+		return false;
+	}
+	if (
+		!isPositiveFiniteNumber(price.price) ||
+		!isPositiveFiniteNumber(price.bid) ||
+		!isPositiveFiniteNumber(price.ask) ||
+		!isPositiveFiniteNumber(price.asOf)
+	) {
+		return false;
+	}
+	const midpoint = (price.bid + price.ask) / 2;
+	const tolerance = Number.EPSILON * Math.max(1, Math.abs(midpoint), Math.abs(price.price)) * 4;
+	return Math.abs(price.price - midpoint) <= tolerance;
+}
+
+function isCompleteSnapshot(value: unknown): value is PublicPricesSnapshot {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const snapshot = value as Partial<PublicPricesSnapshot>;
+	if (
+		snapshot.success !== true ||
+		!snapshot.prices ||
+		typeof snapshot.prices !== 'object' ||
+		Array.isArray(snapshot.prices)
+	) {
+		return false;
+	}
+
+	for (const network of networks) {
+		const networkPrices = snapshot.prices[String(network.id)];
+		if (!networkPrices || typeof networkPrices !== 'object' || Array.isArray(networkPrices)) {
+			return false;
+		}
+		for (const price of Object.values(networkPrices)) {
+			if (!isMidpointPrice(price)) return false;
+		}
+	}
+	return true;
+}
+
+function isStoredPublicPrices(value: unknown): value is StoredPublicPrices {
+	if (!value || typeof value !== 'object') return false;
+	const stored = value as Partial<StoredPublicPrices>;
+	return (
+		typeof stored.cachedAt === 'number' &&
+		Number.isFinite(stored.cachedAt) &&
+		stored.cachedAt > 0 &&
+		isCompleteSnapshot(stored.value)
+	);
+}
+
+function staleUntil(stored: StoredPublicPrices): number {
+	return stored.cachedAt + PUBLIC_PRICES_RETAINED_SECONDS * 1_000;
+}
+
+function asResult(entry: MemoryEntry, now: number): CachedPublicPrices {
+	return {
+		value: entry.value,
+		cachedAt: entry.cachedAt,
+		isStale: now >= entry.cachedAt + PUBLIC_PRICES_TTL_SECONDS * 1_000,
+		revalidateAt: entry.reuseUntil
+	};
+}
+
+function retryDelayMs(error: unknown): number {
+	if (error instanceof St0xMarketPricesRateLimitError && error.retryAfterMs !== null) {
+		return Math.max(1_000, error.retryAfterMs);
+	}
+	return PUBLIC_PRICES_FAILURE_RETRY_SECONDS * 1_000;
+}
+
+async function distributedRateLimitError(
+	now = Date.now()
+): Promise<St0xMarketPricesRateLimitError | null> {
+	const remainingMs = await cacheCooldownRemainingMs(rateLimitCacheKey(), now);
+	return remainingMs === null ? null : new St0xMarketPricesRateLimitError(remainingMs);
+}
+
+async function persistRateLimitCooldown(error: St0xMarketPricesRateLimitError): Promise<void> {
+	await cacheSetCooldown(rateLimitCacheKey(), retryDelayMs(error));
+}
+
+async function distributedFailureError(now = Date.now()): Promise<Error | null> {
+	const remainingMs = await cacheCooldownRemainingMs(failureCacheKey(), now);
+	return remainingMs === null
+		? null
+		: new Error('Public price refresh is cooling down after a failed attempt');
+}
+
+function retainForRetry(
+	stored: StoredPublicPrices,
+	now: number,
+	error: unknown
+): CachedPublicPrices {
+	const expiresAt = staleUntil(stored);
+	memoryEntry = {
+		...stored,
+		reuseUntil: Math.min(now + retryDelayMs(error), expiresAt),
+		staleUntil: expiresAt
+	};
+	return asResult(memoryEntry, now);
+}
+
+async function retainedPrices(
+	error: unknown,
+	failedAt: number
+): Promise<CachedPublicPrices | null> {
+	if (memoryEntry && memoryEntry.staleUntil > failedAt) {
+		return retainForRetry(memoryEntry, failedAt, error);
+	}
+
+	memoryEntry = null;
+	const retained = await cacheGet<StoredPublicPrices>(staleCacheKey());
+	return isStoredPublicPrices(retained) && staleUntil(retained) > failedAt
+		? retainForRetry(retained, failedAt, error)
+		: null;
+}
 
 /**
- * Cache public prices in Redis and in-process.
- *
- * Redis remains the cross-instance source of truth. The one-entry memory layer
- * prevents a missing or temporarily unavailable Redis connection from turning
- * every client poll into a duplicate authenticated REST price request.
+ * Cache complete price snapshots for 90 seconds and retain the last complete
+ * payload for six hours. A failed refresh never replaces either cache entry.
  */
-export async function getCachedPublicPrices<T>(
-	compute: () => Promise<T>,
-	shouldCache: (result: T) => boolean
-): Promise<T> {
+export async function getCachedPublicPrices(
+	compute: () => Promise<PublicPricesSnapshot>
+): Promise<CachedPublicPrices> {
 	const now = Date.now();
-	if (memoryEntry && memoryEntry.expiresAt > now) {
-		return memoryEntry.value as T;
+	if (failureCooldown && failureCooldown.retryUntil > now) {
+		throw failureCooldown.error;
+	}
+	failureCooldown = null;
+	if (memoryEntry && memoryEntry.reuseUntil > now) {
+		return asResult(memoryEntry, now);
+	}
+	const distributedCooldown =
+		(await distributedRateLimitError(now)) ?? (await distributedFailureError(now));
+	if (distributedCooldown) {
+		const retained = await retainedPrices(distributedCooldown, now);
+		if (retained) return retained;
+		failureCooldown = {
+			error: distributedCooldown,
+			retryUntil: now + retryDelayMs(distributedCooldown)
+		};
+		throw distributedCooldown;
 	}
 
-	const value = await withConditionalCache(
-		CACHE_KEYS.publicPrices(),
-		compute,
-		shouldCache,
-		PUBLIC_PRICES_TTL_SECONDS
-	);
-	if (shouldCache(value)) {
+	try {
+		const stored = await withCache(
+			CACHE_KEYS.publicPrices(),
+			async (): Promise<StoredPublicPrices> => {
+				const activeCooldown =
+					(await distributedRateLimitError()) ?? (await distributedFailureError());
+				if (activeCooldown) throw activeCooldown;
+				try {
+					const value = await compute();
+					if (!isCompleteSnapshot(value)) {
+						throw new Error('Public price computation did not return a complete snapshot');
+					}
+					return { value, cachedAt: Date.now() };
+				} catch (error) {
+					if (error instanceof St0xMarketPricesRateLimitError) {
+						await persistRateLimitCooldown(error);
+					} else {
+						await cacheSetCooldown(failureCacheKey(), PUBLIC_PRICES_FAILURE_RETRY_SECONDS * 1_000);
+					}
+					throw error;
+				}
+			},
+			PUBLIC_PRICES_TTL_SECONDS,
+			isStoredPublicPrices,
+			{
+				lockTtlMs: PUBLIC_PRICES_REFRESH_TIMEOUT_MS + 30_000,
+				waitTimeoutMs: PUBLIC_PRICES_REFRESH_TIMEOUT_MS + 5_000,
+				pollMs: 250
+			}
+		);
+		if (!isStoredPublicPrices(stored)) {
+			throw new Error('Public price cache contained an invalid snapshot');
+		}
+
+		const expiresAt = staleUntil(stored);
+		const retainedTtl = Math.floor((expiresAt - Date.now()) / 1_000);
 		memoryEntry = {
-			value,
-			expiresAt: Date.now() + PUBLIC_PRICES_REFRESH_INTERVAL_MS
+			...stored,
+			reuseUntil: stored.cachedAt + PUBLIC_PRICES_TTL_SECONDS * 1_000,
+			staleUntil: expiresAt
 		};
+		if (retainedTtl > 0) {
+			await cacheSet(staleCacheKey(), stored, retainedTtl);
+		}
+		failureCooldown = null;
+		return asResult(memoryEntry, Date.now());
+	} catch (error) {
+		const failedAt = Date.now();
+		const retained = await retainedPrices(error, failedAt);
+		if (retained) return retained;
+		failureCooldown = {
+			error,
+			retryUntil: failedAt + retryDelayMs(error)
+		};
+		throw error;
 	}
-	return value;
+}
+
+export function publicPricesCacheControl(cached: CachedPublicPrices, now = Date.now()): string {
+	const ageSeconds = Math.max(0, Math.floor((now - cached.cachedAt) / 1_000));
+	const retainedRemaining = PUBLIC_PRICES_RETAINED_SECONDS - ageSeconds;
+	if (retainedRemaining <= 0) return 'no-store';
+
+	const freshRemaining = PUBLIC_PRICES_TTL_SECONDS - ageSeconds;
+	if (!cached.isStale && freshRemaining > 0) {
+		const sharedTtl = Math.max(1, freshRemaining);
+		const edgeRemaining = PUBLIC_PRICES_TTL_SECONDS + PUBLIC_PRICES_EDGE_STALE_SECONDS - ageSeconds;
+		const staleWhileRevalidate = Math.max(
+			0,
+			Math.min(retainedRemaining, edgeRemaining) - sharedTtl
+		);
+		return `public, s-maxage=${sharedTtl}, stale-while-revalidate=${staleWhileRevalidate}`;
+	}
+
+	const retryRemaining = Math.max(1, Math.ceil((cached.revalidateAt - now) / 1_000));
+	return `public, s-maxage=${Math.min(retryRemaining, retainedRemaining)}, must-revalidate`;
 }
 
 export function clearPublicPricesMemoryCache(): void {
 	memoryEntry = null;
+	failureCooldown = null;
 }

--- a/src/lib/server/publicTradeActivity.test.ts
+++ b/src/lib/server/publicTradeActivity.test.ts
@@ -51,7 +51,7 @@ describe('public trade activity', () => {
 				trades: [firstTrade],
 				pagination: {
 					page: 1,
-					pageSize: 50,
+					pageSize: 500,
 					totalTrades: 2,
 					totalPages: 2,
 					hasMore: true
@@ -61,7 +61,7 @@ describe('public trade activity', () => {
 				trades: [secondTrade],
 				pagination: {
 					page: 2,
-					pageSize: 50,
+					pageSize: 500,
 					totalTrades: 2,
 					totalPages: 2,
 					hasMore: false
@@ -82,7 +82,7 @@ describe('public trade activity', () => {
 				startTime: range.from,
 				endTime: range.to,
 				page: 1,
-				pageSize: 50,
+				pageSize: 500,
 				denomination: 'wrapped'
 			})
 		);
@@ -101,7 +101,7 @@ describe('public trade activity', () => {
 			trades: [],
 			pagination: {
 				page: 1,
-				pageSize: 50,
+				pageSize: 500,
 				totalTrades: 0,
 				totalPages: 0,
 				hasMore: false
@@ -122,7 +122,7 @@ describe('public trade activity', () => {
 				trades: [trade('0x1', '0x1', '0x2', '1', '2')],
 				pagination: {
 					page: 1,
-					pageSize: 50,
+					pageSize: 500,
 					totalTrades: 51,
 					totalPages: 2,
 					hasMore: true
@@ -141,7 +141,7 @@ describe('public trade activity', () => {
 			trades: [trade('0x1', asset.address, quote.address, '2', '100')],
 			pagination: {
 				page: 1,
-				pageSize: 50,
+				pageSize: 500,
 				totalTrades: 1,
 				totalPages: 1,
 				hasMore: false

--- a/src/lib/server/publicTradeActivity.ts
+++ b/src/lib/server/publicTradeActivity.ts
@@ -7,8 +7,9 @@ import { normalizeAddress } from '$lib/utils/tokenMath';
 import { bucketTimestamp, TRADE_WINDOW_BUCKET_SECONDS } from '$lib/utils/timeWindow';
 
 const WINDOW_SECONDS = 30 * 24 * 60 * 60;
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 500;
 const MAX_PAGES = 1_000;
+export const PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS = 90_000;
 
 export interface TokenTradingRow {
 	address: string;

--- a/src/lib/server/publicTradeActivityCache.test.ts
+++ b/src/lib/server/publicTradeActivityCache.test.ts
@@ -14,6 +14,9 @@ import {
 	publicTradeActivityCacheControl
 } from '$lib/server/publicTradeActivityCache';
 import type { PublicTradeActivitySnapshot } from '$lib/server/publicTradeActivity';
+import { aggregateNetwork } from '$lib/server/publicTradeActivity';
+import { St0xTradesRateLimitError } from '$lib/server/st0xTradesFetcher';
+import { networks } from '$lib/config/network';
 
 function snapshot(
 	totalTrades = 0,
@@ -23,7 +26,31 @@ function snapshot(
 		success: true,
 		range: { from: to - 30 * 24 * 60 * 60, to },
 		totals: { tradingVolume: 0, totalTrades },
-		networks: []
+		networks: networks.map((network, index) => ({
+			...aggregateNetwork(network, []),
+			totalTrades: index === 0 ? totalTrades : 0
+		}))
+	};
+}
+
+function memoryRedis() {
+	const values = new Map<string, string>();
+	return {
+		values,
+		client: {
+			get: vi.fn(async (key: string) => values.get(key) ?? null),
+			set: vi.fn(async (key: string, value: string, options: { NX?: boolean }) => {
+				if (options.NX && values.has(key)) return null;
+				values.set(key, value);
+				return 'OK';
+			}),
+			del: vi.fn(async (key: string) => (values.delete(key) ? 1 : 0)),
+			eval: vi.fn(async (_script: string, options: { keys: string[] }) => {
+				const key = options.keys[0];
+				if (key) values.delete(key);
+				return 1;
+			})
+		}
 	};
 }
 
@@ -68,8 +95,13 @@ describe('public trade activity cache', () => {
 	it('anchors the primary Redis TTL to the snapshot window', async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-01-01T01:00:00Z'));
-		const set = vi.fn();
-		getKvMock.mockResolvedValue({ get: vi.fn(async () => null), set, del: vi.fn() });
+		const set = vi.fn(async () => 'OK');
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async () => null),
+			set,
+			del: vi.fn(),
+			eval: vi.fn()
+		});
 		const complete = snapshot(2, Math.floor(Date.now() / 1_000) - 120);
 
 		await getCachedPublicTradeActivity(async () => complete);
@@ -100,7 +132,12 @@ describe('public trade activity cache', () => {
 		const get = vi.fn(async (key: string) =>
 			key.endsWith(':stale') ? JSON.stringify(retained) : null
 		);
-		getKvMock.mockResolvedValue({ get, set: vi.fn(), del: vi.fn() });
+		getKvMock.mockResolvedValue({
+			get,
+			set: vi.fn(async () => 'OK'),
+			del: vi.fn(),
+			eval: vi.fn()
+		});
 		const compute = vi.fn(async () => {
 			throw new Error('upstream failed');
 		});
@@ -122,6 +159,155 @@ describe('public trade activity cache', () => {
 				throw new Error('upstream failed');
 			})
 		).rejects.toThrow('upstream failed');
+	});
+
+	it('suppresses repeated cold refreshes until the upstream Retry-After', async () => {
+		const error = new St0xTradesRateLimitError(120_000);
+		const compute = vi.fn(async () => {
+			throw error;
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toBe(error);
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toBe(error);
+
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('shares a cold Retry-After cooldown across website instances', async () => {
+		const { values, client } = memoryRedis();
+		getKvMock.mockResolvedValue(client);
+		const error = new St0xTradesRateLimitError(120_000);
+		const compute = vi.fn(async () => {
+			throw error;
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toBe(error);
+		clearPublicTradeActivityMemoryCache();
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toMatchObject({
+			name: 'St0xTradesRateLimitError',
+			retryAfterMs: expect.any(Number)
+		});
+
+		expect(compute).toHaveBeenCalledOnce();
+		expect(values.has('cache:public:trade-activity:rate-limit')).toBe(true);
+	});
+
+	it('shares generic cold failures across website instances', async () => {
+		const { values, client } = memoryRedis();
+		getKvMock.mockResolvedValue(client);
+		const compute = vi.fn(async () => {
+			throw new Error('upstream failed');
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toThrow('upstream failed');
+		clearPublicTradeActivityMemoryCache();
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toThrow(
+			'cooling down after a failed attempt'
+		);
+
+		expect(compute).toHaveBeenCalledOnce();
+		expect(values.has('cache:public:trade-activity:failure')).toBe(true);
+	});
+
+	it('suppresses repeated generic failures locally when Redis writes fail', async () => {
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async () => null),
+			set: vi.fn(async (_key: string, _value: string, options: { NX?: boolean } | undefined) => {
+				if (options?.NX) return 'OK';
+				throw new Error('Redis write failed');
+			}),
+			del: vi.fn(),
+			eval: vi.fn(async () => 1)
+		});
+		const compute = vi.fn(async () => {
+			throw new Error('upstream failed');
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toThrow('upstream failed');
+		await expect(getCachedPublicTradeActivity(compute)).rejects.toThrow('upstream failed');
+
+		expect(compute).toHaveBeenCalledOnce();
+	});
+
+	it('serves retained Redis data during a shared cooldown', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T01:00:01Z'));
+		const retained = snapshot(2, Math.floor(Date.now() / 1_000) - 60 * 60 - 1);
+		const retryUntil = Date.now() + 60_000;
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async (key: string) => {
+				if (key.endsWith(':rate-limit')) return JSON.stringify({ retryUntil });
+				if (key.endsWith(':stale')) return JSON.stringify(retained);
+				return null;
+			}),
+			set: vi.fn(),
+			del: vi.fn(),
+			eval: vi.fn()
+		});
+		const compute = vi.fn(async () => snapshot());
+
+		await expect(getCachedPublicTradeActivity(compute)).resolves.toEqual(retained);
+		expect(compute).not.toHaveBeenCalled();
+	});
+
+	it('rejects a partial retained snapshot', async () => {
+		const partial = { ...snapshot(), networks: [] };
+		getKvMock.mockResolvedValue({
+			get: vi.fn(async (key: string) => (key.endsWith(':stale') ? JSON.stringify(partial) : null)),
+			set: vi.fn(async () => 'OK'),
+			del: vi.fn(),
+			eval: vi.fn()
+		});
+
+		await expect(
+			getCachedPublicTradeActivity(async () => {
+				throw new Error('upstream failed');
+			})
+		).rejects.toThrow('upstream failed');
+	});
+
+	it('rejects retained snapshots with missing token rows or inconsistent totals', async () => {
+		const missingToken = snapshot();
+		const firstNetwork = missingToken.networks[0];
+		if (!firstNetwork) throw new Error('Expected a configured network');
+		firstNetwork.tokens = firstNetwork.tokens.slice(1);
+		const inconsistent = snapshot();
+		inconsistent.totals.totalTrades = 1;
+
+		for (const partial of [missingToken, inconsistent]) {
+			clearPublicTradeActivityMemoryCache();
+			getKvMock.mockResolvedValue({
+				get: vi.fn(async (key: string) =>
+					key.endsWith(':stale') ? JSON.stringify(partial) : null
+				),
+				set: vi.fn(async () => 'OK'),
+				del: vi.fn(),
+				eval: vi.fn()
+			});
+
+			await expect(
+				getCachedPublicTradeActivity(async () => {
+					throw new Error('upstream failed');
+				})
+			).rejects.toThrow('upstream failed');
+		}
+	});
+
+	it('retains stale data for the complete upstream Retry-After window', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		const complete = snapshot(2);
+		await getCachedPublicTradeActivity(async () => complete);
+		vi.advanceTimersByTime(60 * 60 * 1_000 + 1);
+		const compute = vi.fn(async () => {
+			throw new St0xTradesRateLimitError(120_000);
+		});
+
+		await expect(getCachedPublicTradeActivity(compute)).resolves.toEqual(complete);
+		vi.advanceTimersByTime(60_000);
+		await expect(getCachedPublicTradeActivity(compute)).resolves.toEqual(complete);
+
+		expect(compute).toHaveBeenCalledOnce();
 	});
 
 	it('bounds shared HTTP caching by the snapshot stale horizon', () => {

--- a/src/lib/server/publicTradeActivityCache.ts
+++ b/src/lib/server/publicTradeActivityCache.ts
@@ -1,9 +1,27 @@
-import type { PublicTradeActivitySnapshot } from '$lib/server/publicTradeActivity';
-import { cacheGet, cacheSet, CACHE_KEYS, CACHE_TTL, withCache } from '$lib/server/cache';
+import {
+	PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS,
+	type PublicTradeActivitySnapshot
+} from '$lib/server/publicTradeActivity';
+import { networks } from '$lib/config/network';
+import { getAllTokensByNetwork } from '$lib/config/tokens';
+import {
+	cacheCooldownRemainingMs,
+	cacheGet,
+	cacheSet,
+	cacheSetCooldown,
+	CACHE_KEYS,
+	CACHE_TTL,
+	withCache
+} from '$lib/server/cache';
+import { St0xTradesRateLimitError } from '$lib/server/st0xTradesFetcher';
 
 const STALE_TTL_SECONDS = CACHE_TTL.VERY_LONG;
 const STALE_RETRY_SECONDS = 60;
+const DISTRIBUTED_LOCK_TTL_MS = PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS + 30_000;
+const DISTRIBUTED_WAIT_TIMEOUT_MS = PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS + 5_000;
 const staleCacheKey = () => `${CACHE_KEYS.publicTradeActivity()}:stale`;
+const rateLimitCacheKey = () => `${CACHE_KEYS.publicTradeActivity()}:rate-limit`;
+const failureCacheKey = () => `${CACHE_KEYS.publicTradeActivity()}:failure`;
 
 interface MemoryEntry {
 	value: PublicTradeActivitySnapshot;
@@ -12,6 +30,128 @@ interface MemoryEntry {
 }
 
 let memoryEntry: MemoryEntry | null = null;
+let failureCooldown: { error: unknown; retryUntil: number } | null = null;
+
+function numbersMatch(left: number, right: number): boolean {
+	const tolerance = Number.EPSILON * Math.max(1, Math.abs(left), Math.abs(right)) * 16;
+	return Math.abs(left - right) <= tolerance;
+}
+
+function isCompleteSnapshot(value: unknown): value is PublicTradeActivitySnapshot {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const snapshot = value as Partial<PublicTradeActivitySnapshot>;
+	if (
+		snapshot.success !== true ||
+		typeof snapshot.range?.from !== 'number' ||
+		!Number.isFinite(snapshot.range.from) ||
+		typeof snapshot.range.to !== 'number' ||
+		!Number.isFinite(snapshot.range.to) ||
+		snapshot.range.from > snapshot.range.to ||
+		typeof snapshot.totals?.tradingVolume !== 'number' ||
+		!Number.isFinite(snapshot.totals.tradingVolume) ||
+		snapshot.totals.tradingVolume < 0 ||
+		typeof snapshot.totals.totalTrades !== 'number' ||
+		!Number.isSafeInteger(snapshot.totals.totalTrades) ||
+		snapshot.totals.totalTrades < 0 ||
+		!Array.isArray(snapshot.networks) ||
+		snapshot.networks.length !== networks.length
+	) {
+		return false;
+	}
+
+	const expectedNetworks = new Map(networks.map((network) => [network.id, network.chainId]));
+	const seenNetworks = new Set<number>();
+	let summedTradingVolume = 0;
+	let summedTotalTrades = 0;
+	for (const entry of snapshot.networks) {
+		const expectedChainId = expectedNetworks.get(entry.networkId);
+		if (
+			!Number.isSafeInteger(entry.networkId) ||
+			expectedChainId !== entry.chainId ||
+			seenNetworks.has(entry.networkId) ||
+			!Number.isFinite(entry.tradingVolume) ||
+			entry.tradingVolume < 0 ||
+			!Number.isSafeInteger(entry.totalTrades) ||
+			entry.totalTrades < 0 ||
+			!Array.isArray(entry.tokens)
+		) {
+			return false;
+		}
+		seenNetworks.add(entry.networkId);
+		summedTradingVolume += entry.tradingVolume;
+		summedTotalTrades += entry.totalTrades;
+		const expectedTokenAddresses = new Set(
+			getAllTokensByNetwork(expectedChainId).map((token) => token.address.toLowerCase())
+		);
+		const seenTokenAddresses = new Set<string>();
+		for (const token of entry.tokens) {
+			if (
+				!/^0x[0-9a-f]{40}$/.test(token.address) ||
+				!expectedTokenAddresses.has(token.address) ||
+				seenTokenAddresses.has(token.address) ||
+				!Number.isFinite(token.inVolume) ||
+				token.inVolume < 0 ||
+				!Number.isFinite(token.outVolume) ||
+				token.outVolume < 0 ||
+				!Number.isFinite(token.totalVolume) ||
+				token.totalVolume < 0 ||
+				!Number.isFinite(token.quoteVolume) ||
+				token.quoteVolume < 0 ||
+				!Number.isSafeInteger(token.trades) ||
+				token.trades < 0
+			) {
+				return false;
+			}
+			if (!numbersMatch(token.totalVolume, token.inVolume + token.outVolume)) return false;
+			seenTokenAddresses.add(token.address);
+		}
+		if (seenTokenAddresses.size !== expectedTokenAddresses.size) return false;
+	}
+	return (
+		seenNetworks.size === expectedNetworks.size &&
+		numbersMatch(snapshot.totals.tradingVolume, summedTradingVolume) &&
+		snapshot.totals.totalTrades === summedTotalTrades
+	);
+}
+
+function retryDelayMs(error: unknown): number {
+	if (error instanceof St0xTradesRateLimitError && error.retryAfterMs !== null) {
+		return Math.max(1_000, error.retryAfterMs);
+	}
+	return STALE_RETRY_SECONDS * 1_000;
+}
+
+async function distributedRateLimitError(
+	now = Date.now()
+): Promise<St0xTradesRateLimitError | null> {
+	const remainingMs = await cacheCooldownRemainingMs(rateLimitCacheKey(), now);
+	return remainingMs === null ? null : new St0xTradesRateLimitError(remainingMs);
+}
+
+async function persistRateLimitCooldown(error: St0xTradesRateLimitError): Promise<void> {
+	await cacheSetCooldown(rateLimitCacheKey(), retryDelayMs(error));
+}
+
+async function distributedFailureError(now = Date.now()): Promise<Error | null> {
+	const remainingMs = await cacheCooldownRemainingMs(failureCacheKey(), now);
+	return remainingMs === null
+		? null
+		: new Error('Public trade activity refresh is cooling down after a failed attempt');
+}
+
+async function retainedSnapshot(
+	error: unknown,
+	failedAt: number
+): Promise<PublicTradeActivitySnapshot | null> {
+	if (memoryEntry && memoryEntry.staleUntil > failedAt) {
+		return retainForRetry(memoryEntry.value, failedAt, memoryEntry.staleUntil, error);
+	}
+	memoryEntry = null;
+	const retained = await cacheGet<PublicTradeActivitySnapshot>(staleCacheKey());
+	if (!isCompleteSnapshot(retained)) return null;
+	const staleUntil = snapshotExpiresAt(retained, STALE_TTL_SECONDS);
+	return staleUntil > failedAt ? retainForRetry(retained, failedAt, staleUntil, error) : null;
+}
 
 function snapshotExpiresAt(snapshot: PublicTradeActivitySnapshot, ttlSeconds: number): number {
 	return snapshot.range.to * 1_000 + ttlSeconds * 1_000;
@@ -24,11 +164,12 @@ function snapshotTtlSeconds(snapshot: PublicTradeActivitySnapshot, ttlSeconds: n
 function retainForRetry(
 	value: PublicTradeActivitySnapshot,
 	now: number,
-	staleUntil: number
+	staleUntil: number,
+	error: unknown
 ): PublicTradeActivitySnapshot {
 	memoryEntry = {
 		value,
-		reuseUntil: Math.min(now + STALE_RETRY_SECONDS * 1_000, staleUntil),
+		reuseUntil: Math.min(now + retryDelayMs(error), staleUntil),
 		staleUntil
 	};
 	return value;
@@ -62,14 +203,54 @@ export async function getCachedPublicTradeActivity(
 	compute: () => Promise<PublicTradeActivitySnapshot>
 ): Promise<PublicTradeActivitySnapshot> {
 	const now = Date.now();
+	if (failureCooldown && failureCooldown.retryUntil > now) {
+		throw failureCooldown.error;
+	}
+	failureCooldown = null;
 	if (memoryEntry && memoryEntry.reuseUntil > now) {
 		return memoryEntry.value;
 	}
+	const distributedCooldown =
+		(await distributedRateLimitError(now)) ?? (await distributedFailureError(now));
+	if (distributedCooldown) {
+		const retained = await retainedSnapshot(distributedCooldown, now);
+		if (retained) return retained;
+		failureCooldown = {
+			error: distributedCooldown,
+			retryUntil: now + retryDelayMs(distributedCooldown)
+		};
+		throw distributedCooldown;
+	}
 
 	try {
-		const value = await withCache(CACHE_KEYS.publicTradeActivity(), compute, (snapshot) =>
-			snapshotTtlSeconds(snapshot, CACHE_TTL.LONG)
+		const value = await withCache(
+			CACHE_KEYS.publicTradeActivity(),
+			async () => {
+				const activeCooldown =
+					(await distributedRateLimitError()) ?? (await distributedFailureError());
+				if (activeCooldown) throw activeCooldown;
+				try {
+					return await compute();
+				} catch (error) {
+					if (error instanceof St0xTradesRateLimitError) {
+						await persistRateLimitCooldown(error);
+					} else {
+						await cacheSetCooldown(failureCacheKey(), STALE_RETRY_SECONDS * 1_000);
+					}
+					throw error;
+				}
+			},
+			(snapshot) => snapshotTtlSeconds(snapshot, CACHE_TTL.LONG),
+			isCompleteSnapshot,
+			{
+				lockTtlMs: DISTRIBUTED_LOCK_TTL_MS,
+				waitTimeoutMs: DISTRIBUTED_WAIT_TIMEOUT_MS,
+				pollMs: 250
+			}
 		);
+		if (!isCompleteSnapshot(value)) {
+			throw new Error('Public trade activity computation did not return a complete snapshot');
+		}
 		const staleUntil = snapshotExpiresAt(value, STALE_TTL_SECONDS);
 		const retainedTtl = snapshotTtlSeconds(value, STALE_TTL_SECONDS);
 		memoryEntry = {
@@ -80,24 +261,21 @@ export async function getCachedPublicTradeActivity(
 		if (retainedTtl > 0) {
 			await cacheSet(staleCacheKey(), value, retainedTtl);
 		}
+		failureCooldown = null;
 		return value;
 	} catch (error) {
 		const failedAt = Date.now();
-		if (memoryEntry && memoryEntry.staleUntil > failedAt) {
-			return retainForRetry(memoryEntry.value, failedAt, memoryEntry.staleUntil);
-		}
-		memoryEntry = null;
-		const retained = await cacheGet<PublicTradeActivitySnapshot>(staleCacheKey());
-		if (retained !== null) {
-			const staleUntil = snapshotExpiresAt(retained, STALE_TTL_SECONDS);
-			if (staleUntil > failedAt) {
-				return retainForRetry(retained, failedAt, staleUntil);
-			}
-		}
+		const retained = await retainedSnapshot(error, failedAt);
+		if (retained) return retained;
+		failureCooldown = {
+			error,
+			retryUntil: failedAt + retryDelayMs(error)
+		};
 		throw error;
 	}
 }
 
 export function clearPublicTradeActivityMemoryCache(): void {
 	memoryEntry = null;
+	failureCooldown = null;
 }

--- a/src/lib/server/st0xApiConfig.test.ts
+++ b/src/lib/server/st0xApiConfig.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { getSt0xActivityApiConfig, getSt0xPricesApiConfig } from '$lib/server/st0xApiConfig';
+
+describe('getSt0xPricesApiConfig', () => {
+	it('prefers the dedicated price credential', () => {
+		expect(
+			getSt0xPricesApiConfig({
+				ST0X_API_URL: 'https://api.example.test/',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret',
+				ST0X_PRICES_API_KEY: 'prices-key',
+				ST0X_PRICES_API_SECRET: 'prices-secret'
+			})
+		).toEqual({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic cHJpY2VzLWtleTpwcmljZXMtc2VjcmV0',
+			credentialLabel: 'prices'
+		});
+	});
+
+	it('falls back to the general credential during deployment rollout', () => {
+		expect(
+			getSt0xPricesApiConfig({
+				ST0X_API_URL: 'https://api.example.test',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret'
+			})
+		).toMatchObject({ credentialLabel: 'general' });
+	});
+
+	it('rejects a partially configured dedicated credential pair', () => {
+		expect(
+			getSt0xPricesApiConfig({
+				ST0X_API_URL: 'https://api.example.test',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret',
+				ST0X_PRICES_API_KEY: 'prices-key'
+			})
+		).toBeNull();
+	});
+});
+
+describe('getSt0xActivityApiConfig', () => {
+	it('prefers the dedicated activity credential', () => {
+		expect(
+			getSt0xActivityApiConfig({
+				ST0X_API_URL: 'https://api.example.test/',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret',
+				ST0X_ACTIVITY_API_KEY: 'activity-key',
+				ST0X_ACTIVITY_API_SECRET: 'activity-secret'
+			})
+		).toEqual({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic YWN0aXZpdHkta2V5OmFjdGl2aXR5LXNlY3JldA==',
+			credentialLabel: 'activity'
+		});
+	});
+
+	it('falls back to the general credential only when both activity values are absent', () => {
+		expect(
+			getSt0xActivityApiConfig({
+				ST0X_API_URL: 'https://api.example.test',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret'
+			})
+		).toMatchObject({ credentialLabel: 'general' });
+	});
+
+	it('rejects a partially configured activity credential pair', () => {
+		expect(
+			getSt0xActivityApiConfig({
+				ST0X_API_URL: 'https://api.example.test',
+				ST0X_API_KEY: 'general-key',
+				ST0X_API_SECRET: 'general-secret',
+				ST0X_ACTIVITY_API_SECRET: 'activity-secret'
+			})
+		).toBeNull();
+	});
+});

--- a/src/lib/server/st0xApiConfig.ts
+++ b/src/lib/server/st0xApiConfig.ts
@@ -1,0 +1,74 @@
+import type { St0xCredentialLabel } from '$lib/types/st0x';
+
+export interface St0xApiConfig {
+	apiBase: string;
+	authHeader: string;
+	credentialLabel: St0xCredentialLabel;
+}
+
+type St0xEnvironment = Record<string, string | undefined>;
+
+function basicAuth(key: string, secret: string): string {
+	return 'Basic ' + btoa(`${key}:${secret}`);
+}
+
+function getDedicatedApiConfig(
+	environment: St0xEnvironment,
+	keyName: string,
+	secretName: string,
+	credentialLabel: Exclude<St0xCredentialLabel, 'general'>
+): St0xApiConfig | null {
+	const url = environment.ST0X_API_URL;
+	if (!url) return null;
+
+	const dedicatedKey = environment[keyName];
+	const dedicatedSecret = environment[secretName];
+	if (dedicatedKey || dedicatedSecret) {
+		if (!dedicatedKey || !dedicatedSecret) return null;
+		return {
+			apiBase: url.replace(/\/+$/, ''),
+			authHeader: basicAuth(dedicatedKey, dedicatedSecret),
+			credentialLabel
+		};
+	}
+
+	const key = environment.ST0X_API_KEY;
+	const secret = environment.ST0X_API_SECRET;
+	if (!key || !secret) return null;
+	return {
+		apiBase: url.replace(/\/+$/, ''),
+		authHeader: basicAuth(key, secret),
+		credentialLabel: 'general'
+	};
+}
+
+/**
+ * Resolve the dedicated public-price credential when configured.
+ *
+ * A partially configured dedicated pair is rejected instead of mixing it with
+ * the general credential. The general pair remains a deployment-compatible
+ * fallback while operators roll out the isolated price budget.
+ */
+export function getSt0xPricesApiConfig(environment: St0xEnvironment): St0xApiConfig | null {
+	return getDedicatedApiConfig(
+		environment,
+		'ST0X_PRICES_API_KEY',
+		'ST0X_PRICES_API_SECRET',
+		'prices'
+	);
+}
+
+/**
+ * Resolve the dedicated public-activity credential when configured.
+ *
+ * Activity pagination has a separate budget so a cold 30-day refresh cannot
+ * consume the browser proxy or global-orderbook allowance.
+ */
+export function getSt0xActivityApiConfig(environment: St0xEnvironment): St0xApiConfig | null {
+	return getDedicatedApiConfig(
+		environment,
+		'ST0X_ACTIVITY_API_KEY',
+		'ST0X_ACTIVITY_API_SECRET',
+		'activity'
+	);
+}

--- a/src/lib/server/st0xBudgetTelemetry.test.ts
+++ b/src/lib/server/st0xBudgetTelemetry.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { info, warn } = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn()
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	getLogger: () => ({ info, warn })
+}));
+
+import { logSt0xRequestBudget } from '$lib/server/st0xBudgetTelemetry';
+
+describe('logSt0xRequestBudget', () => {
+	beforeEach(() => {
+		info.mockReset();
+		warn.mockReset();
+	});
+
+	it('labels successful upstream budget telemetry by endpoint and credential', () => {
+		logSt0xRequestBudget(
+			'v1/orders/query',
+			'prices',
+			new Response(null, {
+				status: 200,
+				headers: {
+					'X-RateLimit-Remaining': '59',
+					'X-RateLimit-Reset': '123'
+				}
+			})
+		);
+
+		expect(info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'st0x_request_budget',
+				upstream_endpoint: 'v1/orders/query',
+				credential_label: 'prices',
+				remaining: '59'
+			}),
+			'st0x request budget'
+		);
+	});
+
+	it('warns on 429 even when the upstream omits budget headers', () => {
+		logSt0xRequestBudget('v1/trades/query', 'general', new Response(null, { status: 429 }));
+
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				upstream_endpoint: 'v1/trades/query',
+				credential_label: 'general',
+				status: 429
+			}),
+			'st0x request budget exhausted'
+		);
+	});
+});

--- a/src/lib/server/st0xBudgetTelemetry.ts
+++ b/src/lib/server/st0xBudgetTelemetry.ts
@@ -1,0 +1,30 @@
+import { getLogger } from '$lib/server/logger';
+import type { St0xCredentialLabel } from '$lib/types/st0x';
+
+/**
+ * Record the upstream budget headers without logging credential material.
+ * Successful responses without budget headers stay quiet.
+ */
+export function logSt0xRequestBudget(
+	endpoint: string,
+	credentialLabel: St0xCredentialLabel,
+	response: Response
+): void {
+	const remaining = response.headers.get('X-RateLimit-Remaining');
+	const reset = response.headers.get('X-RateLimit-Reset');
+	if (!remaining && !reset && response.status !== 429) return;
+
+	const fields = {
+		event: 'st0x_request_budget',
+		upstream_endpoint: endpoint,
+		credential_label: credentialLabel,
+		status: response.status,
+		remaining,
+		reset
+	};
+	if (response.status === 429) {
+		getLogger().warn(fields, 'st0x request budget exhausted');
+	} else {
+		getLogger().info(fields, 'st0x request budget');
+	}
+}

--- a/src/lib/server/st0xTradesFetcher.test.ts
+++ b/src/lib/server/st0xTradesFetcher.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createServerTradesQueryFetcher } from '$lib/server/st0xTradesFetcher';
+import {
+	createServerTradesQueryFetcher,
+	St0xTradesRateLimitError
+} from '$lib/server/st0xTradesFetcher';
 
 describe('createServerTradesQueryFetcher', () => {
 	it('posts an authenticated token-set query', async () => {
@@ -66,5 +69,29 @@ describe('createServerTradesQueryFetcher', () => {
 				endTime: 2_000
 			})
 		).rejects.toThrow('Batch trades fetch failed (502)');
+	});
+
+	it('preserves Retry-After and suppresses later requests after a 429', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 429, headers: { 'Retry-After': '60' } }));
+		const fetchTrades = createServerTradesQueryFetcher({
+			apiBase: 'https://api.example.test',
+			authHeader: 'Basic credentials',
+			fetchFn: fetchMock as unknown as typeof fetch
+		});
+		const request = {
+			chainId: 8453,
+			tokenAddresses: ['0xabc'],
+			startTime: 1_000,
+			endTime: 2_000
+		};
+
+		await expect(fetchTrades(request)).rejects.toMatchObject({
+			name: 'St0xTradesRateLimitError',
+			retryAfterMs: 60_000
+		} satisfies Partial<St0xTradesRateLimitError>);
+		await expect(fetchTrades(request)).rejects.toBeInstanceOf(St0xTradesRateLimitError);
+		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 });

--- a/src/lib/server/st0xTradesFetcher.ts
+++ b/src/lib/server/st0xTradesFetcher.ts
@@ -1,4 +1,7 @@
 import type { ApiTradesByAddressResponse, ApiTradesTokensQueryRequest } from '$lib/api/st0xApi';
+import { parseRetryAfterMs } from '$lib/clients/http';
+import { logSt0xRequestBudget } from '$lib/server/st0xBudgetTelemetry';
+import type { St0xCredentialLabel } from '$lib/types/st0x';
 
 export type ServerTradesQueryFetcher = (
 	request: ApiTradesTokensQueryRequest
@@ -9,28 +12,67 @@ interface ServerTradesFetcherOptions {
 	authHeader: string;
 	fetchFn?: typeof fetch;
 	timeoutMs?: number;
+	credentialLabel?: St0xCredentialLabel;
+	signal?: AbortSignal;
+}
+
+export class St0xTradesRateLimitError extends Error {
+	readonly retryAfterMs: number | null;
+
+	constructor(retryAfterMs: number | null = null, message = 'ST0x trades API rate limit reached') {
+		super(message);
+		this.name = 'St0xTradesRateLimitError';
+		this.retryAfterMs = retryAfterMs;
+	}
 }
 
 export function createServerTradesQueryFetcher({
 	apiBase,
 	authHeader,
 	fetchFn = fetch,
-	timeoutMs = 15_000
+	timeoutMs = 15_000,
+	credentialLabel = 'general',
+	signal
 }: ServerTradesFetcherOptions): ServerTradesQueryFetcher {
+	let rateLimitError: St0xTradesRateLimitError | null = null;
+
 	return async (request) => {
-		const response = await fetchFn(`${apiBase}/v1/trades/query`, {
-			method: 'POST',
-			headers: {
-				Authorization: authHeader,
-				Accept: 'application/json',
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify(request),
-			signal: AbortSignal.timeout(timeoutMs)
-		});
-		if (!response.ok) {
-			throw new Error(`Batch trades fetch failed (${response.status})`);
+		if (rateLimitError) throw rateLimitError;
+
+		const requestController = new AbortController();
+		const forwardAbort = () => requestController.abort(signal?.reason);
+		if (signal?.aborted) {
+			forwardAbort();
+		} else {
+			signal?.addEventListener('abort', forwardAbort, { once: true });
 		}
-		return (await response.json()) as ApiTradesByAddressResponse;
+		const timeout = setTimeout(() => requestController.abort(), timeoutMs);
+
+		try {
+			const response = await fetchFn(`${apiBase}/v1/trades/query`, {
+				method: 'POST',
+				headers: {
+					Authorization: authHeader,
+					Accept: 'application/json',
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(request),
+				signal: requestController.signal
+			});
+			logSt0xRequestBudget('v1/trades/query', credentialLabel, response);
+			if (response.status === 429) {
+				rateLimitError = new St0xTradesRateLimitError(
+					parseRetryAfterMs(response.headers.get('Retry-After'))
+				);
+				throw rateLimitError;
+			}
+			if (!response.ok) {
+				throw new Error(`Batch trades fetch failed (${response.status})`);
+			}
+			return (await response.json()) as ApiTradesByAddressResponse;
+		} finally {
+			clearTimeout(timeout);
+			signal?.removeEventListener('abort', forwardAbort);
+		}
 	};
 }

--- a/src/lib/types/st0x.ts
+++ b/src/lib/types/st0x.ts
@@ -1,0 +1,1 @@
+export type St0xCredentialLabel = 'general' | 'prices' | 'activity';

--- a/src/lib/utils/monitoring.ts
+++ b/src/lib/utils/monitoring.ts
@@ -19,6 +19,7 @@ export interface QueryFailureEvent {
 	endpoint?: string;
 	itemsKey?: string;
 	network?: string;
+	credentialLabel?: St0xCredentialLabel;
 	attempt?: number;
 	maxAttempts?: number;
 	skip?: number;
@@ -48,3 +49,4 @@ export function logQueryFailure(event: QueryFailureEvent): void {
 export function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
+import type { St0xCredentialLabel } from '$lib/types/st0x';

--- a/src/routes/api/public/prices/+server.ts
+++ b/src/routes/api/public/prices/+server.ts
@@ -6,20 +6,29 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { rateLimiters, getClientIp } from '$lib/server/rateLimit';
-import { PUBLIC_PRICES_CACHE_CONTROL } from '$lib/config/publicPrices';
-import { getCachedPublicPrices } from '$lib/server/publicPricesCache';
+import { PUBLIC_PRICES_FAILURE_RETRY_SECONDS } from '$lib/config/publicPrices';
+import {
+	getCachedPublicPrices,
+	publicPricesCacheControl,
+	type PublicPricesSnapshot
+} from '$lib/server/publicPricesCache';
 import { networks } from '$lib/config/network';
-import { fetchMarketPrices, toWebsiteMarketPrices } from '$lib/server/marketPrices';
+import {
+	fetchMarketPrices,
+	St0xMarketPricesRateLimitError,
+	toWebsiteMarketPrices
+} from '$lib/server/marketPrices';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
 
-export interface PublicPricesResponse {
-	success: boolean;
-	/** networkId (stringified) -> lowercased canonical token address -> price. */
-	prices: Record<string, Record<string, MidpointPrice>>;
-}
+export type PublicPricesResponse =
+	| PublicPricesSnapshot
+	| {
+			success: false;
+			prices: Record<string, Record<string, MidpointPrice>>;
+	  };
 
-async function computePrices(): Promise<PublicPricesResponse> {
+async function computePrices(): Promise<PublicPricesSnapshot> {
 	const entries = await Promise.all(
 		networks.map(async (network) => {
 			try {
@@ -59,17 +68,27 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
-		const data = await getCachedPublicPrices<PublicPricesResponse>(
-			computePrices,
-			(result) => result.success
-		);
+		const cached = await getCachedPublicPrices(computePrices);
 
-		return json(data, {
+		return json(cached.value, {
 			headers: {
-				'Cache-Control': PUBLIC_PRICES_CACHE_CONTROL
+				'Cache-Control': publicPricesCacheControl(cached)
 			}
 		});
 	} catch (error) {
+		if (error instanceof St0xMarketPricesRateLimitError) {
+			const retryAfterSeconds = Math.max(
+				1,
+				Math.ceil((error.retryAfterMs ?? PUBLIC_PRICES_FAILURE_RETRY_SECONDS * 1_000) / 1_000)
+			);
+			return json({ success: false, prices: {} } satisfies PublicPricesResponse, {
+				status: 429,
+				headers: {
+					'Retry-After': String(retryAfterSeconds),
+					'Cache-Control': 'no-store'
+				}
+			});
+		}
 		console.error('[Public Prices] Error:', error);
 		return json({ success: false, prices: {} } satisfies PublicPricesResponse, { status: 500 });
 	}

--- a/src/routes/api/public/prices/server.test.ts
+++ b/src/routes/api/public/prices/server.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {}
+}));
+
+vi.mock('$lib/server/rateLimit', () => ({
+	getClientIp: () => '127.0.0.1',
+	rateLimiters: {
+		publicApi: vi.fn(async () => ({
+			allowed: true,
+			remaining: 99,
+			resetAt: Date.now() + 60_000
+		}))
+	}
+}));
+
+vi.mock('$lib/server/kv', () => ({
+	getKv: vi.fn(async () => null),
+	kvGet: vi.fn(async () => null),
+	kvSet: vi.fn(async () => undefined),
+	KV_KEYS: {
+		midpointLastKnown: (networkId: number) => `midpoint:${networkId}`
+	}
+}));
+
+import { env } from '$env/dynamic/private';
+import { networks } from '$lib/config/network';
+import { clearPublicPricesMemoryCache } from '$lib/server/publicPricesCache';
+import { GET } from './+server';
+
+type PricesEvent = Parameters<typeof GET>[0];
+
+describe('/api/public/prices', () => {
+	beforeEach(() => {
+		clearPublicPricesMemoryCache();
+		env.ST0X_API_URL = 'https://api.example.test/';
+		env.ST0X_API_KEY = 'general-key';
+		env.ST0X_API_SECRET = 'general-secret';
+		env.ST0X_PRICES_API_KEY = 'prices-key';
+		env.ST0X_PRICES_API_SECRET = 'prices-secret';
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('uses the dedicated credential for one batch stream per network', async () => {
+		const fetchMock = vi.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: []
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET({
+			request: new Request('http://localhost/api/public/prices')
+		} as PricesEvent);
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(networks.length);
+		for (const [url, init] of fetchMock.mock.calls) {
+			expect(String(url)).toMatch(/^https:\/\/api\.example\.test\/v1\/prices\?chainId=\d+$/);
+			if (!init) throw new Error('Expected batch request options');
+			const headers = init.headers as Record<string, string>;
+			expect(headers.Authorization).toBe('Basic cHJpY2VzLWtleTpwcmljZXMtc2VjcmV0');
+			expect(headers.Authorization).not.toBe('Basic Z2VuZXJhbC1rZXk6Z2VuZXJhbC1zZWNyZXQ=');
+		}
+	});
+
+	it('preserves a cold 429 and suppresses upstream retries until Retry-After', async () => {
+		const fetchMock = vi
+			.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>()
+			.mockResolvedValue(
+				new Response(null, {
+					status: 429,
+					headers: { 'Retry-After': '60' }
+				})
+			);
+		vi.stubGlobal('fetch', fetchMock);
+		const event = {
+			request: new Request('http://localhost/api/public/prices')
+		} as PricesEvent;
+
+		const first = await GET(event);
+		const second = await GET(event);
+
+		expect(first.status).toBe(429);
+		expect(first.headers.get('Retry-After')).toBe('60');
+		expect(first.headers.get('Cache-Control')).toBe('no-store');
+		expect(second.status).toBe(429);
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+});

--- a/src/routes/api/public/trade-activity/+server.ts
+++ b/src/routes/api/public/trade-activity/+server.ts
@@ -3,6 +3,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
 	computePublicTradeActivity,
+	PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS,
 	type PublicTradeActivityResponse,
 	type PublicTradeActivitySnapshot,
 	tradeActivityWindow
@@ -12,7 +13,11 @@ import {
 	publicTradeActivityCacheControl
 } from '$lib/server/publicTradeActivityCache';
 import { rateLimiters, getClientIp } from '$lib/server/rateLimit';
-import { createServerTradesQueryFetcher } from '$lib/server/st0xTradesFetcher';
+import {
+	createServerTradesQueryFetcher,
+	St0xTradesRateLimitError
+} from '$lib/server/st0xTradesFetcher';
+import { getSt0xActivityApiConfig } from '$lib/server/st0xApiConfig';
 
 export type {
 	NetworkTradeStats,
@@ -20,22 +25,29 @@ export type {
 	TokenTradingRow
 } from '$lib/server/publicTradeActivity';
 
-function getApiConfig(): { apiBase: string; authHeader: string } {
-	const url = env.ST0X_API_URL;
-	const key = env.ST0X_API_KEY;
-	const secret = env.ST0X_API_SECRET;
-	if (!url || !key || !secret) {
-		throw new Error('REST API not configured');
-	}
-	return {
-		apiBase: url.replace(/\/+$/, ''),
-		authHeader: 'Basic ' + btoa(`${key}:${secret}`)
-	};
-}
-
 async function computeTradeActivity(): Promise<PublicTradeActivitySnapshot> {
-	const fetchTrades = createServerTradesQueryFetcher(getApiConfig());
-	return computePublicTradeActivity(fetchTrades);
+	const config = getSt0xActivityApiConfig(env);
+	if (!config) {
+		throw new Error('ST0x public-activity API credentials are not configured');
+	}
+	const controller = new AbortController();
+	const fetchTrades = createServerTradesQueryFetcher({ ...config, signal: controller.signal });
+	let refreshTimeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const refresh = computePublicTradeActivity(fetchTrades);
+		const deadline = new Promise<never>((_, reject) => {
+			refreshTimeout = setTimeout(() => {
+				controller.abort();
+				reject(new Error('Public trade activity refresh exceeded its overall deadline'));
+			}, PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS);
+		});
+		return await Promise.race([refresh, deadline]);
+	} catch (error) {
+		controller.abort();
+		throw error;
+	} finally {
+		if (refreshTimeout) clearTimeout(refreshTimeout);
+	}
 }
 
 export const GET: RequestHandler = async ({ request }) => {
@@ -64,6 +76,25 @@ export const GET: RequestHandler = async ({ request }) => {
 			}
 		});
 	} catch (error) {
+		if (error instanceof St0xTradesRateLimitError) {
+			const retryAfterSeconds = Math.max(1, Math.ceil((error.retryAfterMs ?? 60_000) / 1_000));
+			const now = Math.floor(Date.now() / 1_000);
+			return json(
+				{
+					success: false,
+					range: tradeActivityWindow(now),
+					totals: { tradingVolume: 0, totalTrades: 0 },
+					networks: []
+				} satisfies PublicTradeActivityResponse,
+				{
+					status: 429,
+					headers: {
+						'Retry-After': String(retryAfterSeconds),
+						'Cache-Control': 'no-store'
+					}
+				}
+			);
+		}
 		console.error('[Public TradeActivity] Error:', error);
 		const now = Math.floor(Date.now() / 1000);
 		const range = tradeActivityWindow(now);

--- a/src/routes/api/public/trade-activity/server.test.ts
+++ b/src/routes/api/public/trade-activity/server.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {}
+}));
+
+vi.mock('$lib/server/rateLimit', () => ({
+	getClientIp: () => '127.0.0.1',
+	rateLimiters: {
+		publicApi: vi.fn(async () => ({
+			allowed: true,
+			remaining: 99,
+			resetAt: Date.now() + 60_000
+		}))
+	}
+}));
+
+vi.mock('$lib/server/kv', () => ({
+	getKv: vi.fn(async () => null)
+}));
+
+import { env } from '$env/dynamic/private';
+import { PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS } from '$lib/server/publicTradeActivity';
+import { clearPublicTradeActivityMemoryCache } from '$lib/server/publicTradeActivityCache';
+import { GET } from './+server';
+
+type TradeActivityEvent = Parameters<typeof GET>[0];
+
+describe('/api/public/trade-activity', () => {
+	beforeEach(() => {
+		clearPublicTradeActivityMemoryCache();
+		env.ST0X_API_URL = 'https://api.example.test/';
+		env.ST0X_API_KEY = 'general-key';
+		env.ST0X_API_SECRET = 'general-secret';
+		env.ST0X_ACTIVITY_API_KEY = 'activity-key';
+		env.ST0X_ACTIVITY_API_SECRET = 'activity-secret';
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('uses the dedicated credential and the bounded 500-trade page', async () => {
+		const fetchMock = vi.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>(
+			async () =>
+				new Response(
+					JSON.stringify({
+						trades: [],
+						pagination: {
+							page: 1,
+							pageSize: 500,
+							totalTrades: 0,
+							totalPages: 0,
+							hasMore: false
+						}
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET({
+			request: new Request('http://localhost/api/public/trade-activity')
+		} as TradeActivityEvent);
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalled();
+		for (const [url, init] of fetchMock.mock.calls) {
+			expect(url).toBe('https://api.example.test/v1/trades/query');
+			if (!init) throw new Error('Expected batch request options');
+			const headers = init.headers as Record<string, string>;
+			expect(headers.Authorization).toBe('Basic YWN0aXZpdHkta2V5OmFjdGl2aXR5LXNlY3JldA==');
+			expect(headers.Authorization).not.toBe('Basic Z2VuZXJhbC1rZXk6Z2VuZXJhbC1zZWNyZXQ=');
+			expect(JSON.parse(String(init.body))).toEqual(expect.objectContaining({ pageSize: 500 }));
+		}
+	});
+
+	it('preserves a cold 429 and suppresses retries until Retry-After', async () => {
+		const fetchMock = vi
+			.fn<[RequestInfo | URL, RequestInit?], Promise<Response>>()
+			.mockResolvedValue(
+				new Response(null, {
+					status: 429,
+					headers: { 'Retry-After': '60' }
+				})
+			);
+		vi.stubGlobal('fetch', fetchMock);
+		const event = {
+			request: new Request('http://localhost/api/public/trade-activity')
+		} as TradeActivityEvent;
+
+		const first = await GET(event);
+		const requestsAfterFirst = fetchMock.mock.calls.length;
+		const second = await GET(event);
+
+		expect(first.status).toBe(429);
+		expect(first.headers.get('Retry-After')).toBe('60');
+		expect(first.headers.get('Cache-Control')).toBe('no-store');
+		expect(second.status).toBe(429);
+		expect(fetchMock).toHaveBeenCalledTimes(requestsAfterFirst);
+	});
+
+	it('rejects the complete refresh deadline when a dependency does not settle', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => new Promise(() => undefined))
+		);
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+		const responsePromise = GET({
+			request: new Request('http://localhost/api/public/trade-activity')
+		} as TradeActivityEvent);
+		await vi.advanceTimersByTimeAsync(PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS);
+
+		await expect(responsePromise).resolves.toMatchObject({ status: 500 });
+	});
+});

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -8,9 +8,11 @@
 
 import { env } from '$env/dynamic/private';
 import { getLogger, getRequestContext, requestIdOrUuid } from '$lib/server/logger';
+import { logSt0xRequestBudget } from '$lib/server/st0xBudgetTelemetry';
 import type { RequestEvent, RequestHandler } from './$types';
 
 const TOKEN_DETAILS_LIST_PATH = 'v1/tokens/details';
+const TOKEN_LIST_PATH = 'v1/tokens';
 
 function errorResponse(requestId: string, status: number, code: string, message: string): Response {
 	return new Response(
@@ -49,7 +51,11 @@ function getAuthHeader(): string {
 
 const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: string }> = [
 	{ method: 'GET', pattern: /^health$/ },
-	{ method: 'GET', pattern: /^v1\/tokens$/ },
+	{
+		method: 'GET',
+		pattern: /^v1\/tokens$/,
+		cache: 'public, s-maxage=300, stale-while-revalidate=3600'
+	},
 	{
 		method: 'GET',
 		pattern: /^v1\/tokens\/details$/,
@@ -112,14 +118,35 @@ function matchProxyRoute(method: string, pathSuffix: string): { cache?: string }
 async function shouldCacheResponse(pathSuffix: string, response: Response): Promise<boolean> {
 	if (!response.ok) return false;
 
-	if (pathSuffix !== TOKEN_DETAILS_LIST_PATH) return true;
+	if (pathSuffix !== TOKEN_DETAILS_LIST_PATH && pathSuffix !== TOKEN_LIST_PATH) return true;
 
 	try {
-		const body = (await response.clone().json()) as { errors?: unknown };
-		return !Array.isArray(body.errors) || body.errors.length === 0;
+		const body = (await response.clone().json()) as unknown;
+		if (pathSuffix === TOKEN_LIST_PATH) {
+			return (
+				Array.isArray(body) &&
+				body.length > 0 &&
+				body.every((token) => {
+					if (!token || typeof token !== 'object' || Array.isArray(token)) return false;
+					const item = token as Record<string, unknown>;
+					return (
+						typeof item.address === 'string' &&
+						item.address.length > 0 &&
+						typeof item.symbol === 'string' &&
+						item.symbol.length > 0 &&
+						typeof item.decimals === 'number' &&
+						Number.isInteger(item.decimals) &&
+						item.decimals >= 0
+					);
+				})
+			);
+		}
+
+		const details = body as { errors?: unknown };
+		return !Array.isArray(details.errors) || details.errors.length === 0;
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : 'Unknown parse error';
-		console.warn('[st0x-proxy] Skipping token details cache for unreadable response:', msg);
+		console.warn('[st0x-proxy] Skipping token metadata cache for unreadable response:', msg);
 		return false;
 	}
 }
@@ -166,6 +193,7 @@ const proxyRequest = async ({ request, params, url }: RequestEvent) => {
 	let response: Response;
 	try {
 		response = await fetch(targetUrl, init);
+		logSt0xRequestBudget(pathSuffix, 'general', response);
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : 'Unknown upstream error';
 		getLogger().error(

--- a/tests/lib/api/orders.test.ts
+++ b/tests/lib/api/orders.test.ts
@@ -154,15 +154,15 @@ describe('fetchAndQuotePaymentTokenOrders', () => {
 	it('deduplicates overlapping pages by normalized order hash and preserves page order', async () => {
 		vi.mocked(apiQueryOrders)
 			.mockResolvedValueOnce({
-				orders: [orderSummary({ orderHash: '0x-order-a' })],
-				pagination: { page: 1, pageSize: 50, totalOrders: 3, totalPages: 2, hasMore: true }
-			})
-			.mockResolvedValueOnce({
 				orders: [
-					orderSummary({ orderHash: '0X-ORDER-A' }),
+					orderSummary({ orderHash: '0x-order-a' }),
 					orderSummary({ orderHash: '0x-order-b' })
 				],
-				pagination: { page: 2, pageSize: 50, totalOrders: 3, totalPages: 2, hasMore: false }
+				pagination: { page: 1, pageSize: 2, totalOrders: 3, totalPages: 2, hasMore: true }
+			})
+			.mockResolvedValueOnce({
+				orders: [orderSummary({ orderHash: '0X-ORDER-A' })],
+				pagination: { page: 2, pageSize: 2, totalOrders: 3, totalPages: 2, hasMore: false }
 			});
 
 		const quotes = await fetchAndQuotePaymentTokenOrders(8453, paymentToken);
@@ -241,7 +241,7 @@ describe('fetchAndQuotePaymentTokenOrders', () => {
 		vi.mocked(apiQueryOrders)
 			.mockResolvedValueOnce({
 				orders: [orderSummary()],
-				pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: true }
+				pagination: { page: 1, pageSize: 1, totalOrders: 2, totalPages: 2, hasMore: true }
 			})
 			.mockRejectedValueOnce(new Error('page 2 unavailable'));
 
@@ -250,17 +250,66 @@ describe('fetchAndQuotePaymentTokenOrders', () => {
 		);
 	});
 
-	it('rejects a batch response that exceeds the safety page cap', async () => {
-		vi.mocked(apiQueryOrders).mockResolvedValue({
+	it('rejects inconsistent batch pagination metadata', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
 			orders: [orderSummary()],
+			pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: false }
+		});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'Invalid or unstable batch pagination'
+		);
+	});
+
+	it('rejects a batch response whose total pages do not match its total orders', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [orderSummary()],
+			pagination: { page: 1, pageSize: 50, totalOrders: 100, totalPages: 1, hasMore: false }
+		});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'Invalid or unstable batch pagination'
+		);
+	});
+
+	it('rejects a short non-final batch page', async () => {
+		vi.mocked(apiQueryOrders).mockResolvedValueOnce({
+			orders: [orderSummary()],
+			pagination: { page: 1, pageSize: 2, totalOrders: 3, totalPages: 2, hasMore: true }
+		});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'Invalid or unstable batch pagination'
+		);
+	});
+
+	it('rejects pagination totals that change between pages', async () => {
+		vi.mocked(apiQueryOrders)
+			.mockResolvedValueOnce({
+				orders: [orderSummary()],
+				pagination: { page: 1, pageSize: 1, totalOrders: 2, totalPages: 2, hasMore: true }
+			})
+			.mockResolvedValueOnce({
+				orders: [orderSummary({ orderHash: '0x-second' })],
+				pagination: { page: 2, pageSize: 1, totalOrders: 3, totalPages: 3, hasMore: true }
+			});
+
+		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
+			'Invalid or unstable batch pagination'
+		);
+	});
+
+	it('rejects a batch response that exceeds the safety page cap', async () => {
+		vi.mocked(apiQueryOrders).mockImplementation(async (request) => ({
+			orders: [orderSummary({ orderHash: `0x-order-${request.page}` })],
 			pagination: {
-				page: 1,
-				pageSize: 50,
-				totalOrders: 5_001,
+				page: request.page ?? 1,
+				pageSize: 1,
+				totalOrders: 101,
 				totalPages: 101,
 				hasMore: true
 			}
-		});
+		}));
 
 		await expect(fetchAndQuotePaymentTokenOrders(8453, paymentToken)).rejects.toThrow(
 			'Hit pagination cap'
@@ -274,7 +323,7 @@ describe('fetchAndQuotePaymentTokenOrders', () => {
 		vi.mocked(apiQueryOrders)
 			.mockResolvedValueOnce({
 				orders: [orderSummary()],
-				pagination: { page: 1, pageSize: 50, totalOrders: 2, totalPages: 2, hasMore: true }
+				pagination: { page: 1, pageSize: 1, totalOrders: 2, totalPages: 2, hasMore: true }
 			})
 			.mockImplementationOnce(async () => {
 				controller.abort();

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -35,7 +35,7 @@ describe('/api/st0x proxy', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('allows GET /v1/tokens without adding a proxy cache header', async () => {
+	it('edge-caches the stable GET /v1/tokens metadata response', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify([{ address: '0xToken', symbol: 'TOK', decimals: 18 }]), {
 				status: 200,
@@ -47,7 +47,9 @@ describe('/api/st0x proxy', () => {
 		const response = await GET(proxyEvent('GET', 'v1/tokens'));
 
 		expect(response.status).toBe(200);
-		expect(response.headers.get('Cache-Control')).toBeNull();
+		expect(response.headers.get('Cache-Control')).toBe(
+			'public, s-maxage=300, stale-while-revalidate=3600'
+		);
 		expect(fetchMock).toHaveBeenCalledWith(
 			'https://api.example.test/v1/tokens?page=1',
 			expect.objectContaining({
@@ -59,6 +61,21 @@ describe('/api/st0x proxy', () => {
 		expect((init.headers as Headers).get('Authorization')).toBe(
 			'Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ='
 		);
+	});
+
+	it('does not edge-cache a malformed successful token list', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify([{ address: '0xToken', decimals: 18 }]), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const response = await GET(proxyEvent('GET', 'v1/tokens'));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBeNull();
 	});
 
 	it('allows POST /v1/swap/quote and forwards the JSON body without caching', async () => {
@@ -400,7 +417,7 @@ describe('/api/st0x proxy', () => {
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(await response.text()).toBe('not json');
 		expect(warn).toHaveBeenCalledWith(
-			'[st0x-proxy] Skipping token details cache for unreadable response:',
+			'[st0x-proxy] Skipping token metadata cache for unreadable response:',
 			expect.any(String)
 		);
 	});


### PR DESCRIPTION
## Summary

- migrate the remaining public price refresh to one bounded batch-order stream per network
- isolate price and trade-activity request budgets with dedicated credentials and endpoint/credential telemetry
- raise the bounded trade page size to 500 so a current 30-day activity refresh fits comfortably inside the production 60-request credential budget
- share in-flight refreshes across website instances with Redis locks and bounded cache operations
- retain only complete, semantically valid price and trade snapshots with cold-failure cooldowns and stale fallback
- preserve `Retry-After`, fail closed on partial credential configuration, and abort upstream refresh work at a bounded deadline
- document cache-hit accounting, production credential isolation, failure behavior, and operational recovery

## Stack

- Depends on #247 (batch public trade activity)
- Uses the REST batch API from ST0x-Technology/st0x.rest.api#166

## Cache and compatibility

REST authentication and rate limiting occur before REST response-cache lookup, so every website request that reaches REST consumes request budget. Website memory, Redis, TanStack Query, and edge-cache hits do not.

The public price and trade-activity response contracts remain unchanged. Dedicated `ST0X_PRICES_API_KEY`/`ST0X_PRICES_API_SECRET` and `ST0X_ACTIVITY_API_KEY`/`ST0X_ACTIVITY_API_SECRET` pairs are preferred. The general pair remains a backward-compatible fallback only when both values in a dedicated pair are absent; partial dedicated configuration fails closed.

Redis-backed distributed locks coalesce cold refreshes across website instances. Cache operations are bounded and fail open without wedging requests. Rate-limit and generic-failure cooldowns are shared through Redis, with process-local fallback when Redis writes fail. Failed, partial, malformed, token-incomplete, or aggregate-inconsistent snapshots never replace a complete snapshot.

## Verification

- Svelte check: 0 errors, 0 warnings
- ESLint and Prettier checks passed
- Vitest: 83 files passed; 895 tests passed, 1 skipped
- integration suite passed with one credential-dependent Anvil fork test skipped
- simplification pass plus staged local review completed; final focused rereview found no remaining actionable issue
- fresh local Raindex database populated from registry commit `f40bd8ade09f5c80c7bb508dc5c004bd00263b22`
- production-limit two-instance cold test: both requests returned identical 200 responses in about 26 seconds; one refresh used 9/60 activity requests and returned 4,216 trades; warm response completed in 4.8 ms
- isolated price credential test: 200 response with 33 live prices, using 2/60 price requests

Fixes RAI-1563

Fixes RAI-1560
