### PR TITLE
Remove collateralisation claims from the homepage

### DIFF
--- a/src/lib/components/QuickTradeChart.svelte
+++ b/src/lib/components/QuickTradeChart.svelte
@@ -7,6 +7,7 @@
 	import { browser } from '$app/environment';
 	import { currentNetwork } from '$lib/stores';
 	import type { CategorizedToken } from '$lib/config/network';
+	import { getTokensByNetwork } from '$lib/config/tokens';
 	import { createTokenTradeActivityQuery } from '$lib/queries/tradeActivity';
 	import { apiTradesToHistoryPoints } from '$lib/utils/ohlc';
 
@@ -35,6 +36,11 @@
 	})();
 
 	$: paymentToken = $currentNetwork?.defaultPaymentToken ?? null;
+
+	// Market count is derived from the live token config rather than hardcoded — the
+	// programme is not equities-only (it holds ETFs, commodity trusts and a closed-end
+	// fund), so the label says "markets" and the number tracks what is actually listed.
+	$: marketCount = $currentNetwork ? getTokensByNetwork($currentNetwork.chainId).length : 0;
 	$: tradeQuery = createTokenTradeActivityQuery($currentNetwork, token?.address ?? null);
 
 	$: assetAddresses = (() => {
@@ -196,7 +202,7 @@
 			></span>
 			<span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
 		</span>
-		{hasRealData ? 'Live on-chain price' : 'Live market · 50+ equities'}
+		{hasRealData ? 'Live on-chain price' : `Live market · ${marketCount} markets`}
 	</div>
 </div>
 

--- a/src/lib/components/QuickTradeChart.svelte
+++ b/src/lib/components/QuickTradeChart.svelte
@@ -202,7 +202,9 @@
 			></span>
 			<span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
 		</span>
-		{hasRealData ? 'Live on-chain price' : `Live market · ${marketCount} markets`}
+		{hasRealData
+			? 'Live on-chain price'
+			: `Live market · ${marketCount} market${marketCount === 1 ? '' : 's'}`}
 	</div>
 </div>
 

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -23,7 +23,7 @@
 	}
 
 	// Typewriter animation for hero text
-	const typewriterWords = ['Global', 'Collateralised', 'DeFi-Ready', 'Transferable', 'Redeemable'];
+	const typewriterWords = ['Global', 'DeFi-Ready', 'Transferable', 'Right of Exchange'];
 	let currentWordIndex = 0;
 	let displayedText = '';
 	let isDeleting = false;
@@ -247,7 +247,7 @@
 						</p>
 					</div>
 
-					<!-- 1:1 Collateralised -->
+					<!-- Right of Exchange -->
 					<div class="icon-trigger flex flex-col items-center text-center">
 						<div class="pillar-float" style="animation-delay: -4.6s">
 							<div
@@ -256,9 +256,10 @@
 								<Icon name="shield" className="h-7 w-7" />
 							</div>
 						</div>
-						<h3 class="mt-4 text-base font-semibold text-text">1:1 Collateralised</h3>
+						<h3 class="mt-4 text-base font-semibold text-text">Right of Exchange</h3>
 						<p class="mt-2 max-w-[17rem] text-[13.5px] leading-relaxed text-text-2">
-							Every token fully collateralised with a legal right of exchange.
+							Every issued token carries a contractual right to delivery of the corresponding
+							security, on the terms set out in the Base Prospectus and Final Terms.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
Correction of inaccuracies identified in the **7 August 2026 public estate review** (merged findings register). Homepage surface only — one deliberate, dated deployment per the register's correction protocol (decision 2).

## Findings addressed

| # | Severity | Finding |
|---|---|---|
| 2.1 | Critical | Homepage hero asserted "1:1 Collateralised — Every token fully collateralised with a legal right of exchange." |
| 2.2 | High | Hero typewriter array shipped `"Collateralised"` and `"Redeemable"` in the production bundle |
| 2.14 | High | `"Live market · 50+ equities"` hardcoded; live count is 38 and a material fraction are not equities |

## What changed

**2.1 — the collateral claim.** "Collateralised" asserts security. No executed collateral, pledge or trust structure exists; tokenholders are unsecured contractual creditors, and shares at the broker are held for the Issuer's own account as a hedge. The heading goes entirely — there is no compliant version of it. Replaced with the register's suggested wording, which states the right that actually exists and is genuinely differentiating against cash-settled competitors:

> **Right of Exchange** — Every issued token carries a contractual right to delivery of the corresponding security, on the terms set out in the Base Prospectus and Final Terms.

**2.2 — the rotating hero words.** Animated text is published text; it is in the shipped source and screenshots capture it. `"Collateralised"` repeats 2.1 in animated form. `"Redeemable"`, unqualified, asserts a redemption right — the actual right is the contractual Right of Exchange on prospectus terms, and any redemption mechanics sit with the Issuer under the Final Terms.

```diff
-const typewriterWords = ['Global', 'Collateralised', 'DeFi-Ready', 'Transferable', 'Redeemable'];
+const typewriterWords = ['Global', 'DeFi-Ready', 'Transferable', 'Right of Exchange'];
```

**2.14 — the hardcoded counter.** The register flags this as direct evidence that the site hardcodes figures, and requires every published-as-current figure to be generated from data. `marketCount` is now derived from `getTokensByNetwork()`, which returns 38 today — matching the register's independent count from the markets page and sitemap. The label changes from "equities" to "markets" because eleven listed instruments are ETFs, commodity grantor trusts, a closed-end fund and a 3x daily leveraged ETF.

## Deliberately not in this PR

- **Pioneers logo strip (1.5)** — a decision, not an edit. Removal timing after the 27 July Abmahnung needs Engert's view. Untouched.
- **"Decentralised" pillar** — decision 7 holds this pending the identity of the beacon owner `0xe70d...d611`. Untouched.
- The Terms clause 5 rewrite that 1.5 also requires ships separately.

## Verification

Branched from `259f0ead`, the exact build hash the register recorded live on the homepage, `/faqs`, `/markets` and token pages. `prettier --list-different` and `eslint` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated market chart messaging to reflect the active network’s available markets, including correct singular and plural wording.
  * Refreshed hero messaging with new product positioning terms.
  * Renamed and updated the third trust pillar to “Right of Exchange,” including clearer information about contractual delivery rights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->