### PR TITLE
Correct the onboarding tour and the site-wide metadata

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -831,13 +831,13 @@
 			<span class="h-px flex-1 bg-line"></span>
 		</div>
 
-		<!-- Launch Trading Terminal (secondary) -->
+		<!-- Open the trading interface (secondary) -->
 		<button
 			type="button"
 			class="w-full rounded-xl border border-line-strong bg-overlay-2 py-3 text-sm font-semibold text-text transition hover:bg-overlay-hover"
 			on:click={() => goto('/trade/0x2289249984f1fa2ce86c4e8867e7eb819ea7df95')}
 		>
-			Launch Trading Terminal
+			Open the trading interface
 		</button>
 	</div>
 

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -41,13 +41,13 @@
 		welcome: {
 			title: 'Welcome to ST0x',
 			description:
-				'U.S. equities on-chain. Fully decentralised. Fully backed by real equities. 24/7 trading.',
+				'Tokenised exposure to U.S.-listed assets, on-chain, at any hour. Each issued token carries a contractual Right of Exchange for the underlying.',
 			buttonText: 'Next',
 			isModal: true
 		},
 		'token-list': {
-			title: 'Tradeable Equities',
-			description: 'Currently tradeable equities. More coming soon.',
+			title: 'Tradeable assets',
+			description: 'Currently tradeable assets. More coming soon.',
 			targetSelector: '[data-tutorial="token-list"]',
 			buttonText: 'Next'
 		},
@@ -60,25 +60,25 @@
 		'buy-sell-panel': {
 			title: 'Place Orders',
 			description:
-				'Click Buy or Sell to open the order panel. Choose between market orders, limit orders, and DCAs. All orders are against USDC on Base.',
+				'This interface lets you submit orders to the on-chain contracts. Choose market, limit or DCA. All orders are against USDC on Base.',
 			targetSelector: ['[data-tutorial="buy-sell-buttons"]', '[data-tutorial="trade-panel"]'],
 			buttonText: 'Next'
 		},
 		tradingview: {
 			title: 'Live Market Data',
-			description: 'Live US exchange data on the underlying equity.',
+			description: 'Live US exchange data on the underlying instrument.',
 			targetSelector: ['[data-tutorial="symbol-overview"]', '[data-tutorial="tradingview"]'],
 			buttonText: 'Next'
 		},
 		'dex-activity': {
 			title: 'On-chain Market',
-			description: 'On-chain orderbook and transaction data, including your orders and holdings.',
+			description: 'On-chain order and transaction data, including your orders and holdings.',
 			targetSelector: '[data-tutorial="dex-activity"]',
 			buttonText: 'Next'
 		},
 		fundamentals: {
 			title: 'Learn More',
-			description: 'Explore the underlying equity details or token fundamentals.',
+			description: 'Explore the underlying instrument details or token fundamentals.',
 			targetSelector: '[data-tutorial="fundamentals"]',
 			buttonText: 'Finish'
 		},

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -214,7 +214,7 @@
 			<div class="mt-16 sm:mt-24 lg:mt-28">
 				<p class="text-accent/70 text-xs font-semibold uppercase tracking-[0.2em]">Why st0x</p>
 				<h2 class="mt-3 text-2xl font-bold tracking-tight text-text sm:text-[32px]">
-					Tokenised equities &amp; yield, done properly.
+					Tokenised stocks, ETFs &amp; commodity trusts, done properly.
 				</h2>
 				<div class="mt-10 grid gap-8 sm:grid-cols-3">
 					<!-- Decentralised -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,9 +12,12 @@
 	// load function. Without these, crawlers fall back to scraping visible body text
 	// (e.g. the footer risk warning).
 	const SITE_URL = 'https://www.st0x.io';
-	const DEFAULT_TITLE = 'ST0x — Trade & Earn on DeFi-Native Tokenized Assets';
+	// Metadata travels on every shared link and every search result, so it must not
+	// promise earning or yield: there is no yield product, no terms and no risk
+	// framing behind such a claim, and the audience is ungated.
+	const DEFAULT_TITLE = 'ST0x — Tokenised U.S.-Listed Assets, On-Chain';
 	const DEFAULT_DESCRIPTION =
