### PR TITLE
fix(ui): clean up website visual artifacts

### DIFF
--- a/src/lib/components/QuickTradeChart.svelte
+++ b/src/lib/components/QuickTradeChart.svelte
@@ -26,13 +26,15 @@
 	// the data in it, so anything calmer than MIN_RANGE_PCT reads as flat.
 	const MIN_RANGE_PCT = 0.06;
 
-	// Deterministic decorative wave for the no-history fallback (no Math.random, so
-	// SSR and client render identically).
-	const FALLBACK_SERIES: number[] = (() => {
-		const a: number[] = [];
-		for (let i = 0; i <= 36; i++) a.push(Math.sin(i / 2.4) * 5 + Math.sin(i / 6) * 3);
-		return a;
-	})();
+	// Deterministic, restrained market silhouette for the no-history fallback
+	// (no Math.random, so SSR and client render identically). Keep the movement
+	// modest: the old overlapping sine waves stretched into oversized peaks and
+	// read as broken chart geometry.
+	const FALLBACK_SERIES = [
+		100, 100.4, 100.8, 100.5, 101.1, 101.6, 101.4, 102, 102.5, 102.2, 102.8, 103.1, 102.9, 103.5,
+		104, 103.7, 104.3, 104.8, 104.6, 105.1, 105.5, 105.2, 105.8, 106.3, 106, 106.6, 107, 106.8,
+		107.4, 107.8, 107.5, 108
+	];
 
 	$: paymentToken = $currentNetwork?.defaultPaymentToken ?? null;
 	$: tradeQuery = createTokenTradeActivityQuery($currentNetwork, token?.address ?? null);
@@ -106,8 +108,8 @@
 		const floorSpan = mid > 0 ? mid * MIN_RANGE_PCT : dataSpan;
 		const span = hasRealData ? Math.max(dataSpan, floorSpan) : dataSpan;
 		const base = mid - span / 2;
