### PR TITLE
Classify instruments and stop publishing a charting prefix as the exchange

### DIFF
--- a/src/lib/config/instruments.ts
+++ b/src/lib/config/instruments.ts
@@ -1,0 +1,90 @@
+/**
+ * Instrument classification for the issued programme.
+ *
+ * The programme is not equities-only. Of the instruments currently listed,
+ * eleven are exchange-traded funds, commodity grantor trusts, a closed-end fund
+ * or a leveraged ETF. Describing all of them as "equities" understates the book,
+ * so category language and per-instrument risk disclosure are both driven off
+ * this map rather than being written by hand into page copy.
+ *
+ * Keyed by the underlying ticker (uppercased). Anything absent is treated as a
+ * single-name equity, which is the common case.
+ */
+export type InstrumentType =
+	| 'equity'
+	| 'etf'
+	| 'bond-etf'
+	| 'leveraged-etf'
+	| 'commodity-trust'
+	| 'closed-end-fund'
+	| 'fund';
+
+export const INSTRUMENT_TYPES: Readonly<Record<string, InstrumentType>> = {
+	ARKK: 'etf',
+	DRAM: 'etf',
+	IAU: 'commodity-trust',
+	PPLT: 'commodity-trust',
+	PTY: 'closed-end-fund',
+	QQQM: 'etf',
+	SGOV: 'bond-etf',
+	SIVR: 'commodity-trust',
+	SPYM: 'etf',
+	TQQQ: 'leveraged-etf',
+	VWO: 'fund'
+};
+
+export function getInstrumentType(ticker: string): InstrumentType {
+	return INSTRUMENT_TYPES[ticker.toUpperCase()] ?? 'equity';
+}
+
+/**
+ * Risk disclosure rendered above the trade button for instruments whose risk
+ * profile is not conveyed by the underlying's name alone. Single-name equities
+ * and plain broad-market funds return null — the generic risk line already on
+ * the page covers them.
+ */
+export function getInstrumentRiskDisclosure(type: InstrumentType): string | null {
+	switch (type) {
+		case 'leveraged-etf':
+			return (
+				'This instrument is a leveraged exchange-traded fund. It aims to deliver three times the ' +
+				'daily return of its index. Returns compound daily, so over any period longer than one ' +
+				'day the result can differ substantially from three times the index return over that ' +
+				'period, including in a rising market. It is not designed to be held long term.'
+			);
+		case 'commodity-trust':
+			return (
+				'This instrument is a commodity grantor trust. It holds physical metal rather than shares ' +
+				'in an operating company, and it is not an equity security. Its value tracks the metal ' +
+				'price less the expenses of the trust, and it pays no dividend.'
+			);
+		case 'closed-end-fund':
+			return (
+				'This instrument is a closed-end fund. Its shares trade at a price that can differ ' +
+				'significantly from the value of the fund’s underlying holdings, and the fund may use ' +
+				'leverage.'
+			);
+		default:
+			return null;
+	}
+}
+
+/** Human-readable category label, used where copy needs to name the instrument type. */
+export function getInstrumentLabel(type: InstrumentType): string {
+	switch (type) {
+		case 'etf':
+			return 'exchange-traded fund';
+		case 'bond-etf':
+			return 'bond exchange-traded fund';
+		case 'leveraged-etf':
+			return 'leveraged exchange-traded fund';
+		case 'commodity-trust':
+			return 'commodity grantor trust';
+		case 'closed-end-fund':
+			return 'closed-end fund';
+		case 'fund':
+			return 'fund';
+		default:
+			return 'listed security';
+	}
+}

--- a/src/lib/seo/assets.ts
+++ b/src/lib/seo/assets.ts
@@ -1,4 +1,10 @@
 import { TOKENS } from '$lib/config/tokens';
+import {
+	getInstrumentLabel,
+	getInstrumentRiskDisclosure,
+	getInstrumentType,
+	type InstrumentType
+} from '$lib/config/instruments';
 
 /**
  * SEO metadata for a single tokenized asset, derived from the token registry in
@@ -9,8 +15,12 @@ export interface SeoAsset {
 	slug: string;
 	/** Underlying ticker, uppercased. e.g. 'NVDA' */
 	ticker: string;
