### PR TITLE
fix: use registry RPC fallbacks in client wagmi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,10 +45,8 @@ SENTRY_PROJECT=
 OBSERVABILITY_ALERT_TELEGRAM_BOT_TOKEN=
 OBSERVABILITY_ALERT_TELEGRAM_CHAT_ID=
 
-# Base mainnet RPC — Alchemy app URL (or compatible). Same value used on both sides per
-# Phase 3 D-02 (single key both sides; bundle key is exposed regardless, splitting doubles
-# operational surface for marginal blast-radius reduction).
-PUBLIC_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY_HERE
+# Server-only Base mainnet RPC — Alchemy app URL (or compatible). Browser-side
+# wagmi/viem reads use the ordered RPC list in the active public registry.
 BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY_HERE
 
 # Public Rain strategy registry URL. By default /registry/manifest resolves the

--- a/src/lib/clients/raindexSettings.ts
+++ b/src/lib/clients/raindexSettings.ts
@@ -1,8 +1,9 @@
 import { browser } from '$app/environment';
 import { env as publicEnv } from '$env/dynamic/public';
-import { isMap, parseDocument } from 'yaml';
+import { isMap, isScalar, isSeq, parseDocument } from 'yaml';
 
 const REGISTRY_MANIFEST_URL = publicEnv.PUBLIC_REGISTRY_URL || '/registry/manifest';