-		const top = H * 0.22;
-		const band = H * 0.56;
+		const top = H * (hasRealData ? 0.22 : 0.36);
+		const band = H * (hasRealData ? 0.56 : 0.24);
 		const xy = series.map((v, i) => {
 			const x = series.length > 1 ? (i / (series.length - 1)) * W : 0;
 			const norm = span ? (v - base) / span : 0.5;
@@ -136,7 +138,7 @@
 	>
 		<defs>
 			<linearGradient id="qtchart" x1="0" y1="0" x2="0" y2="1">
-				<stop offset="0%" stop-color="#2de3a6" stop-opacity={hasRealData ? 0.22 : 0.08} />
+				<stop offset="0%" stop-color="#2de3a6" stop-opacity={hasRealData ? 0.22 : 0.06} />
 				<stop offset="100%" stop-color="#2de3a6" stop-opacity="0" />
 			</linearGradient>
 		</defs>
@@ -147,19 +149,13 @@
 			pathLength="1"
 			fill="none"
 			stroke="#2de3a6"
-			stroke-opacity={hasRealData ? 1 : 0.35}
+			stroke-opacity={hasRealData ? 1 : 0.5}
 			stroke-width="2"
 			stroke-linejoin="round"
 			stroke-linecap="round"
 			vector-effect="non-scaling-stroke"
 		/>
 	</svg>
-
-	{#if !hasRealData}
-		<!-- Placeholder/loading affordance: a soft emerald shimmer sweep so the
-		     decorative no-history chart reads as a live placeholder, not flat data. -->
-		<div class="qt-shimmer pointer-events-none absolute inset-0" aria-hidden="true"></div>
-	{/if}
 
 	{#if token}
 		<div class="absolute left-5 top-5 flex max-w-[55%] items-center gap-2.5">
@@ -222,29 +218,8 @@
 		}
 	}
 
-	/* Soft emerald highlight sweeping across the panel — the universal "loading" cue. */
-	.qt-shimmer {
-		background: linear-gradient(
-			100deg,
-			transparent 35%,
-			rgba(45, 227, 166, 0.12) 50%,
-			transparent 65%
-		);
-		background-size: 220% 100%;
-		animation: qt-shimmer 2.4s linear infinite;
-	}
-	@keyframes qt-shimmer {
-		0% {
-			background-position: 160% 0;
-		}
-		100% {
-			background-position: -160% 0;
-		}
-	}
-
 	@media (prefers-reduced-motion: reduce) {
-		.qt-draw,
-		.qt-shimmer {
+		.qt-draw {
 			animation: none;
 		}
 		.qt-draw {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -111,7 +111,7 @@
 
 	{#if (desktop && !collapsed) || (!desktop && visible)}
 		<!-- Assets List (scrollable) -->
-		<div class="flex-1 overflow-y-auto p-3">
+		<div class="asset-scrollbar flex-1 overflow-y-auto p-3">
 			<div class="mb-3 px-2 text-[10px] font-medium uppercase tracking-wider text-text-muted">
 				Assets
 			</div>
@@ -161,3 +161,25 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	/* Keep the long asset list scrollable without the browser's thick default
+	   thumb reading as a detached vertical UI bar beside the content. */
+	.asset-scrollbar {
+		scrollbar-color: var(--line-strong) transparent;
+		scrollbar-width: thin;
+	}
+
+	.asset-scrollbar::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	.asset-scrollbar::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.asset-scrollbar::-webkit-scrollbar-thumb {
+		border-radius: var(--pill);
+		background: var(--line-strong);
+	}
+</style>

--- a/src/lib/components/charts/TradingViewEmbed.svelte
+++ b/src/lib/components/charts/TradingViewEmbed.svelte
@@ -59,4 +59,28 @@
 	});
 </script>
 
-<div bind:this={container} class={`h-full w-full ${containerClass}`} />
+<div
+	bind:this={container}
+	class={`tradingview-embed h-full w-full overflow-hidden ${containerClass}`}
+/>
+
+<style>
+	/*
+	 * TradingView occasionally gives its generated iframe an intrinsic width a
+	 * pixel or two wider than the host. That exposed isolated border fragments
+	 * and pushed the corner attribution mark outside narrow cards.
+	 */
+	.tradingview-embed :global(.tradingview-widget-container),
+	.tradingview-embed :global(.tradingview-widget-container__widget),
+	.tradingview-embed :global(iframe) {
+		box-sizing: border-box;
+		max-width: 100% !important;
+		width: 100% !important;
+	}
+
+	.tradingview-embed :global(iframe) {
+		display: block;
+		border: 0 !important;
+		clip-path: inset(1px);
+	}
+</style>

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -1761,7 +1761,9 @@
 					</div>
 					{#if activeAssetTab === 'company'}
 						{#if tradingViewSymbol}
-							<div class="hidden overflow-hidden sm:block">
+							<div
+								class="hidden overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:block"
+							>
 								<TradingViewWidget
 									widgetType="symbol-profile"
 									symbol={tradingViewSymbol}
@@ -1769,7 +1771,7 @@
 									isTransparent={true}
 								/>
 							</div>
-							<div class="overflow-hidden sm:hidden">
+							<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:hidden">
 								<TradingViewWidget
 									widgetType="symbol-profile"
 									symbol={tradingViewSymbol}
@@ -1784,7 +1786,9 @@
 						{/if}
 					{:else if activeAssetTab === 'fundamentals'}
 						{#if tradingViewSymbol}
-							<div class="hidden overflow-hidden sm:block">
+							<div
+								class="hidden overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:block"
+							>
 								<TradingViewWidget
 									widgetType="financials"
 									symbol={tradingViewSymbol}
@@ -1792,7 +1796,7 @@
 									isTransparent={true}
 								/>
 							</div>
-							<div class="overflow-hidden sm:hidden">
+							<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:hidden">
 								<TradingViewWidget
 									widgetType="financials"
 									symbol={tradingViewSymbol}
@@ -1807,7 +1811,9 @@
 						{/if}
 					{:else if activeAssetTab === 'technical'}
 						{#if tradingViewSymbol}
-							<div class="hidden overflow-hidden sm:block">
+							<div
+								class="hidden overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:block"
+							>
 								<TradingViewWidget
 									widgetType="technical-analysis"
 									symbol={tradingViewSymbol}
@@ -1815,7 +1821,7 @@
 									isTransparent={true}
 								/>
 							</div>
-							<div class="overflow-hidden sm:hidden">
+							<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:hidden">
 								<TradingViewWidget
 									widgetType="technical-analysis"
 									symbol={tradingViewSymbol}
@@ -1829,7 +1835,9 @@
 							</div>
 						{/if}
 					{:else if tradingViewSymbol}
-						<div class="hidden overflow-hidden sm:block">
+						<div
+							class="hidden overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:block"
+						>
 							<TradingViewWidget
 								widgetType="timeline"
 								symbol={tradingViewSymbol}
@@ -1837,7 +1845,7 @@
 								isTransparent={true}
 							/>
 						</div>
-						<div class="overflow-hidden sm:hidden">
+						<div class="overflow-hidden rounded-2xl border border-line bg-overlay-1 sm:hidden">
 							<TradingViewWidget
 								widgetType="timeline"
 								symbol={tradingViewSymbol}


### PR DESCRIPTION
## Motivation

The refreshed website exposed several visual regressions: the asset-list scrollbar rendered as a thick detached bar, TradingView iframe edges and attribution marks escaped their intended panels, and the landing-page fallback chart stretched into an oversized distorted wave.

## Solution

- Restyle the asset-list scrollbar as a narrow theme-aware control.
- Clamp TradingView embeds to their host width, remove iframe edge fragments, and contain the lower detail widgets in complete rounded cards.
- Replace the overlapping sine-wave fallback with a restrained market silhouette and remove the distortion-causing shimmer.
- Preserve live chart behavior whenever real trade history is available.

## Validation

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run lint-check`
- [x] `npm run format-check`
- [x] `npm run test -- --run` — 75 files passed; 802 tests passed, 1 skipped
- [x] Manual local smoke test in light and dark themes on the landing page and TSM trade page

Fixes RAI-1558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved no-history chart visuals with a cleaner, restrained upward trend and reduced visual intensity.
  * Added slimmer, themed scrollbars to the asset sidebar.
  * Improved embedded chart sizing and edge clipping to prevent visual overflow.
  * Updated trading panels with responsive borders, rounded corners, and consistent backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->