-	/** Listing venue of the underlying. e.g. 'NASDAQ' */
-	exchange: string;
+	/** What kind of instrument the underlying is. e.g. 'commodity-trust' */
+	instrumentType: InstrumentType;
+	/** Human-readable instrument category. e.g. 'commodity grantor trust' */
+	instrumentLabel: string;
+	/** Risk disclosure for complex instruments, or null where none is required. */
+	riskDisclosure: string | null;
 	/** Human-friendly underlying name. e.g. 'NVIDIA Corporation' */
 	companyName: string;
 	/** On-chain token symbol. e.g. 'wtNVDA' */
@@ -25,9 +35,16 @@ function toSeoAsset(token: (typeof TOKENS)[number]): SeoAsset | null {
 	const tv = token.tradingViewSymbol;
 	if (!tv) return null;
 
-	const [exchange, rawTicker] = tv.includes(':') ? tv.split(':') : ['', tv];
+	// Only the ticker is taken from the TradingView symbol. The prefix before the
+	// colon is TradingView's own namespace, not a listing venue — it renders
+	// "AMEX" for NYSE Arca-listed funds, for example — so it must not be
+	// published as the underlying's exchange. Listing venues are omitted from the
+	// pages until they are sourced and audited separately.
+	const rawTicker = tv.includes(':') ? tv.split(':')[1] : tv;
 	const ticker = rawTicker?.trim();
 	if (!ticker) return null;
+
+	const instrumentType = getInstrumentType(ticker);
 
 	const companyName = token.name
 		.replace(/^Wrapped\s+/i, '')
@@ -37,7 +54,9 @@ function toSeoAsset(token: (typeof TOKENS)[number]): SeoAsset | null {
 	return {
 		slug: ticker.toLowerCase(),
 		ticker,
-		exchange: exchange ?? '',
+		instrumentType,
+		instrumentLabel: getInstrumentLabel(instrumentType),
+		riskDisclosure: getInstrumentRiskDisclosure(instrumentType),
 		companyName,
 		tokenSymbol: token.symbol,
 		logoUrl: token.logoUrl,

--- a/src/routes/(main)/markets/+page.svelte
+++ b/src/routes/(main)/markets/+page.svelte
@@ -11,9 +11,9 @@
 				Tokenized markets
 			</h1>
 			<p class="mb-12 max-w-2xl text-lg leading-relaxed text-gray-400">
-				Every asset on ST0x provides DeFi-native, on-chain exposure to an underlying security and is
-				available for non-custodial trading 24/7. Explore the tokenized stocks, ETFs and commodities
-				available to trade.
+				Every market on ST0x gives on-chain exposure to an underlying listed instrument and can be
+				traded from a self-custodied wallet at any hour. The programme covers single-name equities,
+				exchange-traded funds and commodity trusts.
 			</p>
 
 			<ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/(main)/markets/[symbol]/+page.svelte
+++ b/src/routes/(main)/markets/[symbol]/+page.svelte
@@ -51,7 +51,7 @@
 						Trade tokenized {asset.companyName}
 					</h1>
 					<p class="mt-2 text-lg text-gray-400">
-						{asset.ticker} · {asset.exchange} · {asset.tokenSymbol} on Base
+						{asset.ticker} · {asset.tokenSymbol} on Base
 					</p>
 				</div>
 			</div>
@@ -78,8 +78,9 @@
 					</h2>
 					<p class="leading-relaxed">
 						Tokenized {asset.companyName} ({asset.ticker}) provides on-chain exposure to the
-						underlying {asset.exchange}-listed security. The issued asset token represents shares
-						held with a regulated broker. On ST0x it trades as
+						underlying listed {asset.instrumentLabel}. The issued asset token is a claim against S01
+						Issuer GmbH on the terms set out in its base prospectus; holders are unsecured
+						contractual creditors of the Issuer. On ST0x it trades as
 						<span class="font-mono text-gray-200">{asset.tokenSymbol}</span>, a vault wrapper on
 						Base whose exchange rate to the issued token can change over time.
 					</p>
@@ -107,6 +108,13 @@
 					</ul>
 				</div>
 
+				{#if asset.riskDisclosure}
+					<div class="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-6">
+						<h2 class="mb-2 text-xl font-semibold text-amber-200">Product risk</h2>
+						<p class="leading-relaxed text-amber-100/90">{asset.riskDisclosure}</p>
+					</div>
+				{/if}
+
 				<div class="rounded-2xl border border-white/10 bg-gray-800/50 p-6 backdrop-blur-sm">
 					<h2 class="mb-2 text-xl font-semibold text-white">Ready to trade {asset.ticker}?</h2>
 					<p class="mb-4 leading-relaxed text-gray-400">
@@ -123,7 +131,9 @@
 
 				<p class="text-xs leading-relaxed text-gray-600">
 					Trading tokenized assets involves substantial risk. Past performance does not guarantee
-					future results. Regional restrictions may apply at token issuance.
+					future results. Access requirements and eligibility restrictions apply. See the Base
+					Prospectus and Final Terms for the jurisdictions and investor categories in which the
+					tokens may be offered.
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Correction of inaccuracies identified in the **7 August 2026 public estate review**. Covers the `/markets` index and all 38 token pages.

## Findings addressed

| # | Severity | Finding |
|---|---|---|
| 2.15 | Critical | Exchange labels unreliable across the book — IAU renders "AMEX" but trades on NYSE Arca |
| 2.14 | High | The book is not an equity programme, but the estate says it is |
| 2.12 | Critical | No per-asset risk disclosure; TQQQ described only as "the underlying NASDAQ-listed security" |
| 2.5 | Critical | "The issued asset token represents shares held with a regulated broker" — on all 38 pages |

## The exchange label — root cause

The register flags IAU as proof "exchange data is unreliable across the book, not just on one page". It is right, and the cause is one line in `src/lib/seo/assets.ts`:

```ts
const [exchange, rawTicker] = tv.includes(':') ? tv.split(':') : ['', tv];
```

The venue was being parsed off the **TradingView symbol prefix**. That prefix is TradingView's own charting namespace, not a listing venue — it uses `AMEX:` for NYSE Arca-listed funds, which is exactly the IAU error. Any label derived this way is unreliable by construction.

I have **removed the label rather than guessed at a replacement**. Populating 38 listing venues from memory would reintroduce the same class of defect the register is complaining about, and its instruction is explicit: *"audit every exchange label against a reliable source before the markets pages render again."* The parse now takes only the ticker, with a comment recording why the prefix must not be republished. Reinstating venues is a data task with a sourced input, not a code change.

The `{asset.exchange}` render in the page subtitle and the "underlying {exchange}-listed security" sentence are both gone.

## Instrument classification (new module)

`src/lib/config/instruments.ts` classifies the eleven non-equity instruments from the register's own enumerated table — ARKK, DRAM, IAU, PPLT, PTY, QQQM, SGOV, SIVR, SPYM, TQQQ, VWO. Anything absent defaults to `equity`. Keeping this as a standalone, reviewable list means counsel can check the classification without reading Svelte.

This drives two things: category language, and risk disclosure.

## Per-asset risk block (2.12)

Rendered above the trade button, driven off the instrument type as the register specifies. TQQQ gets the register's wording verbatim:

> **Product risk.** This instrument is a leveraged exchange-traded fund. It aims to deliver three times the daily return of its index. Returns compound daily, so over any period longer than one day the result can differ substantially from three times the index return over that period, including in a rising market. It is not designed to be held long term.

Commodity grantor trusts (IAU, PPLT, SIVR) and the closed-end fund (PTY) carry their own blocks — these are restrained factual statements I have written, not register-supplied copy, so they are worth a read. Single-name equities and plain broad-market funds return `null` and render nothing; the generic risk line already covers them.

## Category and ownership copy

Markets intro now uses the register's replacement — "single-name equities, exchange-traded funds and commodity trusts", never "equities" as the umbrella. The per-token sentence "The issued asset token represents shares held with a regulated broker" is replaced with the unsecured-creditor position, matching the FAQ answer in #258.

The generic footer line drops "Regional restrictions may apply at token issuance" for the same interim access wording used in #258.

## SPCX

**Left listed.** The register's finding 2.15 calls for delisting on the basis that SpaceX is private with no NASDAQ listing, but `tokens.ts` records the token as deployed 2026-06-10 ahead of a 2026-06-12 Nasdaq IPO (ISIN US84615Q1031), and you have confirmed the listing completed. Tier 0.5 is therefore not applied. SPCX still benefits from the copy fixes above along with every other token page.

Worth flagging back to the reviewer, since 2.15 is one of the register's Critical findings and its premise does not hold.

## Verification

`svelte-check`: 28 errors, all pre-existing (`@rainlanguage/raindex` unresolvable in this environment), **zero in touched files**. `prettier` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)