### PR TITLE
Privacy policy: remove named directors and correct three factual errors

### DIFF
--- a/src/routes/(main)/privacy-policy/+page.svelte
+++ b/src/routes/(main)/privacy-policy/+page.svelte
@@ -20,8 +20,6 @@
 			</p>
 			<div class="mb-6 text-text-2">
 				<p class="font-semibold text-text">SARK X (BVI) Ltd</p>
-				<p>represented by the managing directors</p>
-				<p>Toby Meller and Nicholas Magliocchetti</p>
 				<p>Craigmuir Chambers, Road Town, Tortola</p>
 				<p>VG 1110, British Virgin Islands</p>
 				<p>
@@ -85,7 +83,7 @@
 			<p class="mb-4 text-text-2">
 				The legal bases for the setting of cookies are legitimate interests under Art. 6 (1) (f)
 				GDPR and, if applicable, your consent in accordance with Art. 6 (1) (a) GDPR in conjunction
-				with. &sect; 25 TTDSG. In the case of the initiation of a contract or an ongoing contractual
+				with. &sect; 25 TDDDG. In the case of the initiation of a contract or an ongoing contractual
 				relationship, the legal basis also follows from Art. 6 (1) (b) GDPR.
 			</p>
 			<p class="mb-4 text-text-2">
@@ -211,7 +209,7 @@
 				with immediate effect in accordance with Art. 7 (3) sentence 1 GDPR. Please note that data
 				processing that took place before the revocation is not affected by the revocation and is
 				therefore lawful despite the revocation. If you would like to make use of your right of
-				revocation, a simple notification to the person listed under no. 1.
+				revocation, a simple notification to the controller listed under no. 1 is sufficient.
 			</p>
 
 			<h3 class="mb-3 mt-6 text-xl font-semibold text-text">
@@ -246,9 +244,9 @@
 
 			<h2 class="mb-4 mt-8 text-2xl font-bold text-text">5. Data integrity</h2>
 			<p class="mb-4 text-text-2">
-				To ensure data security on our website, we encrypt it using the SSL method in accordance
-				with the current state of the art. We use appropriate technical and organizational measures
-				to prevent accidental or intentional manipulation, partial or total loss, destruction or
+				To ensure data security on our website, we encrypt it using TLS in accordance with the
+				current state of the art. We use appropriate technical and organizational measures to
+				prevent accidental or intentional manipulation, partial or total loss, destruction or
 				unauthorized access to your data by third parties. Our security measures are continuously
 				improved in line with technological developments. Furthermore, all service providers
 				commissioned by us are obliged by means of appropriate contractual agreements to take


### PR DESCRIPTION
Correction of inaccuracies identified in the **7 August 2026 public estate review**.

## Scope is deliberately narrow

The register's instruction at 3.5 is explicit:

> The policy needs a rebuild by counsel, not a patch. These are the items to hand them, alongside the posture decision at 1.7.

So this PR changes **only plain factual errors** — a name that should not be published, a statute that no longer exists under that name, a sentence with no verb, and a superseded protocol name. Every drafting and posture question is left for counsel. This is not an attempt at the rebuild.

## Findings addressed

| # | Severity | Change |
|---|---|---|
| 1.7 | High | Removed "represented by the managing directors / Toby Meller and Nicholas Magliocchetti" |
| 1.7 | High | `§ 25 TTDSG` → `§ 25 TDDDG` |
| 3.5 | High | Completed the unfinished right-of-revocation sentence |
| 3.5 | High | "we encrypt it using the SSL method" → "using TLS" |

**The named directors.** GDPR requires a controller and a contact point; it does not require named directors. The register's objection is twofold — it is a public assertion about the BVI entity's management at a time when the group relationship is deliberately unresolved (2.13), and it hands Grünecker two named natural persons for personal liability pleading. The controller block still names the entity, its registered address, a contact and the website, which is what the regulation actually asks for.

**TTDSG.** Renamed TDDDG with effect from 14 May 2024 — the citation has been wrong for over two years. Note this correction is *interim*: if decision 4 goes the "genuinely offshore" way, the German statutory citations come out entirely rather than being corrected. Fixing the name is right either way in the meantime, since it is wrong as published today.

**The two hygiene errors** are self-explanatory and were both flagged in the register's own list.

## Explicitly left for counsel

Everything else in 1.7 and 3.5, unchanged:

- **The posture decision (decision 4)** — whether the site is Germany-directed with an Impressum and consistent statutory pages, or genuinely offshore with a jurisdiction-neutral policy and no German citations. The register is clear both cannot stand, and that Engert decides because it interacts directly with the Abmahnung.
- **Undisclosed processors** — Sentry, PostHog, Dynamic, TradingView, Cloudflare Turnstile and WalletConnect all load and none is named in the policy. Adding them is substantive drafting, not a typo fix.
- **Cookie legal basis** resting on legitimate interest, which § 25 does not permit for non-essential cookies, and the pre-*Planet49* "most browsers are preset" formulation.
- **No Article 27 EU representative** for a BVI controller offering services to EEA data subjects.
- **Third-country transfers** permitted only under an adequacy decision, when the BVI has none and the controller is in the BVI.
- **No retention periods, no supervisory authority, no DPO.**
- **Wallet addresses are not mentioned at all** — the register calls this the largest substantive gap, since they are the estate's actual processing and are personal data when linkable.
- **LinkedIn** is linked in the footer and absent from the policy.

## One thing I could not fix

The contact remains `toby@st0x.io`. The register's replacement controller block calls for "a dedicated address, not a personal mailbox" — that needs the mailbox to exist before the page can point at it. Ops action, not a code change.

## Verification

Branched from `259f0ead`. `prettier` and `eslint` clean. No `TTDSG` or `SSL` references remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)