### PR TITLE
chore: bump sft-base subgraph to 1.0.14

### DIFF
--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -63,7 +63,7 @@ export const networks: Network[] = [
 		],
 		icon: 'ethereum',
 		subgraph_url:
-			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.13/gn',
+			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.14/gn',
 		metadata_subgraph_url:
 			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn',
 		orderbook_subgraph_url:

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -63,7 +63,7 @@ export const networks: Network[] = [
 		],
 		icon: 'ethereum',
 		subgraph_url:
-			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.12/gn',
+			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.13/gn',
 		metadata_subgraph_url:
 			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn',
 		orderbook_subgraph_url:


### PR DESCRIPTION
## Summary
- Bump Base SFT subgraph from `1.0.12` to `1.0.14` in `networks.ts`.

## Test plan
- [ ] Confirm `subgraph_url` points at `.../sft-base/1.0.14/gn`
- [ ] Smoke sidebar / token details still loads against the new subgraph