+const REGISTRY_REQUEST_TIMEOUT_MS = 5000;
 
 function appOrigin(): string {
 	if (browser && typeof window !== 'undefined' && window.location?.origin) {
@@ -68,17 +69,37 @@ export function prepareBrowserRaindexSettings(settingsYaml: string): string {
 	return document.toString();
 }
 
-async function fetchText(url: string, label: string): Promise<string> {
-	const response = await fetch(url);
-	if (!response.ok) {
-		throw new Error(`Failed to load ${label} (${response.status})`);
+async function fetchText(url: string, label: string, init?: RequestInit): Promise<string> {
+	const controller = new AbortController();
+	const externalSignal = init?.signal;
+	const abortFromExternalSignal = () => controller.abort(externalSignal?.reason);
+	if (externalSignal?.aborted) {
+		abortFromExternalSignal();
+	} else {
+		externalSignal?.addEventListener('abort', abortFromExternalSignal, { once: true });
 	}
-	return response.text();
+	const timeout = setTimeout(
+		() => controller.abort(new Error(`Timed out loading ${label}`)),
+		REGISTRY_REQUEST_TIMEOUT_MS
+	);
+
+	try {
+		const response = await fetch(url, { ...init, signal: controller.signal });
+		if (!response.ok) {
+			throw new Error(`Failed to load ${label} (${response.status})`);
+		}
+		return response.text();
+	} finally {
+		clearTimeout(timeout);
+		externalSignal?.removeEventListener('abort', abortFromExternalSignal);
+	}
 }
 
 async function fetchBrowserRaindexSettings(): Promise<string> {
 	const manifestUrl = resolveRegistryManifestUrl();
-	const manifest = await fetchText(manifestUrl, 'registry manifest');
+	// The manifest follows the REST API's active registry commit. Bypass the
+	// browser cache so an operator RPC rotation is picked up on the next reload.
+	const manifest = await fetchText(manifestUrl, 'registry manifest', { cache: 'no-store' });
 	const settingsUrl = settingsUrlFromManifest(manifest, manifestUrl);
 	const settings = await fetchText(settingsUrl, 'registry settings');
 	return prepareBrowserRaindexSettings(settings);
@@ -95,4 +116,57 @@ export function getBrowserRaindexSettings(): Promise<string> {
 		});
 	}
 	return settingsPromise;
+}
+
+/**
+ * Read the ordered RPC list for a chain from canonical Raindex settings.
+ *
+ * The order is operational configuration: viem tries the first URL first and
+ * falls through to the remaining URLs when a request fails.
+ */
+export function getRaindexRpcUrls(settingsYaml: string, chainId: number): string[] {
+	const document = parseDocument(settingsYaml, { schema: 'failsafe' });
+	if (document.errors.length > 0) {
+		throw new Error(`Registry settings YAML is invalid: ${document.errors[0].message}`);
+	}
+
+	const networks = document.get('networks', true);
+	if (!isMap(networks)) {
+		throw new Error('Registry settings do not contain a networks map');
+	}
+
+	const network = networks.items
+		.map((pair) => pair.value)
+		.find((value) => isMap(value) && String(value.get('chain-id')).trim() === String(chainId));
+	if (!isMap(network)) {
+		throw new Error(`Registry settings do not contain chain ${chainId}`);
+	}
+
+	const rpcs = network.get('rpcs', true);
+	if (!isSeq(rpcs) || rpcs.items.length === 0) {
+		throw new Error(`Registry settings do not contain RPC URLs for chain ${chainId}`);
+	}
+
+	return rpcs.items.map((item) => {
+		if (!isScalar(item) || typeof item.value !== 'string') {
+			throw new Error(`Registry settings contain a non-string RPC URL for chain ${chainId}`);
+		}
+
+		const value = item.value.trim();
+		let url: URL;
+		try {
+			url = new URL(value);
+		} catch {
+			throw new Error(`Registry settings contain an invalid RPC URL for chain ${chainId}`);
+		}
+		if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+			throw new Error(`Registry settings contain an unsupported RPC URL for chain ${chainId}`);
+		}
+		return value;
+	});
+}
+
+/** Load the active registry once and return its ordered RPC list for a chain. */
+export async function getBrowserRaindexRpcUrls(chainId: number): Promise<string[]> {
+	return getRaindexRpcUrls(await getBrowserRaindexSettings(), chainId);
 }

--- a/src/lib/config/clientRpc.ts
+++ b/src/lib/config/clientRpc.ts
@@ -1,0 +1,57 @@
+/**
+ * Client-side Base RPC URL ordering for wagmi transports.
+ *
+ * svelte-wagmi's defaultConfig uses bare `http()`, which falls through to
+ * public chain RPCs (e.g. mainnet.base.org) and rate-limits under load.
+ * Use {@link getClientRpcUrls} with viem `fallback([...])` so the browser
+ * follows the active registry's ordered RPC list.
+ */
+
+import { fallback, http, type Transport } from 'viem';
+
+/**
+ * Run one retry round after every configured provider has failed once.
+ *
+ * Rate-limit retries live here, rather than in the app-level `withRetry`,
+ * so a logical read cannot multiply two independent retry loops.
+ */
+export const CLIENT_RPC_RETRY_OPTIONS = {
+	retryCount: 1,
+	retryDelay: 1000,
+	rank: false
+} as const;
+
+function getRpcUrlKey(value: string): string {
+	const parsed = new URL(value);
+	parsed.hash = '';
+	return parsed.href;
+}
+
+/**
+ * Ordered, de-duplicated RPC URLs for browser wagmi transports.
+ * The registry's first URL remains first.
+ */
+export function getClientRpcUrls(ordered: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const urls: string[] = [];
+	for (const url of ordered) {
+		const key = getRpcUrlKey(url);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		urls.push(url);
+	}
+	if (urls.length === 0) {
+		throw new Error('At least one client RPC URL is required');
+	}
+	return urls;
+}
+
+/** Build the bounded fallback used by browser-side wagmi reads. */
+export function createClientRpcFallback(transports: Transport[]): Transport {
+	return fallback(transports, CLIENT_RPC_RETRY_OPTIONS);
+}
+
+/** Build HTTP transports for the configured browser RPC URL order. */
+export function createClientRpcTransport(urls: readonly string[]): Transport {
+	return createClientRpcFallback(getClientRpcUrls(urls).map((url) => http(url)));
+}

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -1,4 +1,3 @@
-import { env as publicEnv } from '$env/dynamic/public';
 import type { Token } from '$lib/types';
 import {
 	DEFAULT_PAYMENT_TOKENS,
@@ -35,12 +34,6 @@ export interface Network {
 const basePaymentTokens = PAYMENT_TOKENS_BY_NETWORK[8453] ?? [];
 const baseDefaultPaymentToken = DEFAULT_PAYMENT_TOKENS[8453];
 
-// SEC-01 / Phase 3 D-02: PUBLIC_BASE_RPC_URL is the Alchemy app URL exposed to the
-// client bundle (single-key both-sides per D-02). Dev fallback keeps `npm run dev`
-// working for contributors who haven't provisioned their own Alchemy app. REL-02
-// (Wave 5) wraps server-side reads of this URL list in viem's fallback transport.
-const PRIMARY_RPC = publicEnv.PUBLIC_BASE_RPC_URL || 'https://base-rpc.publicnode.com';
-
 export const networks: Network[] = [
 	{
 		id: 8453,
@@ -52,10 +45,9 @@ export const networks: Network[] = [
 		blockExplorer: 'https://basescan.org',
 		sftExplorer: 'https://stox2.h20.market',
 		blockExplorerIcon: 'etherscan',
-		rpcUrl: PRIMARY_RPC,
+		rpcUrl: 'https://base-rpc.publicnode.com',
 		fallbackRpcUrls: [
 			'https://base-rpc.publicnode.com',
-			PRIMARY_RPC,
 			'https://base.llamarpc.com',
 			'https://base.meowrpc.com',
 			'https://base-mainnet.public.blastapi.io',

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -276,6 +276,12 @@ export function toUserFacingTradeError(
 ): UserFacingTradeError {
 	if (isUserFacingTradeError(error)) return error;
 	if (isHttpError(error)) {
+		if (error.status === 429) {
+			return createTradeError('UPSTREAM_UNAVAILABLE', {
+				stage,
+				requestId: error.requestId
+			});
+		}
 		return createTradeError(error.code, { stage, requestId: error.requestId });
 	}
 
@@ -299,7 +305,10 @@ export function toUserFacingTradeError(
 	if (message.includes('market') && message.includes('closed')) {
 		return createTradeError('TRADE_MARKET_CLOSED', { stage });
 	}
-	if (/rpc|network|timed? ?out|timeout|connection/.test(message)) {
+	if (
+		candidate?.code === -32016 ||
+		/rpc|network|timed? ?out|timeout|connection|rate.?limit|too many requests|\b429\b/.test(message)
+	) {
 		return createTradeError('UPSTREAM_UNAVAILABLE', { stage });
 	}
 

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -1,7 +1,17 @@
 /**
  * Retry wrapper for RPC calls that fail with transient errors.
- * Handles "header not found" and "block not found" errors from load-balanced RPC providers.
+ * Handles load-balanced "header/block not found" flake.
+ *
+ * Rate-limit retries are intentionally owned by the wagmi fallback transport.
+ * Retrying them here as well would replay the entire provider fallback chain.
  */
+function isTransientRpcError(error: unknown): boolean {
+	const errorMessage = String(
+		(error as { message?: unknown } | null)?.message ?? error ?? ''
+	).toLowerCase();
+	return errorMessage.includes('header not found') || errorMessage.includes('block not found');
+}
+
 export async function withRetry<T>(
 	fn: () => Promise<T>,
 	maxRetries = 3,
@@ -17,18 +27,9 @@ export async function withRetry<T>(
 			return await fn();
 		} catch (error) {
 			lastError = error;
-			const errorMessage = String(error);
-			// Retry on "header not found" or "block not found" RPC errors
-			if (
-				errorMessage.includes('header not found') ||
-				errorMessage.includes('block not found') ||
-				(error as { code?: number })?.code === -32000
-			) {
-				if (attempt < maxRetries - 1) {
-					// Exponential backoff
-					await new Promise((resolve) => setTimeout(resolve, delayMs * Math.pow(2, attempt)));
-					continue;
-				}
+			if (isTransientRpcError(error) && attempt < maxRetries - 1) {
+				await new Promise((resolve) => setTimeout(resolve, delayMs * Math.pow(2, attempt)));
+				continue;
 			}
 			throw error;
 		}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -100,11 +100,29 @@
 	}
 
 	const initWallet = async () => {
-		const [{ defaultConfig }, { base }, { injected, walletConnect }] = await Promise.all([
+		// svelte-wagmi's defaultConfig uses bare `http()` → public Base RPCs that
+		// rate-limit under load. Build the same stores/modal setup with an explicit
+		// fallback transport using the active registry's ordered Base RPC list.
+		const [
+			{ wagmiConfig, web3Modal, wagmiLoaded, configuredConnectors, init },
+			{ base },
+			{ injected, walletConnect },
+			{ createConfig, reconnect },
+			{ createWeb3Modal },
+			{ createClientRpcTransport },
+			{ getBrowserRaindexRpcUrls },
+			{ networks }
+		] = await Promise.all([
 			import('svelte-wagmi'),
 			import('@wagmi/core/chains'),
-			import('@wagmi/connectors')
+			import('@wagmi/connectors'),
+			import('@wagmi/core'),
+			import('@web3modal/wagmi'),
+			import('$lib/config/clientRpc'),
+			import('$lib/clients/raindexSettings'),
+			import('$lib/config/networks')
 		]);
+
 		const projectId = publicEnv?.PUBLIC_WALLETCONNECT_ID || '';
 		const connectorsList = [injected()];
 		if (projectId && projectId.trim().length > 0) {
@@ -112,16 +130,44 @@
 			connectorsList.push(walletConnect({ projectId }));
 		}
 
-		const cfgOptions = {
-			autoConnect: true,
-			appName: 'st0x-liquidity',
-			chains: [base] as [typeof base],
-			connectors: connectorsList,
-			walletConnectProjectId: projectId || 'dummy-project-id'
-		};
+		configuredConnectors.set(connectorsList);
 
-		const erckit = defaultConfig(cfgOptions);
-		await erckit.init();
+		const configuredBaseNetwork = networks.find((network) => network.chainId === base.id);
+		const configuredBaseRpcUrls = configuredBaseNetwork
+			? [configuredBaseNetwork.rpcUrl, ...configuredBaseNetwork.fallbackRpcUrls]
+			: base.rpcUrls.default.http;
+		let rpcUrls: readonly string[];
+		try {
+			rpcUrls = await getBrowserRaindexRpcUrls(base.id);
+		} catch (error) {
+			// Wallet connectivity should survive a temporary registry outage.
+			// The statically configured list is an emergency fallback only; successful
+			// registry loads always use the complete operator-controlled list.
+			console.warn('[wallet] Failed to load registry RPCs; using configured Base RPCs:', error);
+			rpcUrls = configuredBaseRpcUrls;
+		}
+
+		const config = createConfig({
+			chains: [base],
+			connectors: connectorsList,
+			transports: {
+				[base.id]: createClientRpcTransport(rpcUrls)
+			}
+		});
+
+		wagmiConfig.set(config);
+		reconnect(config);
+
+		web3Modal.set(
+			createWeb3Modal({
+				wagmiConfig: config,
+				projectId: projectId || 'dummy-project-id',
+				enableAnalytics: true,
+				enableOnramp: true
+			})
+		);
+		wagmiLoaded.set(true);
+		await init();
 	};
 
 	// SEC-03 (Plan 03-08b atomic flip): the 'wallet-address' cookie is a

--- a/tests/integration/ui/fixtures.ts
+++ b/tests/integration/ui/fixtures.ts
@@ -397,20 +397,11 @@ export const test = base.extend<UiFixtures>({
 				})
 			});
 		});
-		// Redirect Base mainnet RPC traffic to anvil. TWO separate clients hit
-		// these hosts:
-		//   1. svelte-wagmi's defaultConfig builds its HTTP transport from
-		//      chain.rpcUrls.default (https://mainnet.base.org for Base) for
-		//      balance reads, contract reads, etc.
-		//   2. The Rain SDK (@rainlanguage/raindex) has its OWN RPC client
-		//      configured via src/lib/clients/raindex.ts:SETTINGS_YAML. Its
-		//      URL is `PUBLIC_BASE_RPC_URL || 'https://base-rpc.publicnode.com'`.
-		//      In E2E we don't set PUBLIC_BASE_RPC_URL on the preview server,
-		//      so the SDK falls back to publicnode.com and its eth_call
-		//      simulation for getTakeOrdersCalldata MUST be forwarded to anvil
-		//      — otherwise the SDK simulates against LIVE Base mainnet, sees
-		//      zero USDC balance / zero allowance for the test wallet (we
-		//      only funded anvil), and returns isReady=false with no calldata.
+		// Redirect Base mainnet RPC traffic to anvil. Both wagmi/viem and the
+		// Rain SDK use the active registry's ordered RPC list. Their eth_call
+		// simulations MUST be forwarded to anvil — otherwise they run against
+		// live Base, where the locally funded test wallet has no balance or
+		// allowance.
 		await page.route(
 			/https:\/\/(mainnet\.base\.org|base-rpc\.publicnode\.com|.*\.g\.alchemy\.com|base\.llamarpc\.com|base\.meowrpc\.com|base-mainnet\.public\.blastapi\.io|gateway\.tenderly\.co|base\.drpc\.org|.*\.drpc\.live).*/,
 			async (route) => {

--- a/tests/lib/clients/raindex.test.ts
+++ b/tests/lib/clients/raindex.test.ts
@@ -4,7 +4,7 @@ import { parseDocument } from 'yaml';
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 import { createRaindexClient } from '$lib/clients/raindex';
-import { prepareBrowserRaindexSettings } from '$lib/clients/raindexSettings';
+import { getRaindexRpcUrls, prepareBrowserRaindexSettings } from '$lib/clients/raindexSettings';
 
 const SETTINGS_URL = 'https://registry.example/settings.yaml';
 const SUBGRAPH_URL =
@@ -14,6 +14,8 @@ networks:
   base:
     rpcs:
       - https://mainnet.base.org
+      - https://base.drpc.org
+      - https://base-rpc.publicnode.com
     chain-id: 8453
     network-id: 8453
     currency: ETH
@@ -48,6 +50,7 @@ local-db-sync:
 
 afterEach(() => {
 	vi.unstubAllGlobals();
+	vi.useRealTimers();
 });
 
 describe('Raindex client configuration', () => {
@@ -64,6 +67,46 @@ describe('Raindex client configuration', () => {
 		expect(prepared.getIn(['subgraphs', 'base'])).toBe(SUBGRAPH_URL);
 	});
 
+	it('reads the ordered RPC list for a chain', () => {
+		expect(getRaindexRpcUrls(SETTINGS_YAML, 8453)).toEqual([
+			'https://mainnet.base.org',
+			'https://base.drpc.org',
+			'https://base-rpc.publicnode.com'
+		]);
+	});
+
+	it('rejects missing and invalid RPC lists', () => {
+		expect(() => getRaindexRpcUrls(SETTINGS_YAML, 1)).toThrow(
+			'Registry settings do not contain chain 1'
+		);
+		expect(() =>
+			getRaindexRpcUrls(
+				SETTINGS_YAML.replace('https://mainnet.base.org', 'ws://mainnet.base.org'),
+				8453
+			)
+		).toThrow('Registry settings contain an unsupported RPC URL for chain 8453');
+	});
+
+	it('aborts a stalled registry request so wallet initialization can fall back', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+			return new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+					once: true
+				});
+			});
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const clientPromise = createRaindexClient();
+		const rejection = expect(clientPromise).rejects.toThrow('Timed out loading registry manifest');
+		await vi.advanceTimersByTimeAsync(5000);
+
+		await rejection;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+	});
+
 	it('initializes from the canonical registry settings', async () => {
 		const fetchMock = vi
 			.fn()
@@ -77,8 +120,13 @@ describe('Raindex client configuration', () => {
 		expect(client).toBeDefined();
 		expect(snapshot.error).toBeUndefined();
 		expect(snapshot.value?.configured).toBe(false);
-		expect(fetchMock).toHaveBeenNthCalledWith(1, `${window.location.origin}/registry/manifest`);
-		expect(fetchMock).toHaveBeenNthCalledWith(2, SETTINGS_URL);
+		expect(fetchMock).toHaveBeenNthCalledWith(1, `${window.location.origin}/registry/manifest`, {
+			cache: 'no-store',
+			signal: expect.any(AbortSignal)
+		});
+		expect(fetchMock).toHaveBeenNthCalledWith(2, SETTINGS_URL, {
+			signal: expect.any(AbortSignal)
+		});
 		client.free();
 	});
 });

--- a/tests/lib/config/clientRpc.test.ts
+++ b/tests/lib/config/clientRpc.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { getClientRpcUrls } from '$lib/config/clientRpc';
+
+describe('getClientRpcUrls', () => {
+	it('preserves registry RPC priority', () => {
+		const urls = getClientRpcUrls(['https://primary.example/rpc', 'https://fallback.example/rpc']);
+		expect(urls).toEqual(['https://primary.example/rpc', 'https://fallback.example/rpc']);
+	});
+
+	it('dedupes equivalent registry RPCs by normalized scheme and host', () => {
+		expect(
+			getClientRpcUrls([
+				'HTTPS://PRIMARY.EXAMPLE/rpc',
+				'https://fallback-a.example',
+				'https://primary.example/rpc',
+				'https://fallback-b.example',
+				'https://FALLBACK-A.example'
+			])
+		).toEqual([
+			'HTTPS://PRIMARY.EXAMPLE/rpc',
+			'https://fallback-a.example',
+			'https://fallback-b.example'
+		]);
+	});
+
+	it('preserves RPC URLs that differ by path or query casing', () => {
+		expect(
+			getClientRpcUrls([
+				'https://rpc.example/ApiKey?token=AbC',
+				'https://rpc.example/apikey?token=AbC',
+				'https://rpc.example/ApiKey?token=abc'
+			])
+		).toEqual([
+			'https://rpc.example/ApiKey?token=AbC',
+			'https://rpc.example/apikey?token=AbC',
+			'https://rpc.example/ApiKey?token=abc'
+		]);
+	});
+
+	it('rejects an empty registry RPC list', () => {
+		expect(() => getClientRpcUrls([])).toThrow('At least one client RPC URL is required');
+	});
+});

--- a/tests/lib/config/clientRpcRetry.test.ts
+++ b/tests/lib/config/clientRpcRetry.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { custom, type Transport } from 'viem';
+import { base } from 'viem/chains';
+import { createClientRpcFallback } from '$lib/config/clientRpc';
+import { withRetry } from '$lib/utils/retry';
+
+function rateLimitError(): Error & { code: number } {
+	return Object.assign(new Error('over rate limit'), { code: -32016 });
+}
+
+function countingTransport(
+	attempts: number[],
+	index: number,
+	request: (attempt: number) => Promise<unknown>
+): Transport {
+	return custom({
+		async request() {
+			attempts[index] += 1;
+			return request(attempts[index]);
+		}
+	});
+}
+
+function buildRequest(transports: Transport[]): (method: string) => Promise<unknown> {
+	const transport = createClientRpcFallback(transports)({
+		chain: base,
+		retryCount: 0
+	});
+	return (method) => transport.request({ method });
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('client RPC retry policy', () => {
+	it('bounds a wrapped rate-limited read to two attempts per provider', async () => {
+		vi.useFakeTimers();
+		const attempts = Array.from({ length: 6 }, () => 0);
+		const request = buildRequest(
+			attempts.map((_, index) =>
+				countingTransport(attempts, index, async () => {
+					throw rateLimitError();
+				})
+			)
+		);
+
+		const result = withRetry(() => request('eth_blockNumber'), 3, 1);
+		const assertion = expect(result).rejects.toThrow('over rate limit');
+		await vi.advanceTimersByTimeAsync(999);
+		expect(attempts).toEqual([1, 1, 1, 1, 1, 1]);
+		await vi.advanceTimersByTimeAsync(1);
+		await assertion;
+
+		expect(attempts).toEqual([2, 2, 2, 2, 2, 2]);
+		expect(attempts.reduce((sum, count) => sum + count, 0)).toBe(12);
+	});
+
+	it('recovers when a fallback becomes healthy on the retry round', async () => {
+		vi.useFakeTimers();
+		const attempts = [0, 0];
+		const request = buildRequest([
+			countingTransport(attempts, 0, async () => {
+				throw rateLimitError();
+			}),
+			countingTransport(attempts, 1, async (attempt) => {
+				if (attempt === 1) throw rateLimitError();
+				return '0x123';
+			})
+		]);
+
+		const result = request('eth_blockNumber');
+		await vi.advanceTimersByTimeAsync(999);
+		expect(attempts).toEqual([1, 1]);
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(result).resolves.toBe('0x123');
+		expect(attempts).toEqual([2, 2]);
+	});
+});

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -50,6 +50,42 @@ describe('tradeError', () => {
 		});
 	});
 
+	it('maps RPC rate-limit failures to UPSTREAM_UNAVAILABLE instead of stage fallback', () => {
+		expect(toUserFacingTradeError(new Error('over rate limit'), 'approval')).toMatchObject({
+			code: 'UPSTREAM_UNAVAILABLE',
+			stage: 'approval',
+			errorClass: 'rpc_error'
+		});
+		expect(
+			toUserFacingTradeError({ code: -32016, message: 'over rate limit' }, 'approval')
+		).toMatchObject({
+			code: 'UPSTREAM_UNAVAILABLE'
+		});
+		expect(
+			toUserFacingTradeError(new Error('429 Too Many Requests'), 'confirmation')
+		).toMatchObject({
+			code: 'UPSTREAM_UNAVAILABLE',
+			stage: 'confirmation'
+		});
+	});
+
+	it('maps typed HTTP 429 errors while preserving their request ID', () => {
+		const error = new HttpError({
+			status: 429,
+			code: 'HTTP_429',
+			requestId: 'request-rate-limit',
+			publicMessage: 'over rate limit',
+			retryAfter: '1'
+		});
+
+		expect(toUserFacingTradeError(error, 'approval')).toMatchObject({
+			code: 'UPSTREAM_UNAVAILABLE',
+			requestId: 'request-rate-limit',
+			stage: 'approval',
+			errorClass: 'rpc_error'
+		});
+	});
+
 	it('rejects unsafe codes before they reach support details or telemetry', () => {
 		const result = createTradeError('bad code\nsecret', { stage: 'submission' });
 		expect(result.code).toBe('TRADE_UNKNOWN');

--- a/tests/lib/utils/retry.test.ts
+++ b/tests/lib/utils/retry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withRetry } from '$lib/utils/retry';
+
+describe('withRetry', () => {
+	it('does not retry rate-limit errors owned by the RPC transport', async () => {
+		const fn = vi.fn().mockRejectedValue({ code: -32016, message: 'over rate limit' });
+
+		await expect(withRetry(fn, 3, 1)).rejects.toMatchObject({ code: -32016 });
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('still retries transient block lookup errors', async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('header not found'))
+			.mockRejectedValueOnce({ code: -32000, message: 'block not found' })
+			.mockResolvedValueOnce('ok');
+
+		await expect(withRetry(fn, 3, 1)).resolves.toBe('ok');
+		expect(fn).toHaveBeenCalledTimes(3);
+	});
+
+	it('does not retry unrelated -32000 errors on write paths', async () => {
+		const fn = vi.fn().mockRejectedValue({ code: -32000, message: 'transaction already known' });
+
+		await expect(withRetry(fn, 3, 1)).rejects.toMatchObject({
+			code: -32000,
+			message: 'transaction already known'
+		});
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not retry non-transient errors', async () => {
+		const fn = vi.fn().mockRejectedValue(new Error('insufficient funds'));
+		await expect(withRetry(fn, 3, 1)).rejects.toThrow('insufficient funds');
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -6,13 +6,9 @@ import { mockCurrentNetwork } from './tests/mocks/mockCurrentNetwork';
 const { mockWagmiConfigStore, mockSignerAddressStore, mockChainIdStore, mockConnectedStore, mockWrongNetworkStore } =
 	await vi.hoisted(() => import('./tests/mocks/mockStores'));
 
-// Plan 03-01 (SEC-01) added `import { env as publicEnv } from '$env/dynamic/public'` to
-// `src/lib/config/networks.ts`. SvelteKit's vitest resolver produces a virtual module
-// for `$env/dynamic/public` whose `env` is undefined in the test environment, so any
-// suite that transitively imports `networks.ts` (via stores, services, etc.) crashes
-// at import time with `Cannot read properties of undefined (reading 'env')`. Provide a
-// default empty `env` so the optional-chained `publicEnv.PUBLIC_BASE_RPC_URL` falls back
-// to the public RPC URL. Test files that need specific values can re-mock per-test.
+// SvelteKit's vitest resolver produces a virtual module for `$env/dynamic/public`
+// whose `env` is undefined in the test environment. Provide a default empty `env`;
+// test files that need specific values can re-mock per-test.
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 vi.mock('svelte-wagmi', async () => {


### PR DESCRIPTION
## Summary

- Source the browser wagmi/viem Base RPC list from the active Raindex registry, matching the SDK configuration source.
- Preserve registry order and use bounded viem failover: one retry round and no background provider-ranking pings.
- Remove PUBLIC_BASE_RPC_URL and keep BASE_RPC_URL server-only.
- Bound each registry request to five seconds, then use the configured static Base fallback pool if the registry is unavailable.
- Preserve case-sensitive RPC path and query components while deduplicating equivalent scheme/host URLs.
- Map typed HTTP 429 failures to UPSTREAM_UNAVAILABLE and avoid replaying unrelated -32000 write failures.

## Rotation behavior

- viem tries the registry RPCs in order and falls through when a request fails.
- Reordering or replacing URLs in the active registry is picked up by newly loaded pages after the existing manifest endpoint cache expires; that endpoint currently has a five-minute TTL. An already-open page retains the list it loaded and can still fail over within that list.
- If registry settings cannot be loaded, wallet initialization falls back after the bounded deadline to the non-secret Base RPC pool in src/lib/config/networks.ts.
- A newly introduced provider hostname must also be permitted by the web app CSP.

## Validation

- Full unit suite: 815 passed, 1 skipped.
- Focused review-regression suite: 21 passed.
- Svelte checks, TypeScript, ESLint, Prettier, and git diff checks pass.
- Production Vercel build passes under the supported Node 22 environment.
- Latest Vercel preview verified at commit fa352838: registry-backed wallet initialization completed, the trade page rendered, and no RPC-rate-limit, CSP, or application error appeared.
- Real limit-order deployment E2E previously passed against this PR preview using an Anvil Base fork at block 49576350, including the expected output-vault deposit.