-		'ST0x brings real-world assets on-chain as DeFi-first tokens. Trade tokenized stocks, ETFs & commodities 24/7, then earn yield with fully composable, on-chain assets.';
+		'Tokenised exposure to U.S.-listed stocks, ETFs and commodity trusts. On-chain, self-custodied, at any hour. Each issued token carries a contractual Right of Exchange.';
 	const OG_IMAGE = `${SITE_URL}/og-image.png`;
 
 	$: metaTitle = ($page.data?.title as string | undefined) ?? DEFAULT_TITLE;


### PR DESCRIPTION
Correction of inaccuracies identified in the **7 August 2026 public estate review**. Two surfaces the register reached by reading shipped bundles rather than server HTML.

## Findings addressed

| # | Severity | Finding |
|---|---|---|
| 2.3 | Critical | Onboarding tutorial says "Fully backed by real equities" and teaches order types in the operator's product voice |
| 3.3 | Medium | "Trade & Earn" / "earn yield" in every title, description and share card, with no yield product |

## 2.3 — the onboarding tour

Found by the reviewer in production chunk `Tutorial.8GvMErbD.js`, triggered by the homepage "New? Take the tour" button. The register counts four breaches in one component.

**Welcome step.** Was: *"U.S. equities on-chain. Fully decentralised. Fully backed by real equities. 24/7 trading."* — "Fully backed" is the collateral class from 2.1, and "U.S. equities on-chain" describes the tokens as *being* the equities rather than instruments referencing them. Replaced with the register's wording.

**Order panel step.** Was: *"Click Buy or Sell to open the order panel. Choose between market orders, limit orders, and DCAs."* The register's concern is precise — this is the operator walking a first-time user through order types in its own product voice, which is exactly what a supervisor reads when deciding whether the interface operator exercises discretion over access. Reframed per the register to present the interface as one client of open contracts:

> This interface lets you submit orders to the on-chain contracts. Choose market, limit or DCA. All orders are against USDC on Base.

**Definite article.** "On-chain orderbook and transaction data" → "On-chain order and transaction data", removing the article that implies an operated facility.

**Equities-only language.** "Tradeable Equities" → "Tradeable assets", and the underlying-equity references in the TradingView and fundamentals steps become "instrument", consistent with #260.

### VaultTutorial deliberately untouched

The register also flags the "Understanding Vaults" and "Vault Deposits" steps. Those live in `VaultTutorial.svelte`, and reading them, the copy is purely mechanical — how a spending budget lands in a vault and how to withdraw it. No collateral, backing, custody or venue-ownership claim. The register's objection is **structural** (onboarding users into vault deposits at all, as evidence going to the 10.2 discretion trigger), which is a product decision and not something a copy edit resolves. Flagging rather than silently rewording it.

## 3.3 — metadata

Metadata travels on every shared link and every search result. The register's point is that combined with the preview APY strip (2.4) and the referral-campaign capture on urlscan (1.10), the picture an opponent assembles is retail yield marketing — promised to an ungated audience with no product, no terms and no risk framing behind it.

```diff
-'ST0x — Trade & Earn on DeFi-Native Tokenized Assets'
+'ST0x — Tokenised U.S.-Listed Assets, On-Chain'
```

The description takes the register's replacement. **The Organization JSON-LD description derives from the same constant**, so it is corrected automatically — the register calls out that block specifically, and this is why it stays in sync.

Also in scope, same finding: the homepage subhead *"Tokenised equities & yield, done properly"* (which carried both the yield claim and the 2.14 equities-umbrella problem), and the *"Launch Trading Terminal"* button → *"Open the trading interface"*.

Verified no residual `Trade & Earn`, `earn yield` or `Trading Terminal` anywhere in `src/`.

## A note on reach

Correcting the metadata here does not clear the superseded wording from search surfaces on its own. Per finding 1.1, a Search Console recrawl should be requested once these deploy, and per 1.10 the Wayback captures of 21 May and 6 June predate the Abmahnung and are unaffected by any edit.

## Verification

Branched from `259f0ead`. `prettier` and `eslint` clean on all four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)