### PR TITLE
feat: make website configuration multichain

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -304,7 +304,7 @@ async function collectProcessedOrderPages({
  * request stream and converts them to ProcessedQuotes.
  */
 export async function fetchAndQuotePaymentTokenOrders(
-	networkId: number = 8453,
+	networkId: number,
 	overridePaymentToken?: Token,
 	signal?: AbortSignal,
 	fetchOrders: OrdersQueryFetcher = apiQueryOrders
@@ -361,13 +361,14 @@ export async function fetchAndQuoteOwnerOrders(
 ): Promise<ProcessedQuote[]> {
 	const { paymentToken, allTokens } = resolveNetworkTokens(networkId, overridePaymentToken);
 	const chainId = networks.find((n) => n.id === networkId)?.chainId;
+	if (chainId === undefined) throw new Error(`Unknown network ${networkId}`);
 
 	const processedQuotes: ProcessedQuote[] = [];
 	const seen = new Set<string>();
 	let page = 1;
 	let hasMore = true;
 	while (hasMore && page <= MAX_ORDER_PAGES) {
-		const response = await apiGetOrdersByOwner(ownerAddress, { page, pageSize: 50 });
+		const response = await apiGetOrdersByOwner(ownerAddress, chainId, { page, pageSize: 50 });
 		for (const order of response.orders) {
 			if (chainId !== undefined && order.chainId !== chainId) continue;
 			if (seen.has(order.orderHash)) continue;
@@ -402,9 +403,11 @@ export async function fetchAndQuoteTokenOrders(
 	overridePaymentToken?: Token
 ) {
 	const { paymentToken, allTokens } = resolveNetworkTokens(networkId, overridePaymentToken);
+	const chainId = networks.find((network) => network.id === networkId)?.chainId;
+	if (chainId === undefined) throw new Error(`Unknown network ${networkId}`);
 
 	return collectProcessedOrderPages({
-		fetchPage: (page) => apiGetOrdersByToken(tokenAddress, { page, pageSize: 50 }),
+		fetchPage: (page) => apiGetOrdersByToken(tokenAddress, chainId, { page, pageSize: 50 }),
 		paymentToken,
 		allTokens,
 		networkId,

--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -32,12 +32,14 @@ export interface ApiToken extends ApiTokenRef {
 // ============================================================================
 
 export interface ApiSwapQuoteRequest {
+	chainId: number;
 	inputToken: string;
 	outputToken: string;
 	outputAmount: string;
 }
 
 export interface ApiSwapQuoteResponse {
+	chainId: number;
 	inputToken: string;
 	outputToken: string;
 	outputAmount: string;
@@ -60,6 +62,7 @@ export interface ApiApproval {
 }
 
 export interface ApiSwapCalldataResponse {
+	chainId: number;
 	to: string;
 	data: string;
 	value: string;
@@ -70,6 +73,7 @@ export interface ApiSwapCalldataResponse {
 export type ApiSwapCalldataMode = 'buyUpTo' | 'spendExact' | 'spendUpTo';
 
 export interface ApiSwapV2RequestCommon {
+	chainId: number;
 	inputToken: string;
 	outputToken: string;
 	mode: ApiSwapCalldataMode;
@@ -156,6 +160,7 @@ export interface ApiOrdersQueryRequest {
 // ============================================================================
 
 export interface ApiTradeByAddress {
+	chainId: number;
 	txHash: string;
 	inputAmount: string;
 	outputAmount: string;
@@ -180,6 +185,7 @@ export interface ApiTradesByAddressResponse {
 }
 
 export interface ApiTradeByTxEntry {
+	chainId: number;
 	orderHash: string;
 	orderOwner: string;
 	request: {
@@ -196,6 +202,7 @@ export interface ApiTradeByTxEntry {
 }
 
 export interface ApiTradesByTxResponse {
+	chainId: number;
 	txHash: string;
 	blockNumber: number;
 	timestamp: number;
@@ -225,7 +232,7 @@ export interface ApiTradesBatchResponse {
 export interface ApiTradesOrderHashesQueryRequest {
 	orderHashes: string[];
 	tokenAddresses?: string[];
-	chainId?: number;
+	chainId: number;
 	startTime?: number;
 	endTime?: number;
 	denomination?: 'wrapped' | 'unwrapped';
@@ -268,6 +275,7 @@ export interface ApiTokenProofReceipt {
 }
 
 export interface ApiTokenProofsResponse {
+	chainId: number;
 	address: string;
 	metadata: MetaV1S[];
 	schemas: ApiTokenProofSchema[];
@@ -279,11 +287,13 @@ export interface ApiTokenProofsResponse {
 // ============================================================================
 
 export interface ApiTokenDetailsError {
+	chainId: number;
 	address: string;
 	message: string;
 }
 
 export interface ApiTokenDetailsSummary {
+	chainId: number;
 	address: string;
 	deployTimestamp?: number;
 	receiptContractAddress?: string | null;
@@ -329,6 +339,7 @@ export interface ApiTokenDetailsListResponse {
 // ============================================================================
 
 export interface ApiWrapRatio {
+	chainId: number;
 	shareAddress: string;
 	assetAddress: string;
 	assetsPerShare: string;
@@ -338,6 +349,7 @@ export interface ApiWrapRatio {
 }
 
 export interface ApiWrapRatioError {
+	chainId: number;
 	shareAddress: string;
 	message: string;
 }
@@ -356,6 +368,7 @@ export interface ApiWrapRatioHistoryEvent {
 }
 
 export interface ApiWrapRatioHistoryResponse {
+	chainId: number;
 	shareAddress: string;
 	assetAddress: string;
 	events: ApiWrapRatioHistoryEvent[];
@@ -440,6 +453,7 @@ function apiUrl(path: string, params?: Record<string, string | number | undefine
  */
 export async function apiGetOrdersByToken(
 	tokenAddress: string,
+	chainId: number,
 	options?: {
 		page?: number;
 		pageSize?: number;
@@ -448,7 +462,8 @@ export async function apiGetOrdersByToken(
 	}
 ): Promise<ApiOrdersListResponse> {
 	assertBrowser('apiGetOrdersByToken');
-	const url = apiUrl(`/v1/orders/token/${tokenAddress}`, {
+	const url = apiUrl(`/v2/orders/token/${tokenAddress}`, {
+		chainId,
 		page: options?.page,
 		pageSize: options?.pageSize,
 		side: options?.side,
@@ -465,7 +480,7 @@ export async function apiQueryOrders(
 	signal?: AbortSignal
 ): Promise<ApiOrdersListResponse> {
 	assertBrowser('apiQueryOrders');
-	return fetchJson<ApiOrdersListResponse>(apiUrl('/v1/orders/query'), {
+	return fetchJson<ApiOrdersListResponse>(apiUrl('/v2/orders/query'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(request),
@@ -476,25 +491,28 @@ export async function apiQueryOrders(
 /**
  * Fetch the canonical supported token list from the REST API.
  */
-export async function apiGetTokens(): Promise<ApiToken[]> {
+export async function apiGetTokens(chainId?: number): Promise<ApiToken[]> {
 	assertBrowser('apiGetTokens');
-	return fetchJson<ApiToken[]>(apiUrl('/v1/tokens'));
+	return fetchJson<ApiToken[]>(apiUrl('/v2/tokens', { chainId }));
 }
 
 /**
  * Fetch raw proof/attestation metadata for a tokenized asset.
  */
-export async function apiGetTokenProofs(address: string): Promise<ApiTokenProofsResponse> {
+export async function apiGetTokenProofs(
+	address: string,
+	chainId: number
+): Promise<ApiTokenProofsResponse> {
 	assertBrowser('apiGetTokenProofs');
-	return fetchJson<ApiTokenProofsResponse>(apiUrl(`/v1/tokens/${address}/proofs`));
+	return fetchJson<ApiTokenProofsResponse>(apiUrl(`/v2/tokens/${address}/proofs`, { chainId }));
 }
 
 /**
  * Fetch ST0x token detail summaries from the REST API.
  */
-export async function apiGetTokenDetails(): Promise<ApiTokenDetailsListResponse> {
+export async function apiGetTokenDetails(chainId?: number): Promise<ApiTokenDetailsListResponse> {
 	assertBrowser('apiGetTokenDetails');
-	return fetchJson<ApiTokenDetailsListResponse>(apiUrl('/v1/tokens/details'));
+	return fetchJson<ApiTokenDetailsListResponse>(apiUrl('/v2/tokens/details', { chainId }));
 }
 
 /**
@@ -502,11 +520,13 @@ export async function apiGetTokenDetails(): Promise<ApiTokenDetailsListResponse>
  */
 export async function apiGetTokenDetailsByAddress(
 	address: string,
+	chainId: number,
 	options?: { activityLimit?: number }
 ): Promise<ApiTokenDetails> {
 	assertBrowser('apiGetTokenDetailsByAddress');
 	return fetchJson<ApiTokenDetails>(
-		apiUrl(`/v1/tokens/${address}/details`, {
+		apiUrl(`/v2/tokens/${address}/details`, {
+			chainId,
 			activityLimit: options?.activityLimit
 		})
 	);
@@ -515,17 +535,22 @@ export async function apiGetTokenDetailsByAddress(
 /**
  * Fetch current wrap ratios for supported wrapped tokens.
  */
-export async function apiGetWrapRatios(): Promise<ApiWrapRatiosResponse> {
+export async function apiGetWrapRatios(chainId?: number): Promise<ApiWrapRatiosResponse> {
 	assertBrowser('apiGetWrapRatios');
-	return fetchJson<ApiWrapRatiosResponse>(apiUrl('/v1/tokens/wrap-ratio'));
+	return fetchJson<ApiWrapRatiosResponse>(apiUrl('/v2/tokens/wrap-ratio', { chainId }));
 }
 
 /**
  * Fetch current wrap ratio for a single wrapped token.
  */
-export async function apiGetWrapRatio(wrappedTokenAddress: string): Promise<ApiWrapRatio> {
+export async function apiGetWrapRatio(
+	wrappedTokenAddress: string,
+	chainId: number
+): Promise<ApiWrapRatio> {
 	assertBrowser('apiGetWrapRatio');
-	return fetchJson<ApiWrapRatio>(apiUrl(`/v1/tokens/wrap-ratio/${wrappedTokenAddress}`));
+	return fetchJson<ApiWrapRatio>(
+		apiUrl(`/v2/tokens/wrap-ratio/${wrappedTokenAddress}`, { chainId })
+	);
 }
 
 /**
@@ -533,11 +558,13 @@ export async function apiGetWrapRatio(wrappedTokenAddress: string): Promise<ApiW
  */
 export async function apiGetWrapRatioHistory(
 	wrappedTokenAddress: string,
+	chainId: number,
 	options?: { page?: number; pageSize?: number }
 ): Promise<ApiWrapRatioHistoryResponse> {
 	assertBrowser('apiGetWrapRatioHistory');
 	return fetchJson<ApiWrapRatioHistoryResponse>(
-		apiUrl(`/v1/tokens/wrap-ratio/${wrappedTokenAddress}/history`, {
+		apiUrl(`/v2/tokens/wrap-ratio/${wrappedTokenAddress}/history`, {
+			chainId,
 			page: options?.page,
 			pageSize: options?.pageSize
 		})
@@ -549,7 +576,7 @@ export async function apiGetWrapRatioHistory(
  */
 export async function apiGetSwapQuote(request: ApiSwapQuoteRequest): Promise<ApiSwapQuoteResponse> {
 	assertBrowser('apiGetSwapQuote');
-	return fetchJson<ApiSwapQuoteResponse>(apiUrl('/v1/swap/quote'), {
+	return fetchJson<ApiSwapQuoteResponse>(apiUrl('/v2/swap/quote'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(request)
@@ -578,7 +605,7 @@ export async function apiGetSwapCalldata(
 	request: ApiSwapCalldataRequest
 ): Promise<ApiSwapCalldataResponse> {
 	assertBrowser('apiGetSwapCalldata');
-	return fetchJson<ApiSwapCalldataResponse>(apiUrl('/v1/swap/calldata'), {
+	return fetchJson<ApiSwapCalldataResponse>(apiUrl('/v2/swap/calldata'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(request)
@@ -605,10 +632,12 @@ export async function apiGetSwapCalldataV2(
  */
 export async function apiGetTradesByAddress(
 	address: string,
+	chainId: number,
 	options?: { page?: number; pageSize?: number; startTime?: number; endTime?: number }
 ): Promise<ApiTradesByAddressResponse> {
 	assertBrowser('apiGetTradesByAddress');
-	const url = apiUrl(`/v1/trades/${address}`, {
+	const url = apiUrl(`/v2/trades/${address}`, {
+		chainId,
 		page: options?.page,
 		pageSize: options?.pageSize,
 		startTime: options?.startTime,
@@ -622,10 +651,12 @@ export async function apiGetTradesByAddress(
  */
 export async function apiGetTakerTrades(
 	address: string,
+	chainId: number,
 	options?: { page?: number; pageSize?: number }
 ): Promise<ApiTradesByAddressResponse> {
 	assertBrowser('apiGetTakerTrades');
-	const url = apiUrl(`/v1/trades/taker/${address}`, {
+	const url = apiUrl(`/v2/trades/taker/${address}`, {
+		chainId,
 		page: options?.page,
 		pageSize: options?.pageSize
 	});
@@ -633,9 +664,14 @@ export async function apiGetTakerTrades(
 }
 
 /** Fetch the indexed trade totals for one confirmed transaction. */
-export async function apiGetTradesByTx(txHash: string): Promise<ApiTradesByTxResponse> {
+export async function apiGetTradesByTx(
+	txHash: string,
+	chainId: number
+): Promise<ApiTradesByTxResponse> {
 	assertBrowser('apiGetTradesByTx');
-	return fetchJson<ApiTradesByTxResponse>(apiUrl(`/v1/trades/tx/${txHash}`), { retries: 0 });
+	return fetchJson<ApiTradesByTxResponse>(apiUrl(`/v2/trades/tx/${txHash}`, { chainId }), {
+		retries: 0
+	});
 }
 
 /**
@@ -643,10 +679,12 @@ export async function apiGetTradesByTx(txHash: string): Promise<ApiTradesByTxRes
  */
 export async function apiGetOrdersByOwner(
 	ownerAddress: string,
+	chainId: number,
 	options?: { page?: number; pageSize?: number; state?: 'active' | 'inactive' | 'all' }
 ): Promise<ApiOrdersListResponse> {
 	assertBrowser('apiGetOrdersByOwner');
-	const url = apiUrl(`/v1/orders/owner/${ownerAddress}`, {
+	const url = apiUrl(`/v2/orders/owner/${ownerAddress}`, {
+		chainId,
 		page: options?.page,
 		pageSize: options?.pageSize,
 		state: options?.state
@@ -675,7 +713,7 @@ export async function apiQueryTrades(
 	signal?: AbortSignal
 ): Promise<ApiTradesQueryResponse> {
 	assertBrowser('apiQueryTrades');
-	return fetchJson<ApiTradesQueryResponse>(apiUrl('/v1/trades/query'), {
+	return fetchJson<ApiTradesQueryResponse>(apiUrl('/v2/trades/query'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(request),
@@ -687,8 +725,11 @@ export async function apiQueryTrades(
  * Fetch trades for multiple orders in a single query request.
  * Used to compute filled amounts for a user's deployed orders.
  */
-export async function apiGetTradesBatch(orderHashes: string[]): Promise<ApiTradesBatchResponse> {
-	return apiQueryTrades({ orderHashes });
+export async function apiGetTradesBatch(
+	orderHashes: string[],
+	chainId: number
+): Promise<ApiTradesBatchResponse> {
+	return apiQueryTrades({ orderHashes, chainId });
 }
 
 /**
@@ -696,6 +737,7 @@ export async function apiGetTradesBatch(orderHashes: string[]): Promise<ApiTrade
  */
 export async function apiGetTradesByToken(
 	tokenAddress: string,
+	chainId: number,
 	page: number = 1,
 	pageSize: number = 200,
 	startTime?: number,
@@ -703,12 +745,13 @@ export async function apiGetTradesByToken(
 ): Promise<ApiTradesByAddressResponse> {
 	assertBrowser('apiGetTradesByToken');
 	const params = new URLSearchParams({
+		chainId: String(chainId),
 		page: String(page),
 		pageSize: String(pageSize)
 	});
 	if (startTime !== undefined) params.set('startTime', String(startTime));
 	if (endTime !== undefined) params.set('endTime', String(endTime));
 	return fetchJson<ApiTradesByAddressResponse>(
-		`/api/st0x/v1/trades/token/${tokenAddress}?${params}`
+		`/api/st0x/v2/trades/token/${tokenAddress}?${params}`
 	);
 }

--- a/src/lib/clients/raindexSettings.ts
+++ b/src/lib/clients/raindexSettings.ts
@@ -21,7 +21,7 @@ function resolveRegistryManifestUrl(): string {
 	return new URL(REGISTRY_MANIFEST_URL, `${appOrigin()}/`).toString();
 }
 
-function settingsUrlFromManifest(manifest: string, manifestUrl: string): string {
+export function settingsUrlFromManifest(manifest: string, manifestUrl: string): string {
 	const settingsEntry = manifest
 		.split(/\r?\n/)
 		.map((line) => line.trim())

--- a/src/lib/components/DepositModal.svelte
+++ b/src/lib/components/DepositModal.svelte
@@ -53,11 +53,13 @@
 		}
 	}
 
-	// Per UI-SPEC §DepositModal: payment token displayed in body copy.
-	// Network's default payment token on Base is USDC.
-	$: paymentToken = 'USDC';
-	$: networkName = $currentNetwork?.displayName ?? 'Base';
-	$: basescanUrl = $walletAddress ? `https://basescan.org/address/${$walletAddress}` : '';
+	// Per UI-SPEC §DepositModal: registry-backed network and payment token in body copy.
+	$: paymentToken = $currentNetwork?.defaultPaymentToken?.symbol ?? 'payment token';
+	$: networkName = $currentNetwork?.displayName ?? 'the selected network';
+	$: explorerUrl =
+		$walletAddress && $currentNetwork
+			? `${$currentNetwork.blockExplorer}/address/${$walletAddress}`
+			: '';
 </script>
 
 <Modal show={$showDepositModal} title="Deposit" maxWidthClass="max-w-md" onClose={handleClose}>
@@ -109,7 +111,7 @@
 			</div>
 		</div>
 
-		<!-- Copy and Basescan buttons -->
+		<!-- Copy and network explorer buttons -->
 		<div class="flex gap-3">
 			<Button on:click={copyAddress} variant="secondary" fullWidth>
 				{#if copied}
@@ -143,7 +145,7 @@
 					</span>
 				{/if}
 			</Button>
-			<a href={basescanUrl} target="_blank" rel="noopener noreferrer" class="flex-1">
+			<a href={explorerUrl} target="_blank" rel="noopener noreferrer" class="flex-1">
 				<Button variant="ghost" fullWidth>
 					<span class="flex items-center justify-center gap-2">
 						<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -154,7 +156,7 @@
 								d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
 							/>
 						</svg>
-						View on Basescan
+						View on block explorer
 					</span>
 				</Button>
 			</a>

--- a/src/lib/components/LowFundsBanner.svelte
+++ b/src/lib/components/LowFundsBanner.svelte
@@ -11,12 +11,13 @@
 	let dismissed = false;
 	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
 	$: paymentTokens = ($apiTokensQuery.data ?? []).filter((token) => token.category === 'CRYPTO');
+	$: primaryPaymentToken = $currentNetwork?.defaultPaymentToken;
 
 	// Share the same query key as dashboard to avoid duplicate RPC calls
 	// Uses same settings as dashboard - invalidation happens after transactions
 	$: usdcBalanceQuery = createQuery({
 		queryKey: [
-			'usdcWalletBalance',
+			'paymentTokenWalletBalance',
 			$walletAddress,
 			$currentNetwork?.chainId,
 			paymentTokens.map((token) => token.address).join(',')
@@ -30,14 +31,15 @@
 		),
 		staleTime: 30_000, // Consider data fresh for 30 seconds
 		queryFn: async () => {
-			if (paymentTokens.length === 0 || !$walletAddress) return [];
+			if (paymentTokens.length === 0 || !$walletAddress || !$currentNetwork) return [];
 
 			// Build multicall contracts array
 			const contracts = paymentTokens.map((token) => ({
 				abi: erc20Abi,
 				address: token.address as `0x${string}`,
 				functionName: 'balanceOf' as const,
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			}));
 
 			try {
@@ -60,15 +62,17 @@
 					})
 					.filter((b): b is NonNullable<typeof b> => b !== null);
 			} catch (e) {
-				console.error('Multicall failed for USDC balance:', e);
+				console.error('Multicall failed for payment-token balances:', e);
 				return [];
 			}
 		}
 	});
 
-	// Check if USDC balance is 0
-	$: usdcBalance = $usdcBalanceQuery.data?.find((t) => t.symbol === 'USDC')?.walletBalance ?? 0n;
-	$: hasNoFunds = usdcBalance === 0n && $usdcBalanceQuery.isSuccess;
+	$: primaryPaymentBalance =
+		$usdcBalanceQuery.data?.find(
+			(token) => token.address.toLowerCase() === primaryPaymentToken?.address.toLowerCase()
+		)?.walletBalance ?? 0n;
+	$: hasNoFunds = primaryPaymentBalance === 0n && $usdcBalanceQuery.isSuccess;
 	$: showBanner = $isAuthenticated && hasNoFunds && !dismissed;
 
 	function handleDeposit() {
@@ -91,7 +95,7 @@
 					d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
 				/>
 			</svg>
-			<span>No USDC found in your wallet.</span>
+			<span>No {primaryPaymentToken?.symbol ?? 'payment tokens'} found in your wallet.</span>
 			<button
 				type="button"
 				on:click={handleDeposit}

--- a/src/lib/components/MarketPriceRow.svelte
+++ b/src/lib/components/MarketPriceRow.svelte
@@ -75,7 +75,9 @@
 	{:else if priceData}
 		<td class="px-2 py-1">
 			<ExternalLink
-				href={`${$currentNetwork.blockExplorer}/address/${token.address}`}
+				href={`${$currentNetwork?.blockExplorer ?? 'https://blockscan.com'}/address/${
+					token.address
+				}`}
 				label={token.symbol || ''}
 				className="underline"
 			/>

--- a/src/lib/components/NetworkSelector.svelte
+++ b/src/lib/components/NetworkSelector.svelte
@@ -3,65 +3,62 @@
 	import type { Network } from '$lib/config/network';
 	import { switchChain } from '@wagmi/core';
 	import { wagmiConfig, chainId, connected } from 'svelte-wagmi';
-	import { get } from 'svelte/store';
 	import { track } from '$lib/services/analytics';
 	import Icon from '$lib/components/ui/Icon.svelte';
+	import { onDestroy } from 'svelte';
 
 	let isOpen = false;
+	let pendingSwitchTimer: ReturnType<typeof setTimeout> | null = null;
 
-	function getChainLogo(network: Network): string {
-		return network.icon.startsWith('/') ? network.icon : '/images/ETH.svg';
-	}
-
-	async function selectNetwork(network: Network) {
-		const previousNetwork = $currentNetwork;
-
+	function selectNetwork(network: Network) {
 		$currentNetwork = network;
 		isOpen = false;
+	}
 
-		// If wallet is connected and on a different network, prompt to switch
-		if ($connected && $chainId && $chainId !== network.id) {
-			track('network_switch_initiated', {
-				from_network: previousNetwork?.displayName,
-				to_network: network.displayName,
-				from_chain_id: previousNetwork?.chainId,
-				to_chain_id: network.chainId
-			});
+	function scheduleWalletSwitch(
+		network: Network | null,
+		isConnected: boolean,
+		walletChainId: number | null | undefined,
+		config: Parameters<typeof switchChain>[0] | undefined
+	) {
+		if (pendingSwitchTimer) {
+			clearTimeout(pendingSwitchTimer);
+			pendingSwitchTimer = null;
+		}
+		if (!network || !isConnected || !walletChainId || !config || walletChainId === network.id) {
+			return;
+		}
 
+		track('network_switch_initiated', {
+			to_network: network.displayName,
+			from_chain_id: walletChainId,
+			to_chain_id: network.chainId
+		});
+		pendingSwitchTimer = setTimeout(async () => {
+			pendingSwitchTimer = null;
 			try {
-				await switchChain(get(wagmiConfig), { chainId: network.id });
+				await switchChain(config, { chainId: network.id });
 				track('network_switched', {
-					from_network: previousNetwork?.displayName,
 					to_network: network.displayName,
-					from_chain_id: previousNetwork?.chainId,
+					from_chain_id: walletChainId,
 					to_chain_id: network.chainId
 				});
 			} catch (error) {
 				track('network_switch_failed', {
-					from_network: previousNetwork?.displayName,
 					to_network: network.displayName,
+					from_chain_id: walletChainId,
+					to_chain_id: network.chainId,
 					error: error instanceof Error ? error.message : 'Unknown error'
 				});
 			}
-		} else {
-			// No wallet chain switch needed, just track the UI selection
-			track('network_switched', {
-				from_network: previousNetwork?.displayName,
-				to_network: network.displayName,
-				from_chain_id: previousNetwork?.chainId,
-				to_chain_id: network.chainId
-			});
-		}
-	}
-
-	// Auto-trigger network switch when currentNetwork changes from other parts of the app
-	$: if ($currentNetwork && $connected && $chainId && $chainId !== $currentNetwork.id) {
-		const network = $currentNetwork;
-		// Small delay to avoid immediate switching during initial load
-		setTimeout(async () => {
-			await switchChain(get(wagmiConfig), { chainId: network.id });
 		}, 100);
 	}
+
+	$: scheduleWalletSwitch($currentNetwork, $connected, $chainId, $wagmiConfig);
+
+	onDestroy(() => {
+		if (pendingSwitchTimer) clearTimeout(pendingSwitchTimer);
+	});
 
 	function toggleDropdown() {
 		isOpen = !isOpen;
@@ -119,11 +116,11 @@
 							? 'bg-accent-soft'
 							: ''}"
 					>
-						<img
-							src={getChainLogo(network)}
-							alt={network.displayName}
-							class="h-4 w-4 rounded-full"
-						/>
+						{#if network.icon.startsWith('/')}
+							<img src={network.icon} alt={network.displayName} class="h-4 w-4 rounded-full" />
+						{:else}
+							<Icon name="blocks" className="h-4 w-4 text-text-3" />
+						{/if}
 						<div class="flex flex-col items-start">
 							<span class="font-medium">{network.displayName}</span>
 							<span class="text-xs text-text-3">{network.currencySymbol}</span>

--- a/src/lib/components/NetworkSelector.svelte
+++ b/src/lib/components/NetworkSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { currentNetwork } from '$lib/stores';
-	import { networks } from '$lib/config/network';
+	import { availableNetworks, currentNetwork } from '$lib/stores';
+	import type { Network } from '$lib/config/network';
 	import { switchChain } from '@wagmi/core';
 	import { wagmiConfig, chainId, connected } from 'svelte-wagmi';
 	import { get } from 'svelte/store';
@@ -9,19 +9,11 @@
 
 	let isOpen = false;
 
-	function getChainLogo(n: (typeof networks)[0]): string {
-		if (!n) return '/images/ETH.svg';
-		switch (n.chainId) {
-			case 42161:
-				return '/images/ARB.svg';
-			case 8453:
-				return '/images/BASE.svg';
-			default:
-				return '/images/ETH.svg';
-		}
+	function getChainLogo(network: Network): string {
+		return network.icon.startsWith('/') ? network.icon : '/images/ETH.svg';
 	}
 
-	async function selectNetwork(network: (typeof networks)[0]) {
+	async function selectNetwork(network: Network) {
 		const previousNetwork = $currentNetwork;
 
 		$currentNetwork = network;
@@ -64,9 +56,10 @@
 
 	// Auto-trigger network switch when currentNetwork changes from other parts of the app
 	$: if ($currentNetwork && $connected && $chainId && $chainId !== $currentNetwork.id) {
+		const network = $currentNetwork;
 		// Small delay to avoid immediate switching during initial load
 		setTimeout(async () => {
-			await switchChain(get(wagmiConfig), { chainId: $currentNetwork.id });
+			await switchChain(get(wagmiConfig), { chainId: network.id });
 		}, 100);
 	}
 
@@ -96,7 +89,7 @@
 		class="flex items-center gap-1.5 rounded-lg border border-line bg-overlay-1 px-2.5 py-1.5 text-sm font-medium text-text-2 transition-all duration-200 hover:bg-overlay-hover active:scale-95"
 	>
 		<span class="h-2 w-2 rounded-full bg-iris-500"></span>
-		<span class="hidden capitalize sm:inline">{$currentNetwork.name}</span>
+		<span class="hidden capitalize sm:inline">{$currentNetwork?.name ?? 'Network'}</span>
 		<Icon
 			name="chevronDown"
 			className="h-4 w-4 text-text-3 transition-transform duration-200 {isOpen ? 'rotate-180' : ''}"
@@ -118,10 +111,10 @@
 			class="bg-surface-1/95 absolute left-0 right-0 top-full z-[9999] mx-2 mt-1 min-w-[200px] rounded-lg border border-line shadow-[var(--shadow-2)] backdrop-blur-lg sm:left-auto sm:right-0 sm:top-full sm:mx-0 sm:w-auto"
 		>
 			<div class="p-1">
-				{#each networks as network}
+				{#each $availableNetworks as network}
 					<button
 						on:click={() => selectNetwork(network)}
-						class="flex w-full items-center gap-3 rounded-md px-3 py-3 text-sm text-text transition-colors hover:bg-surface-2 active:bg-surface-3 {$currentNetwork.id ===
+						class="flex w-full items-center gap-3 rounded-md px-3 py-3 text-sm text-text transition-colors hover:bg-surface-2 active:bg-surface-3 {$currentNetwork?.id ===
 						network.id
 							? 'bg-accent-soft'
 							: ''}"
@@ -129,8 +122,7 @@
 						<img
 							src={getChainLogo(network)}
 							alt={network.displayName}
-							class="h-4 w-4"
-							class:rounded-full={network.chainId !== 8453}
+							class="h-4 w-4 rounded-full"
 						/>
 						<div class="flex flex-col items-start">
 							<span class="font-medium">{network.displayName}</span>

--- a/src/lib/components/OldTokensBanner.svelte
+++ b/src/lib/components/OldTokensBanner.svelte
@@ -20,13 +20,20 @@
 		enabled: !!($isAuthenticated && $walletAddress && $wagmiConfig),
 		staleTime: 60_000, // Check every minute
 		queryFn: async () => {
-			if (!$walletAddress || !$wagmiConfig) return { hasOldTokens: false, count: 0 };
+			if (!$walletAddress || !$wagmiConfig || !$currentNetwork) {
+				return { hasOldTokens: false, count: 0 };
+			}
 
-			const contracts = TOKEN_MIGRATION_MAPPINGS.map((mapping) => ({
+			const mappings = TOKEN_MIGRATION_MAPPINGS.filter(
+				(mapping) => mapping.chainId === $currentNetwork.chainId
+			);
+
+			const contracts = mappings.map((mapping) => ({
 				abi: erc20Abi,
 				address: mapping.oldToken.address as `0x${string}`,
 				functionName: 'balanceOf' as const,
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			}));
 
 			try {
@@ -37,7 +44,7 @@
 					const result = results[i];
 					if (result.status === 'success') {
 						const balance = result.result as bigint;
-						const decimals = TOKEN_MIGRATION_MAPPINGS[i]?.oldToken.decimals ?? 18;
+						const decimals = mappings[i]?.oldToken.decimals ?? 18;
 						const balanceNum = parseFloat(formatUnits(balance, decimals));
 						if (balanceNum >= DUST_THRESHOLD) {
 							count++;

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -241,12 +241,13 @@
 	$: usdcBalanceQuery = createQuery({
 		queryKey: ['usdcBalance', $currentNetwork?.id, paymentToken?.address, $walletAddress],
 		queryFn: async () => {
-			if (!paymentToken?.address || !$walletAddress || !$wagmiConfig) return 0n;
+			if (!paymentToken?.address || !$walletAddress || !$currentNetwork || !$wagmiConfig) return 0n;
 			return (await readContract($wagmiConfig, {
 				abi: erc20Abi,
 				address: paymentToken.address as `0x${string}`,
 				functionName: 'balanceOf',
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			})) as bigint;
 		},
 		enabled: Boolean(paymentToken?.address && $walletAddress && $wagmiConfig)
@@ -255,12 +256,13 @@
 	$: tokenBalanceQuery = createQuery({
 		queryKey: ['tokenBalance', $currentNetwork?.id, selectedTokenAddress, $walletAddress],
 		queryFn: async () => {
-			if (!selectedTokenAddress || !$walletAddress || !$wagmiConfig) return 0n;
+			if (!selectedTokenAddress || !$walletAddress || !$currentNetwork || !$wagmiConfig) return 0n;
 			return (await readContract($wagmiConfig, {
 				abi: erc20Abi,
 				address: selectedTokenAddress as `0x${string}`,
 				functionName: 'balanceOf',
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			})) as bigint;
 		},
 		enabled: Boolean(selectedTokenAddress && $walletAddress && $wagmiConfig)
@@ -541,7 +543,7 @@
 		<!-- Card header -->
 		<div class="flex items-center justify-between text-xs text-text-2">
 			<span>Quick trade</span>
-			<span>Base · {paymentToken?.symbol ?? 'USDC'}</span>
+			<span>{$currentNetwork?.displayName ?? 'Network'} · {paymentToken?.symbol ?? 'Quote'}</span>
 		</div>
 
 		<!-- USDC section -->
@@ -768,8 +770,8 @@
 		<!-- Network info -->
 		<div class="flex items-center justify-center gap-2 text-xs text-text-3">
 			<span>Trading on</span>
-			<img src="/images/BASE.svg" alt="Base" class="h-4 w-4" />
-			<span class="text-text-2">{$currentNetwork?.displayName ?? 'Base'}</span>
+			<img src="/images/ETH.svg" alt="Network" class="h-4 w-4 rounded-full" />
+			<span class="text-text-2">{$currentNetwork?.displayName ?? 'Network'}</span>
 		</div>
 
 		<!-- Error display -->

--- a/src/lib/components/SendFundsModal.svelte
+++ b/src/lib/components/SendFundsModal.svelte
@@ -38,7 +38,12 @@
 	// Build available tokens list based on current network
 	$: availableTokens = (() => {
 		const tokens: TokenOption[] = [
-			{ symbol: 'ETH', name: 'Ethereum', address: 'native', decimals: 18 }
+			{
+				symbol: $currentNetwork?.currencySymbol ?? 'ETH',
+				name: `${$currentNetwork?.displayName ?? 'Network'} native currency`,
+				address: 'native',
+				decimals: 18
+			}
 		];
 
 		for (const token of apiTokens) {
@@ -56,7 +61,7 @@
 
 	let recipientAddress = '';
 	let amount = '';
-	let selectedTokenSymbol = 'ETH';
+	let selectedTokenSymbol = '';
 	let sending = false;
 	let error: string | null = null;
 	let txHash: string | null = null;
@@ -64,6 +69,9 @@
 	// When modal opens with pre-selected token, set it
 	$: if ($showSendFundsModal && $sendModalToken) {
 		selectedTokenSymbol = $sendModalToken.symbol;
+	}
+	$: if (!availableTokens.some((token) => token.symbol === selectedTokenSymbol)) {
+		selectedTokenSymbol = availableTokens[0]?.symbol ?? '';
 	}
 
 	// Get the selected token object
@@ -89,7 +97,7 @@
 	function resetForm() {
 		recipientAddress = '';
 		amount = '';
-		selectedTokenSymbol = 'ETH';
+		selectedTokenSymbol = $currentNetwork?.currencySymbol ?? '';
 		error = null;
 		txHash = null;
 		sending = false;
@@ -140,8 +148,8 @@
 			dispatch('sent', { to: recipientAddress, amount, token: selectedToken.symbol, txHash: hash });
 
 			// Invalidate balance queries to refresh the page
-			queryClient.invalidateQueries({ queryKey: ['usdcWalletBalance'] });
-			queryClient.invalidateQueries({ queryKey: ['ethWalletBalance'] });
+			queryClient.invalidateQueries({ queryKey: ['paymentTokenWalletBalance'] });
+			queryClient.invalidateQueries({ queryKey: ['nativeWalletBalance'] });
 			queryClient.invalidateQueries({ queryKey: ['sftHoldings'] });
 		} catch (err) {
 			console.error('[send] Error:', err);
@@ -200,7 +208,7 @@
 						rel="noopener noreferrer"
 						class="mt-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 					>
-						View on BaseScan
+						View transaction
 						<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 							<path
 								stroke-linecap="round"

--- a/src/lib/components/SendFundsModal.svelte
+++ b/src/lib/components/SendFundsModal.svelte
@@ -111,7 +111,8 @@
 	}
 
 	async function handleSend() {
-		if (!canSend || !$dynamicSession?.walletAddress || !selectedToken) return;
+		if (!canSend || !$dynamicSession?.walletAddress || !selectedToken || !$currentNetwork) return;
+		const chainId = $currentNetwork.chainId;
 
 		error = null;
 		sending = true;
@@ -124,7 +125,8 @@
 				const valueInWei = parseEther(amount);
 				hash = await sendTransaction({
 					to: recipientAddress as `0x${string}`,
-					value: valueInWei
+					value: valueInWei,
+					chainId
 				});
 			} else {
 				// Send ERC20 token
@@ -140,7 +142,8 @@
 				// Send transaction to the token contract
 				hash = await sendTransaction({
 					to: selectedToken.address,
-					data
+					data,
+					chainId
 				});
 			}
 

--- a/src/lib/components/TokenSwapModal.svelte
+++ b/src/lib/components/TokenSwapModal.svelte
@@ -109,7 +109,7 @@
 
 	// Get current mapping based on selection
 	$: currentMapping = selectedOldTokenAddress
-		? getMigrationMappingByAddress(selectedOldTokenAddress)
+		? getMigrationMappingByAddress(selectedOldTokenAddress, $currentNetwork?.chainId)
 		: null;
 
 	// Query to fetch all old token balances for the user
@@ -118,27 +118,33 @@
 		enabled: !!($isAuthenticated && $walletAddress && $wagmiConfig && $showTokenSwapModal),
 		staleTime: 30_000,
 		queryFn: async () => {
-			if (!$walletAddress || !$wagmiConfig) return [];
+			if (!$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
 
-			const contracts = TOKEN_MIGRATION_MAPPINGS.map((mapping) => ({
+			const mappings = TOKEN_MIGRATION_MAPPINGS.filter(
+				(mapping) => mapping.chainId === $currentNetwork.chainId
+			);
+			const contracts = mappings.map((mapping) => ({
 				abi: erc20Abi,
 				address: mapping.oldToken.address as `0x${string}`,
 				functionName: 'balanceOf' as const,
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			}));
 
 			try {
 				const results = await readContracts($wagmiConfig, { contracts });
 
-				return TOKEN_MIGRATION_MAPPINGS.map((mapping, index) => {
-					const result = results[index];
-					const balance = result.status === 'success' ? (result.result as bigint) : 0n;
-					return {
-						...mapping,
-						balance,
-						balanceFormatted: parseFloat(formatUnits(balance, mapping.oldToken.decimals))
-					};
-				}).filter((item) => item.balance > 0n);
+				return mappings
+					.map((mapping, index) => {
+						const result = results[index];
+						const balance = result.status === 'success' ? (result.result as bigint) : 0n;
+						return {
+							...mapping,
+							balance,
+							balanceFormatted: parseFloat(formatUnits(balance, mapping.oldToken.decimals))
+						};
+					})
+					.filter((item) => item.balance > 0n);
 			} catch (e) {
 				console.error('Failed to fetch old token balances:', e);
 				return [];
@@ -201,7 +207,7 @@
 		selectedOldTokenAddress = address;
 		swapAmount = '';
 		liquidityWarning = false;
-		const mapping = getMigrationMappingByAddress(address);
+		const mapping = getMigrationMappingByAddress(address, $currentNetwork?.chainId);
 		track('legacy_swap_token_selected', {
 			old_token_symbol: mapping?.oldToken.symbol,
 			new_token_symbol: mapping?.newToken.symbol

--- a/src/lib/components/TradeAmountInput.svelte
+++ b/src/lib/components/TradeAmountInput.svelte
@@ -65,6 +65,12 @@
 		return `${address}:${chainId}`;
 	};
 
+	const getBalanceRequestFingerprint = (token?: Token, address?: string | null) => {
+		const tokenFingerprint = getTokenFingerprint(token);
+		if (!tokenFingerprint || !address) return undefined;
+		return `${address.toLowerCase()}:${tokenFingerprint}`;
+	};
+
 	$: if (amountToken) {
 		const fingerprint = getTokenFingerprint(amountToken);
 		const fallbackDecimals = parseDecimals((amountToken as Partial<Token>).decimals);
@@ -141,11 +147,13 @@
 
 	$: balancePromise = (async () => {
 		const token = balanceToken ?? amountToken;
+		balance = 0n;
+		balanceDecimals = null;
 		if (!token) return null;
 		if (!token.chainId) return null;
 		if (!$walletAddress) return null;
 		if (!$wagmiConfig) return null;
-		const fingerprint = getTokenFingerprint(token);
+		const fingerprint = getBalanceRequestFingerprint(token, $walletAddress);
 		const [tokenBalance, tokenDecimals] = await Promise.all([
 			readContract($wagmiConfig, {
 				abi: erc20Abi,
@@ -168,7 +176,10 @@
 	$: balancePromise
 		.then((data) => {
 			if (!data) return;
-			const activeFingerprint = getTokenFingerprint(balanceToken ?? amountToken);
+			const activeFingerprint = getBalanceRequestFingerprint(
+				balanceToken ?? amountToken,
+				$walletAddress
+			);
 			if (!activeFingerprint || data.fingerprint !== activeFingerprint) {
 				return;
 			}

--- a/src/lib/components/TradeAmountInput.svelte
+++ b/src/lib/components/TradeAmountInput.svelte
@@ -142,6 +142,7 @@
 	$: balancePromise = (async () => {
 		const token = balanceToken ?? amountToken;
 		if (!token) return null;
+		if (!token.chainId) return null;
 		if (!$walletAddress) return null;
 		if (!$wagmiConfig) return null;
 		const fingerprint = getTokenFingerprint(token);
@@ -150,13 +151,15 @@
 				abi: erc20Abi,
 				address: token.address as `0x${string}`,
 				functionName: 'balanceOf',
-				args: [$walletAddress as Hex]
+				args: [$walletAddress as Hex],
+				chainId: token.chainId
 			}),
 			readContract($wagmiConfig, {
 				abi: erc20Abi,
 				address: token.address as `0x${string}`,
 				functionName: 'decimals',
-				args: []
+				args: [],
+				chainId: token.chainId
 			})
 		]);
 		return { balance: tokenBalance, decimals: tokenDecimals, fingerprint };

--- a/src/lib/components/TradeAmountInput.svelte
+++ b/src/lib/components/TradeAmountInput.svelte
@@ -186,7 +186,10 @@
 			balance = data.balance;
 			const resolvedDecimals = parseDecimals(data.decimals);
 			balanceDecimals = resolvedDecimals;
-			if (resolvedDecimals !== null && activeFingerprint === amountTokenFingerprint) {
+			if (
+				resolvedDecimals !== null &&
+				getTokenFingerprint(balanceToken ?? amountToken) === amountTokenFingerprint
+			) {
 				amountDecimals = resolvedDecimals;
 			}
 		})

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -60,7 +60,7 @@
 		'buy-sell-panel': {
 			title: 'Place Orders',
 			description:
-				'Click Buy or Sell to open the order panel. Choose between market orders, limit orders, and DCAs. All orders are against USDC on Base.',
+				'Click Buy or Sell to open the order panel. Choose between market orders, limit orders, and DCAs. Orders use the selected network’s configured quote token.',
 			targetSelector: ['[data-tutorial="buy-sell-buttons"]', '[data-tutorial="trade-panel"]'],
 			buttonText: 'Next'
 		},

--- a/src/lib/components/WrapUnwrapModal.svelte
+++ b/src/lib/components/WrapUnwrapModal.svelte
@@ -46,9 +46,9 @@
 	$: currentMapping = (() => {
 		if (!selectedTokenAddress) return null;
 		if (isWrapMode) {
-			return getWrappingMappingByUnwrappedAddress(selectedTokenAddress);
+			return getWrappingMappingByUnwrappedAddress(selectedTokenAddress, $currentNetwork?.chainId);
 		} else {
-			return getWrappingMappingByWrappedAddress(selectedTokenAddress);
+			return getWrappingMappingByWrappedAddress(selectedTokenAddress, $currentNetwork?.chainId);
 		}
 	})();
 
@@ -63,18 +63,21 @@
 		refetchOnMount: 'always' as const,
 		refetchOnWindowFocus: true,
 		queryFn: async () => {
-			if (!$walletAddress || !$wagmiConfig) return [];
+			if (!$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
 
 			// Get addresses based on mode
 			const addresses = isWrapMode
-				? getAllUnwrappedTokenAddresses()
-				: TOKEN_WRAPPING_MAPPINGS.map((m) => m.wrappedToken.address);
+				? getAllUnwrappedTokenAddresses($currentNetwork.chainId)
+				: TOKEN_WRAPPING_MAPPINGS.filter(
+						(mapping) => mapping.chainId === $currentNetwork.chainId
+					).map((mapping) => mapping.wrappedToken.address);
 
 			const contracts = addresses.map((address) => ({
 				abi: erc20Abi,
 				address: address as `0x${string}`,
 				functionName: 'balanceOf' as const,
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			}));
 
 			try {
@@ -85,8 +88,8 @@
 						const result = results[index];
 						const balance = result.status === 'success' ? (result.result as bigint) : 0n;
 						const mapping = isWrapMode
-							? getWrappingMappingByUnwrappedAddress(address)
-							: getWrappingMappingByWrappedAddress(address);
+							? getWrappingMappingByUnwrappedAddress(address, $currentNetwork.chainId)
+							: getWrappingMappingByWrappedAddress(address, $currentNetwork.chainId);
 
 						if (!mapping) return null;
 

--- a/src/lib/components/WrapUnwrapModal.svelte
+++ b/src/lib/components/WrapUnwrapModal.svelte
@@ -152,12 +152,22 @@
 
 		try {
 			const amountWei = parseUnits(amount, selectedTokenData.decimals);
+			const chainId = $currentNetwork?.chainId;
+			if (!chainId) return;
 
 			if (isWrapMode) {
-				const shares = await previewWrap(selectedTokenData.address as `0x${string}`, amountWei);
+				const shares = await previewWrap(
+					selectedTokenData.address as `0x${string}`,
+					amountWei,
+					chainId
+				);
 				previewAmount = formatUnits(shares, currentMapping.wrappedToken.decimals);
 			} else {
-				const assets = await previewUnwrap(selectedTokenData.address as `0x${string}`, amountWei);
+				const assets = await previewUnwrap(
+					selectedTokenData.address as `0x${string}`,
+					amountWei,
+					chainId
+				);
 				previewAmount = formatUnits(assets, currentMapping.unwrappedToken.decimals);
 			}
 		} catch {
@@ -207,7 +217,7 @@
 
 	// Execute wrap or unwrap
 	async function handleExecute() {
-		if (!selectedTokenData || !currentMapping || !$walletAddress) return;
+		if (!selectedTokenData || !currentMapping || !$walletAddress || !$currentNetwork) return;
 		if (parsedAmount <= 0) return;
 
 		// Capture values before closing modal (handleClose resets state)
@@ -217,6 +227,7 @@
 		const wrapMode = isWrapMode;
 		const targetToken = wrapMode ? mapping.wrappedToken : mapping.unwrappedToken;
 		const walletAddr = $walletAddress;
+		const chainId = $currentNetwork.chainId;
 
 		track('wrap_unwrap_initiated', {
 			mode: wrapMode ? 'wrap' : 'unwrap',
@@ -237,7 +248,8 @@
 			amountWei,
 			walletAddr as `0x${string}`,
 			tokenData.symbol,
-			targetToken.symbol
+			targetToken.symbol,
+			chainId
 		);
 
 		// Invalidate modal-specific query (dashboard queries handled by transactionStore)

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -423,12 +423,14 @@
 		orderSide === 'Buy'
 			? 'bg-green-500 hover:bg-green-600 text-text'
 			: 'bg-red-500 hover:bg-red-600 text-text';
+	$: marketClosed = isOutsideMarketHours();
 
 	$: disableDeploy =
 		!selectedAmount ||
 		!assetToken ||
 		selectedAmountError ||
 		insufficientBalanceError ||
+		marketClosed ||
 		isSubmittingMarketOrder;
 
 	// Calculate the "other side" of the trade for display
@@ -555,6 +557,14 @@
 		}
 		const selectedNetwork = $currentNetwork;
 		if (!selectedNetwork) return;
+		if (marketClosed) {
+			orderPreparationTradeError = createTradeError('TRADE_MARKET_CLOSED', {
+				stage: 'calldata'
+			});
+			orderPreparationError = orderPreparationTradeError.message;
+			serviceErrorClass = orderPreparationTradeError.errorClass;
+			return;
+		}
 
 		if (isSubmittingMarketOrder) {
 			return;
@@ -1092,6 +1102,11 @@
 				>
 					Cancel
 				</button>
+				{#if marketClosed}
+					<p class="text-center text-xs text-text-3" role="status">
+						Market orders are available during NYSE trading hours.
+					</p>
+				{/if}
 				<button
 					class="flex-1 rounded-xl bg-amber-500/20 px-4 py-2 text-sm font-medium text-amber-700 hover:bg-amber-500/30 dark:text-amber-400"
 					on:click={confirmHighSlippage}

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -34,7 +34,7 @@
 	} from '$lib/services/tradeError';
 	import TradeErrorPanel from '$lib/components/trade/TradeErrorPanel.svelte';
 	import { selectVisibleTradeError } from '$lib/components/trade/tradeErrorUi';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 
 	export let orderSide: 'Buy' | 'Sell' = 'Buy';
 
@@ -81,6 +81,8 @@
 	// Quote freshness tracking
 	let quoteFreshnessSeconds = 0;
 	let quoteFreshnessInterval: ReturnType<typeof setInterval> | null = null;
+	let marketHoursInterval: ReturnType<typeof setInterval> | null = null;
+	let marketClosed = isOutsideMarketHours();
 
 	function updateQuoteFreshness() {
 		const lastUpdated = $orderbookQuotesQuery?.dataUpdatedAt ?? 0;
@@ -137,6 +139,10 @@
 
 	onMount(() => {
 		panelOpenTime = Date.now();
+		marketClosed = isOutsideMarketHours();
+		marketHoursInterval = setInterval(() => {
+			marketClosed = isOutsideMarketHours();
+		}, 30_000);
 		trackTradeEvent('trade_panel_opened', {
 			order_type: 'market',
 			token_symbol: assetToken?.symbol
@@ -208,9 +214,9 @@
 	}
 
 	// Cleanup interval on component destroy
-	import { onDestroy } from 'svelte';
 	onDestroy(() => {
 		if (quoteFreshnessInterval) clearInterval(quoteFreshnessInterval);
+		if (marketHoursInterval) clearInterval(marketHoursInterval);
 
 		// Track abandonment if user had entered values but didn't complete trade
 		// Use trackingState to get current values (avoids stale closure)
@@ -423,8 +429,6 @@
 		orderSide === 'Buy'
 			? 'bg-green-500 hover:bg-green-600 text-text'
 			: 'bg-red-500 hover:bg-red-600 text-text';
-	$: marketClosed = isOutsideMarketHours();
-
 	$: disableDeploy =
 		!selectedAmount ||
 		!assetToken ||
@@ -557,6 +561,7 @@
 		}
 		const selectedNetwork = $currentNetwork;
 		if (!selectedNetwork) return;
+		marketClosed = isOutsideMarketHours();
 		if (marketClosed) {
 			orderPreparationTradeError = createTradeError('TRADE_MARKET_CLOSED', {
 				stage: 'calldata'

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -553,6 +553,8 @@
 		if (!selectedAmount) {
 			return;
 		}
+		const selectedNetwork = $currentNetwork;
+		if (!selectedNetwork) return;
 
 		if (isSubmittingMarketOrder) {
 			return;
@@ -638,7 +640,7 @@
 						decimals: paymentToken.decimals,
 						symbol: paymentToken.symbol
 					},
-					network: $currentNetwork
+					network: selectedNetwork
 				});
 
 				if (!result.success && result.error) {
@@ -719,7 +721,7 @@
 	}}
 />
 
-{#if $currentNetwork && assetToken}
+{#if $currentNetwork && assetToken && paymentToken}
 	<div data-testid="market-form" data-mode="market" data-side={orderSide.toLowerCase()}>
 		<div
 			class="space-y-4"

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -81,8 +81,6 @@
 	// Quote freshness tracking
 	let quoteFreshnessSeconds = 0;
 	let quoteFreshnessInterval: ReturnType<typeof setInterval> | null = null;
-	let marketHoursInterval: ReturnType<typeof setInterval> | null = null;
-	let marketClosed = isOutsideMarketHours();
 
 	function updateQuoteFreshness() {
 		const lastUpdated = $orderbookQuotesQuery?.dataUpdatedAt ?? 0;
@@ -139,10 +137,6 @@
 
 	onMount(() => {
 		panelOpenTime = Date.now();
-		marketClosed = isOutsideMarketHours();
-		marketHoursInterval = setInterval(() => {
-			marketClosed = isOutsideMarketHours();
-		}, 30_000);
 		trackTradeEvent('trade_panel_opened', {
 			order_type: 'market',
 			token_symbol: assetToken?.symbol
@@ -216,7 +210,6 @@
 	// Cleanup interval on component destroy
 	onDestroy(() => {
 		if (quoteFreshnessInterval) clearInterval(quoteFreshnessInterval);
-		if (marketHoursInterval) clearInterval(marketHoursInterval);
 
 		// Track abandonment if user had entered values but didn't complete trade
 		// Use trackingState to get current values (avoids stale closure)
@@ -434,7 +427,6 @@
 		!assetToken ||
 		selectedAmountError ||
 		insufficientBalanceError ||
-		marketClosed ||
 		isSubmittingMarketOrder;
 
 	// Calculate the "other side" of the trade for display
@@ -561,15 +553,6 @@
 		}
 		const selectedNetwork = $currentNetwork;
 		if (!selectedNetwork) return;
-		marketClosed = isOutsideMarketHours();
-		if (marketClosed) {
-			orderPreparationTradeError = createTradeError('TRADE_MARKET_CLOSED', {
-				stage: 'calldata'
-			});
-			orderPreparationError = orderPreparationTradeError.message;
-			serviceErrorClass = orderPreparationTradeError.errorClass;
-			return;
-		}
 
 		if (isSubmittingMarketOrder) {
 			return;
@@ -1107,11 +1090,6 @@
 				>
 					Cancel
 				</button>
-				{#if marketClosed}
-					<p class="text-center text-xs text-text-3" role="status">
-						Market orders are available during NYSE trading hours.
-					</p>
-				{/if}
 				<button
 					class="flex-1 rounded-xl bg-amber-500/20 px-4 py-2 text-sm font-medium text-amber-700 hover:bg-amber-500/30 dark:text-amber-400"
 					on:click={confirmHighSlippage}

--- a/src/lib/components/orders/OrdersTable.svelte
+++ b/src/lib/components/orders/OrdersTable.svelte
@@ -257,7 +257,7 @@
 				let page = 1;
 				let hasMore = true;
 				while (hasMore && page <= MAX_CLOSED_ORDER_PAGES) {
-					const result = await apiGetOrdersByOwner(signer, {
+					const result = await apiGetOrdersByOwner(signer, network.chainId, {
 						page,
 						pageSize: CLOSED_ORDERS_PAGE_SIZE,
 						state: 'inactive'
@@ -662,7 +662,7 @@
 								<td class="py-3 pr-4">
 									{#if quote}
 										{@const raindexUrl = getRaindexOrderUrl(
-											$currentNetwork?.id ?? 0,
+											$currentNetwork?.chainId,
 											orderbookId,
 											quote.orderHash
 										)}

--- a/src/lib/components/ui/TxLink.svelte
+++ b/src/lib/components/ui/TxLink.svelte
@@ -16,7 +16,8 @@
 		return value.length <= h + t ? value : `${value.slice(0, h)}...${value.slice(-t)}`;
 	}
 
-	$: url = href ?? (hash ? `${$currentNetwork.blockExplorer}/tx/${hash}` : undefined);
+	$: url =
+		href ?? (hash && $currentNetwork ? `${$currentNetwork.blockExplorer}/tx/${hash}` : undefined);
 	$: fullValue = label ?? hash ?? '';
 	$: desktopText = truncate(fullValue);
 	$: mobileText = fullValue ? `…${fullValue.slice(-6)}` : '';

--- a/src/lib/components/wrap/DenomToggle.svelte
+++ b/src/lib/components/wrap/DenomToggle.svelte
@@ -8,7 +8,7 @@
 	 *  - 'unwrapped' → shares (the t* asset)
 	 *  - 'wrapped'   → tokens (the wt* wrapper)
 	 *
-	 * These match the new query param accepted by /v1/trades/* and /v1/orders/*
+	 * These match the query param accepted by /v2/trades/* and /v2/orders/*
 	 * (renamed from tstock/wtstock).
 	 */
 	import { createEventDispatcher } from 'svelte';

--- a/src/lib/components/wrap/RatioHistoryTab.svelte
+++ b/src/lib/components/wrap/RatioHistoryTab.svelte
@@ -2,6 +2,7 @@
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import { createExchangeRateHistoryQuery } from '$lib/queries/exchangeRates';
 	import RatioStepChart from './RatioStepChart.svelte';
+	import { currentNetwork } from '$lib/stores';
 
 	/**
 	 * "Ratio History" tab inside Token Details. The REST API returns sampled
@@ -13,7 +14,9 @@
 	export let currentRatio: number;
 	export let onLearnMore: (() => void) | undefined = undefined;
 
-	$: query = createExchangeRateHistoryQuery(wrappedTokenAddress, { pageSize: 100 });
+	$: query = createExchangeRateHistoryQuery(wrappedTokenAddress, $currentNetwork?.chainId, {
+		pageSize: 100
+	});
 
 	$: rawEvents = $query.data?.events ?? [];
 	$: events = [...rawEvents].sort((a, b) => {

--- a/src/lib/config/clientRpc.ts
+++ b/src/lib/config/clientRpc.ts
@@ -1,8 +1,8 @@
 /**
- * Client-side Base RPC URL ordering for wagmi transports.
+ * Client-side registry RPC URL ordering for wagmi transports.
  *
  * svelte-wagmi's defaultConfig uses bare `http()`, which falls through to
- * public chain RPCs (e.g. mainnet.base.org) and rate-limits under load.
+ * public chain RPCs and rate-limits under load.
  * Use {@link getClientRpcUrls} with viem `fallback([...])` so the browser
  * follows the active registry's ordered RPC list.
  */

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -142,7 +142,9 @@ async function buildNetworkCatalogFromClient(
 			blockExplorerIcon: 'etherscan',
 			rpcUrl: rpcs[0],
 			fallbackRpcUrls: rpcs.slice(1),
-			icon: 'ethereum',
+			// The registry SDK does not currently expose a network icon URL.
+			// Consumers render a neutral chain glyph unless a future catalog supplies one.
+			icon: '',
 			subgraph_url: subgraphs.get(`sft-${slug}`) ?? '',
 			metadata_subgraph_url: metaboards.get(slug) ?? '',
 			orderbook_subgraph_url: orderbookSubgraph,

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -1,10 +1,19 @@
 import type { Token } from '$lib/types';
+import type { CategorizedToken } from '$lib/config/tokens';
 import {
 	DEFAULT_PAYMENT_TOKENS,
 	PAYMENT_TOKENS_BY_NETWORK,
 	getDefaultPaymentTokenForNetwork,
 	getPaymentTokensForNetwork
 } from '$lib/config/tokens';
+import { prepareBrowserRaindexSettings } from '$lib/clients/raindexSettings';
+import {
+	DotrainRegistry,
+	RaindexClient,
+	type NetworkCfg,
+	type RaindexCfg
+} from '@rainlanguage/raindex';
+import { isMap, isScalar, parseDocument } from 'yaml';
 
 export interface Network {
 	id: number;
@@ -23,57 +32,171 @@ export interface Network {
 	metadata_subgraph_url: string;
 	orderbook_subgraph_url: string;
 	orderbook_subgraph_urls_inactive: string[];
-	/** Previous SFT subgraph URLs for historical data (legacy tokens, old vaults) */
 	subgraph_urls_legacy: string[];
 	paymentTokens: Token[];
 	defaultPaymentToken: Token;
-	/** Whitelist of trusted orderbook contract addresses for this network */
 	trustedOrderbooks: string[];
 }
 
-const basePaymentTokens = PAYMENT_TOKENS_BY_NETWORK[8453] ?? [];
-const baseDefaultPaymentToken = DEFAULT_PAYMENT_TOKENS[8453];
+export const networks: Network[] = [];
 
-export const networks: Network[] = [
-	{
-		id: 8453,
-		chainId: 8453,
-		name: 'base',
-		raindexNetworkSlug: 'base',
-		displayName: 'Base Mainnet',
-		currencySymbol: 'ETH',
-		blockExplorer: 'https://basescan.org',
-		sftExplorer: 'https://stox2.h20.market',
-		blockExplorerIcon: 'etherscan',
-		rpcUrl: 'https://base-rpc.publicnode.com',
-		fallbackRpcUrls: [
-			'https://base-rpc.publicnode.com',
-			'https://base.llamarpc.com',
-			'https://base.meowrpc.com',
-			'https://base-mainnet.public.blastapi.io',
-			'https://gateway.tenderly.co/public/base'
-		],
-		icon: 'ethereum',
-		subgraph_url:
-			'https://api.goldsky.com/api/public/project_cmjr2df7svg6t01tl2ic706ao/subgraphs/sft-base/1.0.14/gn',
-		metadata_subgraph_url:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn',
-		orderbook_subgraph_url:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn',
-		orderbook_subgraph_urls_inactive: [
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2025-10-11-a62b/gn'
-		],
-		subgraph_urls_legacy: [
-			'https://api.goldsky.com/api/public/project_cm153vmqi5gke01vy66p4ftzf/subgraphs/sft-offchainassetvaulttest-base/1.0.5/gn'
-		],
-		paymentTokens: basePaymentTokens,
-		defaultPaymentToken: baseDefaultPaymentToken!,
-		// Trusted orderbook contract addresses - transactions to unknown orderbooks are blocked
-		trustedOrderbooks: [
-			'0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D' // Rain Orderbook v4 on Base
-		]
+function stringValue(value: unknown): string | undefined {
+	if (isScalar(value)) return String(value.value).trim() || undefined;
+	if (typeof value === 'string') return value.trim() || undefined;
+	return undefined;
+}
+
+function titleFromSlug(slug: string): string {
+	return slug
+		.split(/[-_]/g)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function networkLabel(tokens: readonly CategorizedToken[], chainId: number, slug: string): string {
+	for (const token of tokens) {
+		if (token.chainId !== chainId) continue;
+		const label = token.network?.label;
+		if (typeof label === 'string' && label.trim()) return label.trim();
 	}
-];
+	return titleFromSlug(slug);
+}
+
+function urlMap(document: ReturnType<typeof parseDocument>, key: string): Map<string, string> {
+	const source = document.get(key, true);
+	const result = new Map<string, string>();
+	if (!isMap(source)) return result;
+	for (const pair of source.items) {
+		const name = stringValue(pair.key);
+		const url = stringValue(pair.value);
+		if (name && url) result.set(name, url);
+	}
+	return result;
+}
+
+function paymentTokensForChain(
+	tokens: readonly CategorizedToken[],
+	chainId: number
+): CategorizedToken[] {
+	return tokens.filter((token) => token.chainId === chainId && token.category === 'CRYPTO');
+}
+
+async function buildNetworkCatalogFromClient(
+	settingsYaml: string,
+	tokens: readonly CategorizedToken[],
+	client: RaindexClient
+): Promise<Network[]> {
+	const document = parseDocument(settingsYaml, { schema: 'failsafe' });
+	if (document.errors.length > 0) {
+		throw new Error(`Registry settings YAML is invalid: ${document.errors[0].message}`);
+	}
+
+	const subgraphs = urlMap(document, 'subgraphs');
+	const metaboards = urlMap(document, 'metaboards');
+	const networkResult = client.getAllNetworks();
+	if (networkResult.error) throw new Error(networkResult.error.readableMsg);
+	const raindexResult = client.getAllRaindexes();
+	if (raindexResult.error) throw new Error(raindexResult.error.readableMsg);
+	const configuredNetworks = networkResult.value as Map<string, NetworkCfg>;
+	const configuredRaindexes = raindexResult.value as Map<string, RaindexCfg>;
+	const result: Network[] = [];
+
+	for (const [slug, sdkNetwork] of configuredNetworks) {
+		const chainId = sdkNetwork.chainId;
+		if (!Number.isSafeInteger(chainId) || chainId <= 0) {
+			throw new Error(`Registry network ${slug} has an invalid chain-id`);
+		}
+
+		const rpcs = sdkNetwork.rpcs.filter((url) => typeof url === 'string' && url.length > 0);
+		if (rpcs.length === 0) {
+			throw new Error(`Registry network ${slug} does not contain RPC URLs`);
+		}
+
+		const paymentTokens = paymentTokensForChain(tokens, chainId);
+		const defaultPaymentToken =
+			paymentTokens.find((token) => token.paymentToken) ??
+			paymentTokens.find((token) => token.symbol.toUpperCase() === 'USDC') ??
+			paymentTokens[0];
+		if (!defaultPaymentToken) {
+			throw new Error(`REST token catalog has no payment token for chain ${chainId}`);
+		}
+
+		const trustedOrderbooks: string[] = [];
+		let orderbookSubgraph = '';
+		for (const raindex of configuredRaindexes.values()) {
+			if (raindex.network.chainId !== chainId) continue;
+			trustedOrderbooks.push(raindex.address);
+			if (!orderbookSubgraph) orderbookSubgraph = raindex.subgraph.url;
+		}
+
+		result.push({
+			id: chainId,
+			chainId,
+			name: slug,
+			raindexNetworkSlug: slug,
+			displayName: sdkNetwork.label ?? networkLabel(tokens, chainId, slug),
+			currencySymbol: sdkNetwork.currency ?? 'ETH',
+			blockExplorer: 'https://blockscan.com',
+			sftExplorer: 'https://blockscan.com',
+			blockExplorerIcon: 'etherscan',
+			rpcUrl: rpcs[0],
+			fallbackRpcUrls: rpcs.slice(1),
+			icon: 'ethereum',
+			subgraph_url: subgraphs.get(`sft-${slug}`) ?? '',
+			metadata_subgraph_url: metaboards.get(slug) ?? '',
+			orderbook_subgraph_url: orderbookSubgraph,
+			orderbook_subgraph_urls_inactive: [],
+			subgraph_urls_legacy: [],
+			paymentTokens,
+			defaultPaymentToken,
+			trustedOrderbooks
+		});
+	}
+
+	if (result.length === 0) throw new Error('Registry settings contain no usable networks');
+	return result.sort((left, right) => left.chainId - right.chainId);
+}
+
+/** Build a catalog from an already fetched settings document (primarily tests/tooling). */
+export async function buildNetworkCatalog(
+	settingsYaml: string,
+	tokens: readonly CategorizedToken[]
+): Promise<Network[]> {
+	const clientResult = await RaindexClient.new([prepareBrowserRaindexSettings(settingsYaml)]);
+	if (clientResult.error) {
+		throw new Error(`Raindex SDK rejected registry settings: ${clientResult.error.readableMsg}`);
+	}
+	return buildNetworkCatalogFromClient(settingsYaml, tokens, clientResult.value);
+}
+
+/**
+ * Build the live catalog through DotrainRegistry, the canonical SDK entry point.
+ * It resolves the registry manifest, shared settings YAML, remote token sources,
+ * networks, and raindexes as one immutable registry view.
+ */
+export async function buildNetworkCatalogFromRegistry(
+	registryUrl: string,
+	tokens: readonly CategorizedToken[]
+): Promise<Network[]> {
+	const registryResult = await DotrainRegistry.new(registryUrl);
+	if (registryResult.error) {
+		throw new Error(`Dotrain registry load failed: ${registryResult.error.readableMsg}`);
+	}
+	const registry = registryResult.value;
+	// The public settings include local DB synchronization for the REST service.
+	// Browsers/serverless requests do not provide that database implementation,
+	// so pass the SDK-resolved settings through the established browser-safe view.
+	const clientResult = await RaindexClient.new([prepareBrowserRaindexSettings(registry.settings)]);
+	if (clientResult.error) {
+		throw new Error(`Dotrain registry settings failed: ${clientResult.error.readableMsg}`);
+	}
+	return buildNetworkCatalogFromClient(registry.settings, tokens, clientResult.value);
+}
+
+export function replaceNetworkCatalog(nextNetworks: readonly Network[]): void {
+	networks.splice(0, networks.length, ...nextNetworks);
+}
 
 export function getNetworkById(id: number): Network | undefined {
 	return networks.find((network) => network.id === id);

--- a/src/lib/config/tokenMigration.ts
+++ b/src/lib/config/tokenMigration.ts
@@ -4,12 +4,13 @@
  * This file contains the mapping of old (legacy) tokens to their new wrapped equivalents.
  * The site now trades wrapped tStock tokens (wt[ticker]), so all tokens are named "Wrapped [tStock name]".
  *
- * NOTE: All address data is derived from TOKENS in tokens.ts (single source of truth)
+ * NOTE: All address data is derived from the API-backed runtime token catalog.
  */
 
-import { TOKENS, getTokenByLegacyAddress } from './tokens';
+import { getTokenByLegacyAddress, onTokenCatalogChange, type CategorizedToken } from './tokens';
 
 export interface TokenMigrationMapping {
+	chainId: number;
 	oldToken: {
 		address: string;
 		symbol: string;
@@ -22,36 +23,15 @@ export interface TokenMigrationMapping {
 		name: string;
 		decimals: number;
 	};
-	// Hardcoded swap order hash for checking liquidity and price
+	// Registry-provided migration order hash for checking liquidity and price.
 	swapOrderHash: string;
 }
-
-/**
- * Hardcoded swap order hashes for each token pair
- * These orders are specifically set up to handle the old -> new token migration
- * Keyed by legacy symbol (e.g., tNVDA, tSPLG)
- */
-export const SWAP_ORDER_HASHES: Record<string, string> = {
-	tNVDA: '0x9ae7b0a88787c0bcf97a4da26826cc7905c76a0f32c304402283c3741f9bd684',
-	tAMZN: '0x8ab0322b227ea8e24786af724e3100ed84784b0d12225578c8756fc9872dbd0a',
-	tTSLA: '0xefba39f9c82ff5bb6f8445f9efed252f788ceb92e0d03b3fa1c1dec2abda13b3',
-	tMSTR: '0x0baf4d5d34980b9952b2ef6ddf955af770d7ce194805ea7f11030346eb824590',
-	tIAU: '0xd0c72d4ed0e98b1a80c40c10604ae7a375287a9178a108c43a6ab445a8c64b6c',
-	tCOIN: '0x254855ac352435888114955ccc569389cfdc99d96fb0d470f6aa7bebd7d6394d',
-	tSPYM: '0x39a31c73bb3ed9325c78ced7d04f497f83801592b43b4cb39fa4e7c47baaf584',
-	tSIVR: '0x192421975c1385cf575692446c10f164f8994e1f932569c72a11e047d86f8fc7',
-	tCRCL: '0x97af9eed666eb12c5eea5275460e8e96161af40cd9af77152d96a5cb12f51111',
-	tBMNR: '0xc4a5e19079ded34f2e51400d51b914aeea2feeba29a6e186b1d967e1f02865d4',
-	tPPLT: '0x401c3be3eef4cdd68243339bbf3bf4f122e4ac39aab719d584951880e2d7b97d'
-	// tSTOX temporarily disabled
-	// tSTOX: '0x9cb21c2dbdd39fbd45c863cead8bccd205014f57fbafafb2c93e519229a6ab48'
-};
 
 /**
  * Derive old/legacy symbol from token
  * Uses legacySymbol if explicitly set (e.g., tSPLG -> wtSPYM), otherwise derives from wrapped symbol
  */
-function getLegacySymbol(token: (typeof TOKENS)[0]): string {
+function getLegacySymbol(token: CategorizedToken): string {
 	if (token.legacySymbol) {
 		return token.legacySymbol;
 	}
@@ -73,111 +53,145 @@ function getLegacyName(wrappedName: string): string {
 }
 
 /**
- * Complete token migration mappings - derived from TOKENS (single source of truth)
+ * Complete token migration mappings, rebuilt when the remote catalog changes.
  */
-export const TOKEN_MIGRATION_MAPPINGS: TokenMigrationMapping[] = TOKENS.filter(
-	(t) => t.legacyAddress && t.category === 'ST0x'
-).map((t) => {
-	const legacySymbol = getLegacySymbol(t);
-	return {
-		oldToken: {
-			address: t.legacyAddress!,
-			symbol: legacySymbol,
-			name: getLegacyName(t.name),
-			decimals: t.decimals
-		},
-		newToken: {
-			address: t.address,
-			symbol: t.symbol,
-			name: t.name,
-			decimals: t.decimals
-		},
-		swapOrderHash: SWAP_ORDER_HASHES[legacySymbol] ?? ''
-	};
-});
+export const TOKEN_MIGRATION_MAPPINGS: TokenMigrationMapping[] = [];
 
 // Create lookup maps for efficient access
-const oldTokenAddressSet = new Set(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => m.oldToken.address.toLowerCase())
-);
+const mappingByOldAddress = new Map<string, TokenMigrationMapping[]>();
+const mappingByOldSymbol = new Map<string, TokenMigrationMapping[]>();
+const mappingByNewAddress = new Map<string, TokenMigrationMapping[]>();
 
-const mappingByOldAddress = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.oldToken.address.toLowerCase(), m])
-);
+function addMapping(
+	lookup: Map<string, TokenMigrationMapping[]>,
+	key: string,
+	mapping: TokenMigrationMapping
+) {
+	lookup.set(key, [...(lookup.get(key) ?? []), mapping]);
+}
 
-const mappingByOldSymbol = new Map(TOKEN_MIGRATION_MAPPINGS.map((m) => [m.oldToken.symbol, m]));
+function resolveMapping(
+	lookup: Map<string, TokenMigrationMapping[]>,
+	key: string,
+	chainId?: number
+): TokenMigrationMapping | null {
+	const matches = lookup.get(key) ?? [];
+	if (chainId !== undefined) return matches.find((mapping) => mapping.chainId === chainId) ?? null;
+	return matches.length === 1 ? matches[0] : null;
+}
 
-const newTokenAddressSet = new Set(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => m.newToken.address.toLowerCase())
-);
+onTokenCatalogChange((tokens) => {
+	const mappings = tokens
+		.filter((token) => token.legacyAddress && token.migrationOrderHash && token.category === 'ST0x')
+		.map((token) => {
+			const legacySymbol = getLegacySymbol(token);
+			return {
+				chainId: token.chainId,
+				oldToken: {
+					address: token.legacyAddress!,
+					symbol: legacySymbol,
+					name: getLegacyName(token.name),
+					decimals: token.decimals
+				},
+				newToken: {
+					address: token.address,
+					symbol: token.symbol,
+					name: token.name,
+					decimals: token.decimals
+				},
+				swapOrderHash: token.migrationOrderHash!
+			};
+		});
 
-const mappingByNewAddress = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.newToken.address.toLowerCase(), m])
-);
+	TOKEN_MIGRATION_MAPPINGS.splice(0, TOKEN_MIGRATION_MAPPINGS.length, ...mappings);
+	mappingByOldAddress.clear();
+	mappingByOldSymbol.clear();
+	mappingByNewAddress.clear();
+	for (const mapping of mappings) {
+		const oldAddress = mapping.oldToken.address.toLowerCase();
+		const newAddress = mapping.newToken.address.toLowerCase();
+		addMapping(mappingByOldAddress, oldAddress, mapping);
+		addMapping(mappingByOldSymbol, mapping.oldToken.symbol, mapping);
+		addMapping(mappingByNewAddress, newAddress, mapping);
+	}
+});
 
 /**
  * Check if an address is an old (legacy) token that needs migration
  */
-export function isOldToken(address: string): boolean {
-	return oldTokenAddressSet.has(address.toLowerCase());
+export function isOldToken(address: string, chainId?: number): boolean {
+	return getMigrationMappingByAddress(address, chainId) !== null;
 }
 
 /**
  * Check if an address is a new wrapped token
  */
-export function isWrappedToken(address: string): boolean {
-	return newTokenAddressSet.has(address.toLowerCase());
+export function isWrappedToken(address: string, chainId?: number): boolean {
+	return getMigrationMappingByNewAddress(address, chainId) !== null;
 }
 
 /**
  * Get the migration mapping for an old token by its address
  */
-export function getMigrationMappingByAddress(oldAddress: string): TokenMigrationMapping | null {
-	return mappingByOldAddress.get(oldAddress.toLowerCase()) ?? null;
+export function getMigrationMappingByAddress(
+	oldAddress: string,
+	chainId?: number
+): TokenMigrationMapping | null {
+	return resolveMapping(mappingByOldAddress, oldAddress.toLowerCase(), chainId);
 }
 
 /**
  * Get the migration mapping by new (wrapped) token address
  */
-export function getMigrationMappingByNewAddress(newAddress: string): TokenMigrationMapping | null {
-	return mappingByNewAddress.get(newAddress.toLowerCase()) ?? null;
+export function getMigrationMappingByNewAddress(
+	newAddress: string,
+	chainId?: number
+): TokenMigrationMapping | null {
+	return resolveMapping(mappingByNewAddress, newAddress.toLowerCase(), chainId);
 }
 
 /**
  * Get the migration mapping for an old token by its symbol
  */
-export function getMigrationMappingBySymbol(oldSymbol: string): TokenMigrationMapping | null {
-	return mappingByOldSymbol.get(oldSymbol) ?? null;
+export function getMigrationMappingBySymbol(
+	oldSymbol: string,
+	chainId?: number
+): TokenMigrationMapping | null {
+	return resolveMapping(mappingByOldSymbol, oldSymbol, chainId);
 }
 
 /**
  * Get the new wrapped token address for an old token
  */
-export function getWrappedTokenAddress(oldAddress: string): string | null {
-	const token = getTokenByLegacyAddress(oldAddress);
+export function getWrappedTokenAddress(oldAddress: string, chainId?: number): string | null {
+	const token = getTokenByLegacyAddress(oldAddress, chainId);
 	return token?.address ?? null;
 }
 
 /**
  * Get the swap order hash for migrating an old token
  */
-export function getSwapOrderHash(oldAddress: string): string | null {
-	const mapping = getMigrationMappingByAddress(oldAddress);
+export function getSwapOrderHash(oldAddress: string, chainId?: number): string | null {
+	const mapping = getMigrationMappingByAddress(oldAddress, chainId);
 	return mapping?.swapOrderHash ?? null;
 }
 
 /**
  * Get all old token addresses as an array
  */
-export function getAllOldTokenAddresses(): string[] {
-	return TOKEN_MIGRATION_MAPPINGS.map((m) => m.oldToken.address);
+export function getAllOldTokenAddresses(chainId?: number): string[] {
+	return TOKEN_MIGRATION_MAPPINGS.filter(
+		(mapping) => chainId === undefined || mapping.chainId === chainId
+	).map((mapping) => mapping.oldToken.address);
 }
 
 /**
  * Get all migration mappings
  */
-export function getAllMigrationMappings(): TokenMigrationMapping[] {
-	return TOKEN_MIGRATION_MAPPINGS;
+export function getAllMigrationMappings(chainId?: number): TokenMigrationMapping[] {
+	return TOKEN_MIGRATION_MAPPINGS.filter(
+		(mapping) => chainId === undefined || mapping.chainId === chainId
+	);
 }
 
 /**

--- a/src/lib/config/tokenMigration.ts
+++ b/src/lib/config/tokenMigration.ts
@@ -81,6 +81,13 @@ function resolveMapping(
 }
 
 onTokenCatalogChange((tokens) => {
+	for (const token of tokens) {
+		if (token.category === 'ST0x' && token.legacyAddress && !token.migrationOrderHash) {
+			console.warn(
+				`[token-migration] ${token.symbol} on chain ${token.chainId} has a legacy address but no migrationOrderHash`
+			);
+		}
+	}
 	const mappings = tokens
 		.filter((token) => token.legacyAddress && token.migrationOrderHash && token.category === 'ST0x')
 		.map((token) => {

--- a/src/lib/config/tokenWrapping.ts
+++ b/src/lib/config/tokenWrapping.ts
@@ -8,12 +8,13 @@
  * Old/Legacy tStock --[Swap]--> Wrapped tStock (wt) <--[Wrap/Unwrap]--> Unwrapped tStock (t)
  *    (existing)              (ERC4626 vault)                      (underlying)
  *
- * NOTE: All address data is derived from TOKENS in tokens.ts (single source of truth)
+ * NOTE: All address data is derived from the API-backed runtime token catalog.
  */
 
-import { TOKENS, getTokenByWrappedAddress, getTokenByUnwrappedAddress } from './tokens';
+import { onTokenCatalogChange } from './tokens';
 
 export interface TokenWrappingMapping {
+	chainId: number;
 	/** The ERC4626 vault token (wrapped tStock) - this IS the vault contract */
 	wrappedToken: {
 		address: string;
@@ -51,97 +52,86 @@ function getUnwrappedName(wrappedName: string): string {
 }
 
 /**
- * Complete token wrapping mappings - derived from TOKENS (single source of truth)
+ * Complete token wrapping mappings, rebuilt when the remote catalog changes.
  */
-export const TOKEN_WRAPPING_MAPPINGS: TokenWrappingMapping[] = TOKENS.filter(
-	(t) => t.unwrappedAddress && t.category === 'ST0x'
-).map((t) => ({
-	wrappedToken: {
-		address: t.address,
-		symbol: t.symbol,
-		name: t.name,
-		decimals: t.decimals
-	},
-	unwrappedToken: {
-		address: t.unwrappedAddress!,
-		symbol: getUnwrappedSymbol(t.symbol),
-		name: getUnwrappedName(t.name),
-		decimals: t.decimals
-	}
-}));
-
-/**
- * Underlying token addresses for each wrapped token (derived from TOKENS)
- * These are the underlying assets of the ERC4626 vaults
- */
-export const UNDERLYING_TOKEN_ADDRESSES: Record<string, string> = Object.fromEntries(
-	TOKENS.filter((t) => t.unwrappedAddress).map((t) => [
-		getUnwrappedSymbol(t.symbol),
-		t.unwrappedAddress!
-	])
-);
-
-/**
- * Wrapped token addresses (ERC4626 vaults) - derived from TOKENS
- * These are the vault contracts that hold the underlying tokens
- */
-export const WRAPPED_TOKEN_ADDRESSES: Record<string, string> = Object.fromEntries(
-	TOKENS.filter((t) => t.category === 'ST0x').map((t) => [t.symbol, t.address])
-);
+export const TOKEN_WRAPPING_MAPPINGS: TokenWrappingMapping[] = [];
 
 // Create lookup maps for efficient access
-const mappingByWrappedAddress = new Map(
-	TOKEN_WRAPPING_MAPPINGS.map((m) => [m.wrappedToken.address.toLowerCase(), m])
-);
+const mappingByWrappedAddress = new Map<string, TokenWrappingMapping[]>();
+const mappingByUnwrappedAddress = new Map<string, TokenWrappingMapping[]>();
 
-const mappingByUnwrappedAddress = new Map(
-	TOKEN_WRAPPING_MAPPINGS.map((m) => [m.unwrappedToken.address.toLowerCase(), m])
-);
+function addMapping(
+	lookup: Map<string, TokenWrappingMapping[]>,
+	address: string,
+	mapping: TokenWrappingMapping
+) {
+	const key = address.toLowerCase();
+	lookup.set(key, [...(lookup.get(key) ?? []), mapping]);
+}
 
-const unwrappedAddressSet = new Set(
-	TOKEN_WRAPPING_MAPPINGS.map((m) => m.unwrappedToken.address.toLowerCase())
-);
+function resolveMapping(
+	lookup: Map<string, TokenWrappingMapping[]>,
+	address: string,
+	chainId?: number
+): TokenWrappingMapping | null {
+	const matches = lookup.get(address.toLowerCase()) ?? [];
+	if (chainId !== undefined) return matches.find((mapping) => mapping.chainId === chainId) ?? null;
+	return matches.length === 1 ? matches[0] : null;
+}
+
+onTokenCatalogChange((tokens) => {
+	const mappings: TokenWrappingMapping[] = tokens
+		.filter((token) => token.unwrappedAddress && token.category === 'ST0x')
+		.map((token) => ({
+			chainId: token.chainId,
+			wrappedToken: {
+				address: token.address,
+				symbol: token.symbol,
+				name: token.name,
+				decimals: token.decimals
+			},
+			unwrappedToken: {
+				address: token.unwrappedAddress!,
+				symbol: getUnwrappedSymbol(token.symbol),
+				name: getUnwrappedName(token.name),
+				decimals: token.decimals
+			}
+		}));
+
+	TOKEN_WRAPPING_MAPPINGS.splice(0, TOKEN_WRAPPING_MAPPINGS.length, ...mappings);
+	mappingByWrappedAddress.clear();
+	mappingByUnwrappedAddress.clear();
+	for (const mapping of mappings) {
+		addMapping(mappingByWrappedAddress, mapping.wrappedToken.address, mapping);
+		addMapping(mappingByUnwrappedAddress, mapping.unwrappedToken.address, mapping);
+	}
+});
 
 /**
  * Get the wrapping mapping for a wrapped token by its address (vault address)
  */
-export function getWrappingMappingByWrappedAddress(address: string): TokenWrappingMapping | null {
-	return mappingByWrappedAddress.get(address.toLowerCase()) ?? null;
+export function getWrappingMappingByWrappedAddress(
+	address: string,
+	chainId?: number
+): TokenWrappingMapping | null {
+	return resolveMapping(mappingByWrappedAddress, address, chainId);
 }
 
 /**
  * Get the wrapping mapping for an unwrapped token by its address (underlying asset)
  */
-export function getWrappingMappingByUnwrappedAddress(address: string): TokenWrappingMapping | null {
-	return mappingByUnwrappedAddress.get(address.toLowerCase()) ?? null;
-}
-
-/**
- * Check if an address is an unwrapped (underlying) token
- */
-export function isUnwrappedToken(address: string): boolean {
-	return unwrappedAddressSet.has(address.toLowerCase());
+export function getWrappingMappingByUnwrappedAddress(
+	address: string,
+	chainId?: number
+): TokenWrappingMapping | null {
+	return resolveMapping(mappingByUnwrappedAddress, address, chainId);
 }
 
 /**
  * Get all unwrapped token addresses as an array
  */
-export function getAllUnwrappedTokenAddresses(): string[] {
-	return TOKEN_WRAPPING_MAPPINGS.map((m) => m.unwrappedToken.address);
-}
-
-/**
- * Get the vault (wrapped token) address for an underlying token
- */
-export function getVaultAddressForUnderlying(underlyingAddress: string): string | null {
-	const token = getTokenByUnwrappedAddress(underlyingAddress);
-	return token?.address ?? null;
-}
-
-/**
- * Get the underlying token address for a vault (wrapped token)
- */
-export function getUnderlyingAddressForVault(vaultAddress: string): string | null {
-	const token = getTokenByWrappedAddress(vaultAddress);
-	return token?.unwrappedAddress ?? null;
+export function getAllUnwrappedTokenAddresses(chainId?: number): string[] {
+	return TOKEN_WRAPPING_MAPPINGS.filter(
+		(mapping) => chainId === undefined || mapping.chainId === chainId
+	).map((mapping) => mapping.unwrappedToken.address);
 }

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -130,7 +130,13 @@ export function replaceTokenCatalog(tokens: readonly CategorizedToken[]): void {
 
 	rebuildTokenLookups();
 	rebuildPaymentTokens();
-	for (const listener of tokenCatalogListeners) listener(TOKENS);
+	for (const listener of tokenCatalogListeners) {
+		try {
+			listener(TOKENS);
+		} catch (error) {
+			console.error('[token-catalog] Listener failed:', error);
+		}
+	}
 }
 
 export function onTokenCatalogChange(listener: TokenCatalogListener): () => void {

--- a/src/lib/config/tokens.ts
+++ b/src/lib/config/tokens.ts
@@ -1,34 +1,4 @@
-import { arbitrum, base } from '@wagmi/core/chains';
 import type { Token } from '$lib/types';
-
-export const PAYMENT_TOKENS_BY_NETWORK: Record<number, Token[]> = {
-	8453: [
-		{
-			chainId: 8453,
-			address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-			symbol: 'USDC',
-			decimals: 6,
-			name: 'USD Coin',
-			logoUrl: '/images/USDC.png'
-		}
-	]
-};
-
-export const DEFAULT_PAYMENT_TOKENS: Record<number, Token> = Object.fromEntries(
-	Object.entries(PAYMENT_TOKENS_BY_NETWORK).map(([chainId, tokens]) => [
-		Number(chainId),
-		tokens[0] as Token
-	])
-);
-
-export function getPaymentTokensForNetwork(chainId: number): Token[] {
-	return PAYMENT_TOKENS_BY_NETWORK[chainId] ?? [];
-}
-
-export function getDefaultPaymentTokenForNetwork(chainId: number): Token | undefined {
-	const [first] = getPaymentTokensForNetwork(chainId);
-	return first;
-}
 
 export type TokenCategory = 'ST0x' | 'CRYPTO';
 
@@ -37,628 +7,150 @@ export interface LimitOrder {
 	type: 'Buy' | 'Sell';
 }
 
+export interface TokenNetworkMetadata {
+	key?: string;
+	chainId: number;
+	label?: string;
+	networkId?: number;
+	currency?: string;
+}
+
 export interface CategorizedToken extends Token {
 	category: TokenCategory;
+	network?: TokenNetworkMetadata;
+	logoUrl?: string;
 	tradingViewSymbol?: string;
 	tradingViewMarket?: string;
 	limitOrders?: LimitOrder[];
-	// Token address variants for ST0x tokens
-	unwrappedAddress?: string; // Underlying ERC4626 asset (tNVDA)
-	legacyAddress?: string; // Old token for migration (optional)
-	legacySymbol?: string; // Old symbol if different (e.g., tSPLG -> wtSPYM)
-	previousSymbols?: string[]; // Historical symbol names for blob storage lookups
+	unwrappedAddress?: string;
+	legacyAddress?: string;
+	legacySymbol?: string;
+	previousSymbols?: string[];
+	receiptAddress?: string;
+	isin?: string;
+	priceFeedId?: string;
+	fallbackPrice?: number;
+	paymentToken?: boolean;
+	migrationOrderHash?: string;
 }
 
-export const TOKENS: CategorizedToken[] = [
-	{
-		chainId: base.id,
-		address: '0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7',
-		unwrappedAddress: '0x7271a3c91bb6070ed09333b84a815949d4f16d14',
-		legacyAddress: '0x69fca9f7fad46a7eef3acef5beac9df5b7eca73b',
-		symbol: 'wtNVDA',
-		decimals: 18,
-		name: 'Wrapped NVIDIA Corporation ST0x',
-		logoUrl: '/images/NVDA.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:NVDA',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x997baE3EC193a249596d3708C3fAB7C501Bb8a53',
-		unwrappedAddress: '0x466cb2e46fa1afc0ab5e22274b34d0391db18efd',
-		legacyAddress: '0x8d8c315db61f60dcc3c66cdb48ca87fc643e35ea',
-		symbol: 'wtAMZN',
-		decimals: 18,
-		name: 'Wrapped Amazon.com Inc ST0x',
-		logoUrl: '/images/AMZN.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AMZN',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x219A8d384a10BF19b9f24cB5cC53F79Dd0e5A03D',
-		unwrappedAddress: '0x4e169cd2ab4f82640a8c65c68fed55863866fdb0',
-		legacyAddress: '0x470b06815a2e286df8c38c9c73280e0760088623',
-		symbol: 'wtTSLA',
-		decimals: 18,
-		name: 'Wrapped Tesla Inc ST0x',
-		logoUrl: '/images/TSLA.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:TSLA',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xFF05E1bD696900dc6A52CA35Ca61Bb1024eDa8e2',
-		unwrappedAddress: '0x013b782f402d61aa1004cca95b9f5bb402c9d5fe',
-		legacyAddress: '0xff647ad8c4b065bd746911bb9ea1a33c38c63604',
-		symbol: 'wtMSTR',
-		decimals: 18,
-		name: 'Wrapped MicroStrategy Incorporated ST0x',
-		logoUrl: '/images/MSTR.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:MSTR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x1E46d7eFef64A833AFB1CD49299a7AD5B439f4d8',
-		unwrappedAddress: '0x9a507314ea2a6c5686c0d07bfecb764dcf324dff',
-		legacyAddress: '0xd0a90b7c9ae5facbe09ca4c576a3795eda53b397',
-		symbol: 'wtIAU',
-		decimals: 18,
-		name: 'Wrapped iShares Gold Trust ST0x',
-		logoUrl: '/images/ishares.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:IAU',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x5cDa0E1CA4ce2af96315f7F8963C85399c172204',
-		unwrappedAddress: '0x626757e6f50675d17fcad312e82f989ae7a23d38',
-		legacyAddress: '0xb616f8b391d1adc118fd7e4063526d5530d49b10',
-		symbol: 'wtCOIN',
-		decimals: 18,
-		name: 'Wrapped Coinbase Global Inc ST0x',
-		logoUrl: '/images/COIN.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:COIN',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x31C2C14134e6E3B7ef9478297F199331133Fc2d8',
-		unwrappedAddress: '0x8fdf41116f755771bfe0747d5f8c3711d5debfbb',
-		legacyAddress: '0x2289249984f1fa2ce86c4e8867e7eb819ea7df95',
-		legacySymbol: 'tSPYM', // Symbol changed from SPLG to SPYM
-		previousSymbols: ['wtSPLG', 'tSPLG'], // Historical blob storage names
-		symbol: 'wtSPYM',
-		decimals: 18,
-		name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-		logoUrl: '/images/state_street.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SPYM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	// wtSTOX token temporarily disabled
-	// {
-	// 	chainId: base.id,
-	// 	address: '0xf3da872A3B8e674A8925c67c866b2a4a67a1fC8a',
-	// 	unwrappedAddress: '0x9e0052b62ff6ce9055b33996a1dee768041b1f67',
-	// 	legacyAddress: '0xcf877a4f3ebec00c5b070cccb0a6a0583afbcd88',
-	// 	// legacySymbol: 'tSTOX',
-	// 	symbol: 'wtSTOX',
-	// 	decimals: 18,
-	// 	name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
-	// 	logoUrl: '/images/state_street.png',
-	// 	category: 'ST0x',
-	// 	tradingViewSymbol: 'AMEX:SPLG',
-	// 	tradingViewMarket: 'america',
-	// 	limitOrders: []
-	// },
-	{
-		chainId: base.id,
-		address: '0xEB7F3E4093C9d68253b6104FbbfF561F3eC0442F',
-		unwrappedAddress: '0x58ce5024b89b4f73c27814c0f0abbea331c99be8',
-		legacyAddress: '0x826a85de1f7b70f4c7450c0f882a6db06000ed80',
-		symbol: 'wtSIVR',
-		decimals: 18,
-		name: 'Wrapped abrdn Physical Silver Shares ETF ST0x',
-		logoUrl: '/images/abrdn.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:SIVR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x8AFba81DEc38DE0A18E2Df5E1967a7493651eebf',
-		unwrappedAddress: '0x38eb797892ed71da69bdc27a456a7c83ff813b52',
-		legacyAddress: '0x43422a9d11a6640ef0d5f65292ef8adf87cf8522',
-		symbol: 'wtCRCL',
-		decimals: 18,
-		name: 'Wrapped Circle Internet Group Inc ST0x',
-		logoUrl: '/images/CRCL.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:CRCL',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x2512EC661f0bA089c275EA105E31bAD6FcFcf319',
-		unwrappedAddress: '0xfbde45df60249203b12148452fc77c3b5f811eb2',
-		legacyAddress: '0xf8fdfd6a686346d34b3143fc23072aa45c9e8386',
-		symbol: 'wtBMNR',
-		decimals: 18,
-		name: 'Wrapped Bitmine Immersion Technologies, Inc ST0x',
-		logoUrl: '/images/BMNR.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:BMNR',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x82f5BAEE1076334357a34A19E04f7c282D51cE47',
-		unwrappedAddress: '0x1f17523b147ccc2a2328c0f014f6d49c479ea063',
-		legacyAddress: '0x6192539a2036c786aba3ca6a2222ff7a0f9c287e',
-		symbol: 'wtPPLT',
-		decimals: 18,
-		name: 'Wrapped abrdn Physical Platinum Shares ETF ST0x',
-		logoUrl: '/images/abrdn.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:PPLT',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x823FF7Bbde2869aAe73A6CD53e7f614442836757',
-		unwrappedAddress: '0x09ee803ba675052e10a54bfc8e18c0f67793056b',
-		symbol: 'wtQQQM',
-		decimals: 18,
-		name: 'Wrapped Invesco NASDAQ 100 ETF ST0x',
-		logoUrl: '/images/invesco.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:QQQM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x23ec6886b49D7ab123E9ee8e474D2fa7AB6Cbc2d',
-		unwrappedAddress: '0x0acfea6833c4a3f41bf2fbd736aa9eea547d90ee',
-		symbol: 'wtVWO',
-		decimals: 18,
-		name: 'Wrapped Vanguard Emerging Markets Stock Index Fund ST0x',
-		logoUrl: '/images/vanguard.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:VWO',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x9FfF48B4535AF3765Ac9E1b164720EDc01DF8EE7',
-		unwrappedAddress: '0x323804af6f3bb463d688b854667c6870a0fc06ad',
-		symbol: 'wtARKK',
-		decimals: 18,
-		name: 'Wrapped ARK Innovation ETF ST0x',
-		logoUrl: '/images/ARKK.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'AMEX:ARKK',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		// wtSGOV — iShares 0-3 Month Treasury Bond ETF. Added via st0x.registry
-		// PR #22 (ST0x-Technology/st0x.registry). This is the first ST0x wrapper
-		// expected to develop a non-1:1 wrap ratio over time (T-bill yield
-		// accrues into the vault, increasing assetsPerShare).
-		chainId: base.id,
-		address: '0x78c31580c97101694C70022c83D570150c11e935',
-		unwrappedAddress: '0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612',
-		symbol: 'wtSGOV',
-		decimals: 18,
-		name: 'Wrapped iShares 0-3 Month Treasury Bond ETF ST0x',
-		logoUrl: '/images/ishares.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:SGOV',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		// wtSPCX — Space Exploration Technologies Corp (SpaceX). Deployed on Base
-		// 2026-06-10 ahead of the 2026-06-12 Nasdaq IPO (ticker SPCX, ISIN
-		// US84615Q1031).
-		chainId: base.id,
-		address: '0x19F89aaEf8a93f38A974beca9776f09aB844887F',
-		unwrappedAddress: '0xc585AeB8B76c5F5e4215470A7625258e86ED7746',
-		symbol: 'wtSPCX',
-		decimals: 18,
-		name: 'Wrapped Space Exploration Technologies Corp. ST0x',
-		logoUrl: '/images/SPCX.svg',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:SPCX',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x3aF952888Cd89DAD3e8AF67cf4b7E740B36829C3',
-		unwrappedAddress: '0x9a5D3cAeC90b0332b18C0B93fEF42F3F8C918289',
-		symbol: 'wtCEG',
-		decimals: 18,
-		name: 'Wrapped Constellation Energy Corporation ST0x',
-		logoUrl: '/images/CEG.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:CEG',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x1A91Df4a970EBaB1bB4AF32Eb6d10509028eE4b8',
-		unwrappedAddress: '0x96DE077262609298CD891E4Ab21bd34837dE33aB',
-		symbol: 'wtDRAM',
-		decimals: 18,
-		name: 'Wrapped Roundhill Memory ETF ST0x',
-		logoUrl: '/images/roundhill.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'CBOE:DRAM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x71C66449d2528E23514A9c197BFD55Ae9DB3B714',
-		unwrappedAddress: '0x7001e2974F775f0Fd73a3D2e5914e591f3EC3fBB',
-		symbol: 'wtTSM',
-		decimals: 18,
-		name: 'Wrapped Taiwan Semiconductor Manufacturing Company ST0x',
-		logoUrl: '/images/TSM.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:TSM',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x8200c6d9AB9E02A25D7F2099244C476d99a085ef',
-		unwrappedAddress: '0x722Cb373f1871A176fb5DC3953046f2EAE22F619',
-		symbol: 'wtASML',
-		decimals: 18,
-		name: 'Wrapped ASML Holding N.V. ST0x',
-		logoUrl: '/images/ASML.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:ASML',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9',
-		unwrappedAddress: '0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c',
-		symbol: 'wtSKHY',
-		decimals: 18,
-		name: 'Wrapped SK hynix Inc. ADR ST0x',
-		logoUrl: '/images/SKHY.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:SKHY',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x89EcfE9E0728D6b3c5eb0EE7236f8C6F806C7B56',
-		unwrappedAddress: '0x7d89a2DFfDaF9f48A64337C725D925381b431aE2',
-		symbol: 'wtMU',
-		decimals: 18,
-		name: 'Wrapped Micron Technology, Inc. ST0x',
-		logoUrl: '/images/MU.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:MU',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x648042Acd8638E12fEfd51C2b25A9f993f21a612',
-		unwrappedAddress: '0x50b5225409A55B873fD6C2Fd5880AF5a11acE9b1',
-		symbol: 'wtAMD',
-		decimals: 18,
-		name: 'Wrapped Advanced Micro Devices, Inc. ST0x',
-		logoUrl: '/images/AMD.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AMD',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x70A182f481AEF05836666B6CfDbe84dCBCE8AC19',
-		unwrappedAddress: '0x6088F8ef741AE1f5A61882866f130631b41617E2',
-		symbol: 'wtAVGO',
-		decimals: 18,
-		name: 'Wrapped Broadcom Inc. ST0x',
-		logoUrl: '/images/AVGO.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AVGO',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x522DC65c89C9Af4f410BAe01bbf53aF75854a9f9',
-		unwrappedAddress: '0x98C02B58b7E65EF5a4262d9536162949e3B2E141',
-		symbol: 'wtAMAT',
-		decimals: 18,
-		name: 'Wrapped Applied Materials, Inc. ST0x',
-		logoUrl: '/images/AMAT.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AMAT',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x328B9aFFa511fE26673edBb4fEa37eDaF908A3bc',
-		unwrappedAddress: '0xDdE9346107609A05439A0B59Ab6eD4f7F81a1FBF',
-		symbol: 'wtLRCX',
-		decimals: 18,
-		name: 'Wrapped Lam Research Corporation ST0x',
-		logoUrl: '/images/LRCX.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:LRCX',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x045Fb493D970f94a54FeaF931033622fC82192e6',
-		unwrappedAddress: '0x1a29eD11DF8295D5F3B5F59849FD94caD615E024',
-		symbol: 'wtTTWO',
-		decimals: 18,
-		name: 'Wrapped Take-Two Interactive Software, Inc. ST0x',
-		logoUrl: '/images/TTWO.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:TTWO',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c',
-		unwrappedAddress: '0x15De944Cd020A18C8E5626fB0F81b36e73956199',
-		symbol: 'wtGOOGL',
-		decimals: 18,
-		name: 'Wrapped Alphabet Inc. Class A ST0x',
-		logoUrl: '/images/GOOGL.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:GOOGL',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722',
-		unwrappedAddress: '0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3',
-		symbol: 'wtINTC',
-		decimals: 18,
-		name: 'Wrapped Intel Corporation ST0x',
-		logoUrl: '/images/INTC.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:INTC',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88',
-		unwrappedAddress: '0xD36056a4a03707D3743fCE4e9C08852820ADcfdC',
-		symbol: 'wtAAPL',
-		decimals: 18,
-		name: 'Wrapped Apple Inc. ST0x',
-		logoUrl: '/images/AAPL.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:AAPL',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E',
-		unwrappedAddress: '0x6a071E25fa25653cF15d1ee320eA3df771926Aa0',
-		symbol: 'wtMSFT',
-		decimals: 18,
-		name: 'Wrapped Microsoft Corporation ST0x',
-		logoUrl: '/images/MSFT.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:MSFT',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd',
-		unwrappedAddress: '0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554',
-		symbol: 'wtLLY',
-		decimals: 18,
-		name: 'Wrapped Eli Lilly and Company ST0x',
-		logoUrl: '/images/LLY.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:LLY',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a',
-		unwrappedAddress: '0xb6021810971714cD48572af527307Acc324ecF61',
-		symbol: 'wtPTY',
-		decimals: 18,
-		name: 'Wrapped PIMCO Corporate & Income Opportunity Fund ST0x',
-		logoUrl: '/images/PTY.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:PTY',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425',
-		unwrappedAddress: '0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f',
-		symbol: 'wtHOOD',
-		decimals: 18,
-		name: 'Wrapped Robinhood Markets, Inc. ST0x',
-		logoUrl: '/images/HOOD.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:HOOD',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726',
-		unwrappedAddress: '0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B',
-		symbol: 'wtORCL',
-		decimals: 18,
-		name: 'Wrapped Oracle Corporation ST0x',
-		logoUrl: '/images/ORCL.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:ORCL',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0',
-		unwrappedAddress: '0x8518931497d2A8f07Bc607D1D3295b398D065A65',
-		symbol: 'wtSMCI',
-		decimals: 18,
-		name: 'Wrapped Super Micro Computer, Inc. ST0x',
-		logoUrl: '/images/SMCI.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:SMCI',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD',
-		unwrappedAddress: '0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5',
-		symbol: 'wtBABA',
-		decimals: 18,
-		name: 'Wrapped Alibaba Group Holding Limited ADR ST0x',
-		logoUrl: '/images/BABA.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NYSE:BABA',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	},
-	{
-		chainId: base.id,
-		address: '0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada',
-		unwrappedAddress: '0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E',
-		symbol: 'wtTQQQ',
-		decimals: 18,
-		name: 'Wrapped ProShares UltraPro QQQ ST0x',
-		logoUrl: '/images/TQQQ.png',
-		category: 'ST0x',
-		tradingViewSymbol: 'NASDAQ:TQQQ',
-		tradingViewMarket: 'america',
-		limitOrders: []
-	}
-	// {
-	// 	chainId: base.id,
-	// 	address: '0xF4f8c66085910d583c01f3b4e44Bf731D4e2c565',
-	// 	unwrappedAddress: '0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b',
-	// 	// No legacy address - wtRKLB is a new token
-	// 	symbol: 'wtRKLB',
-	// 	decimals: 18,
-	// 	name: 'Wrapped Rocket Lab USA Inc ST0x',
-	// 	logoUrl: '/images/RKLB.png',
-	// 	category: 'ST0x',
-	// 	tradingViewSymbol: 'NASDAQ:RKLB',
-	// 	tradingViewMarket: 'america',
-	// 	limitOrders: []
-	// }
-];
+/**
+ * Runtime token catalog hydrated from the REST API.
+ *
+ * These collections keep stable identities because several long-lived stores
+ * retain references to them. Registry refreshes replace their contents in
+ * place instead of requiring a website release for every token or network.
+ */
+export const TOKENS: CategorizedToken[] = [];
+export const CRYPTO_TOKENS: CategorizedToken[] = [];
+export const TOKEN_SYMBOLS: string[] = [];
+export const TOKEN_WRAPPED_ADDRESS_SET = new Set<string>();
+export const PREVIOUS_SYMBOLS_BY_TOKEN = new Map<string, string[]>();
+export const PAYMENT_TOKENS_BY_NETWORK: Record<number, CategorizedToken[]> = {};
+export const DEFAULT_PAYMENT_TOKENS: Record<number, CategorizedToken> = {};
 
-export const CRYPTO_TOKENS: CategorizedToken[] = [
-	{
-		chainId: arbitrum.id,
-		address: '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
-		symbol: 'WBTC',
-		decimals: 18,
-		name: 'Wrapped BTC',
-		logoUrl: '/images/BTC.svg',
-		category: 'CRYPTO',
-		tradingViewSymbol: 'BINANCE:BTCUSDT',
-		tradingViewMarket: 'crypto'
-	},
-	{
-		chainId: arbitrum.id,
-		address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-		symbol: 'WETH',
-		decimals: 18,
-		name: 'Wrapped Ether',
-		logoUrl: '/images/ETH.svg',
-		category: 'CRYPTO',
-		tradingViewSymbol: 'BINANCE:ETHUSDT',
-		tradingViewMarket: 'crypto'
-	},
-	{
-		chainId: arbitrum.id,
-		address: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-		symbol: 'ARB',
-		decimals: 18,
-		name: 'Arbitrum (ARB)',
-		logoUrl: '/images/ARB.svg',
-		category: 'CRYPTO',
-		tradingViewSymbol: 'BINANCE:ARBUSDT',
-		tradingViewMarket: 'crypto'
-	},
-	{
-		chainId: arbitrum.id,
-		address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-		symbol: 'USDC',
-		decimals: 6,
-		name: 'USD Coin',
-		logoUrl: '/images/USDC.png',
-		category: 'CRYPTO',
-		tradingViewSymbol: 'KRAKEN:USDCUSD',
-		tradingViewMarket: 'crypto'
-	},
-	{
-		chainId: base.id,
-		address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-		symbol: 'USDC',
-		decimals: 6,
-		name: 'USD Coin',
-		logoUrl: '/images/USDC.png',
-		category: 'CRYPTO',
-		tradingViewSymbol: 'KRAKEN:USDCUSD',
-		tradingViewMarket: 'crypto'
+type TokenCatalogListener = (tokens: readonly CategorizedToken[]) => void;
+const tokenCatalogListeners = new Set<TokenCatalogListener>();
+
+const tokenByWrappedAddress = new Map<string, CategorizedToken[]>();
+const tokenByUnwrappedAddress = new Map<string, CategorizedToken[]>();
+const tokenByLegacyAddress = new Map<string, CategorizedToken[]>();
+
+function replaceRecord<T>(target: Record<number, T>, values: Record<number, T>): void {
+	for (const key of Object.keys(target)) delete target[Number(key)];
+	Object.assign(target, values);
+}
+
+function addAddressLookup(
+	lookup: Map<string, CategorizedToken[]>,
+	address: string | undefined,
+	token: CategorizedToken
+): void {
+	if (!address) return;
+	const key = address.toLowerCase();
+	lookup.set(key, [...(lookup.get(key) ?? []), token]);
+}
+
+function rebuildTokenLookups(): void {
+	tokenByWrappedAddress.clear();
+	tokenByUnwrappedAddress.clear();
+	tokenByLegacyAddress.clear();
+	for (const token of TOKENS) {
+		addAddressLookup(tokenByWrappedAddress, token.address, token);
+		addAddressLookup(tokenByUnwrappedAddress, token.unwrappedAddress, token);
+		addAddressLookup(tokenByLegacyAddress, token.legacyAddress, token);
 	}
-];
+}
+
+function resolveAddressLookup(
+	lookup: Map<string, CategorizedToken[]>,
+	address: string,
+	chainId?: number
+): CategorizedToken | null {
+	const matches = lookup.get(address.toLowerCase()) ?? [];
+	if (chainId !== undefined) {
+		return matches.find((token) => token.chainId === chainId) ?? null;
+	}
+	return matches.length === 1 ? matches[0] : null;
+}
+
+function rebuildPaymentTokens(): void {
+	const byNetwork: Record<number, CategorizedToken[]> = {};
+	for (const token of CRYPTO_TOKENS) {
+		(byNetwork[token.chainId] ??= []).push(token);
+	}
+	replaceRecord(PAYMENT_TOKENS_BY_NETWORK, byNetwork);
+
+	const defaults: Record<number, CategorizedToken> = {};
+	for (const [chainIdText, tokens] of Object.entries(byNetwork)) {
+		const selected =
+			tokens.find((token) => token.paymentToken) ??
+			tokens.find((token) => token.symbol.toUpperCase() === 'USDC') ??
+			tokens[0];
+		if (selected) defaults[Number(chainIdText)] = selected;
+	}
+	replaceRecord(DEFAULT_PAYMENT_TOKENS, defaults);
+}
+
+export function replaceTokenCatalog(tokens: readonly CategorizedToken[]): void {
+	const assets = tokens.filter((token) => token.category === 'ST0x');
+	const crypto = tokens.filter((token) => token.category === 'CRYPTO');
+	TOKENS.splice(0, TOKENS.length, ...assets);
+	CRYPTO_TOKENS.splice(0, CRYPTO_TOKENS.length, ...crypto);
+
+	TOKEN_SYMBOLS.splice(0, TOKEN_SYMBOLS.length, ...new Set(assets.map((token) => token.symbol)));
+	TOKEN_WRAPPED_ADDRESS_SET.clear();
+	PREVIOUS_SYMBOLS_BY_TOKEN.clear();
+	for (const token of assets) {
+		TOKEN_WRAPPED_ADDRESS_SET.add(token.address.toLowerCase());
+		if (token.previousSymbols?.length) {
+			PREVIOUS_SYMBOLS_BY_TOKEN.set(token.symbol, token.previousSymbols);
+		}
+	}
+
+	rebuildTokenLookups();
+	rebuildPaymentTokens();
+	for (const listener of tokenCatalogListeners) listener(TOKENS);
+}
+
+export function onTokenCatalogChange(listener: TokenCatalogListener): () => void {
+	tokenCatalogListeners.add(listener);
+	listener(TOKENS);
+	return () => tokenCatalogListeners.delete(listener);
+}
+
+export function getPaymentTokensForNetwork(chainId: number): CategorizedToken[] {
+	return PAYMENT_TOKENS_BY_NETWORK[chainId] ?? [];
+}
+
+export function getDefaultPaymentTokenForNetwork(chainId: number): CategorizedToken | undefined {
+	return DEFAULT_PAYMENT_TOKENS[chainId];
+}
 
 export function getAllTokens(): CategorizedToken[] {
 	return TOKENS;
 }
 
-// Helper function to get tokens filtered by network chainId
 export function getTokensByNetwork(chainId: number): CategorizedToken[] {
 	return TOKENS.filter((token) => token.chainId === chainId);
 }
@@ -671,73 +163,69 @@ export function getAllTokensByNetwork(chainId: number): CategorizedToken[] {
 	return [...getTokensByNetwork(chainId), ...getCryptoTokensByNetwork(chainId)];
 }
 
-// Address lookup maps (built once at module load)
-const tokenByWrappedAddress = new Map(TOKENS.map((t) => [t.address.toLowerCase(), t]));
-
-const tokenByUnwrappedAddress = new Map(
-	TOKENS.filter((t) => t.unwrappedAddress).map((t) => [t.unwrappedAddress!.toLowerCase(), t])
-);
-
-const tokenByLegacyAddress = new Map(
-	TOKENS.filter((t) => t.legacyAddress).map((t) => [t.legacyAddress!.toLowerCase(), t])
-);
-
-export function getTokenByWrappedAddress(address: string): CategorizedToken | null {
-	return tokenByWrappedAddress.get(address.toLowerCase()) ?? null;
+export function getTokenByWrappedAddress(
+	address: string,
+	chainId?: number
+): CategorizedToken | null {
+	return resolveAddressLookup(tokenByWrappedAddress, address, chainId);
 }
 
-export function getTokenByUnwrappedAddress(address: string): CategorizedToken | null {
-	return tokenByUnwrappedAddress.get(address.toLowerCase()) ?? null;
+export function getTokenByUnwrappedAddress(
+	address: string,
+	chainId?: number
+): CategorizedToken | null {
+	return resolveAddressLookup(tokenByUnwrappedAddress, address, chainId);
 }
 
-export function getTokenByLegacyAddress(address: string): CategorizedToken | null {
-	return tokenByLegacyAddress.get(address.toLowerCase()) ?? null;
+export function getTokenByLegacyAddress(
+	address: string,
+	chainId?: number
+): CategorizedToken | null {
+	return resolveAddressLookup(tokenByLegacyAddress, address, chainId);
 }
 
-/**
- * Get a token by any of its addresses (wrapped, unwrapped, or legacy).
- * Useful for URL redirects and lookups where address type is unknown.
- */
-export function getTokenByAnyAddress(address: string): CategorizedToken | null {
-	const lowerAddress = address.toLowerCase();
+export function getTokenByAnyAddress(address: string, chainId?: number): CategorizedToken | null {
 	return (
-		tokenByWrappedAddress.get(lowerAddress) ??
-		tokenByUnwrappedAddress.get(lowerAddress) ??
-		tokenByLegacyAddress.get(lowerAddress) ??
-		null
+		getTokenByWrappedAddress(address, chainId) ??
+		getTokenByUnwrappedAddress(address, chainId) ??
+		getTokenByLegacyAddress(address, chainId)
 	);
 }
 
-export function isWrappedTokenAddress(address: string): boolean {
-	return tokenByWrappedAddress.has(address.toLowerCase());
+export function isWrappedTokenAddress(address: string, chainId?: number): boolean {
+	return getTokenByWrappedAddress(address, chainId) !== null;
 }
 
-export function isUnwrappedTokenAddress(address: string): boolean {
-	return tokenByUnwrappedAddress.has(address.toLowerCase());
+export function isUnwrappedTokenAddress(address: string, chainId?: number): boolean {
+	return getTokenByUnwrappedAddress(address, chainId) !== null;
 }
 
-export function isLegacyTokenAddress(address: string): boolean {
-	return tokenByLegacyAddress.has(address.toLowerCase());
+export function isLegacyTokenAddress(address: string, chainId?: number): boolean {
+	return getTokenByLegacyAddress(address, chainId) !== null;
 }
 
-export function getAllUnwrappedTokenAddresses(): string[] {
-	return TOKENS.filter((t) => t.unwrappedAddress).map((t) => t.unwrappedAddress!);
+export function getAllUnwrappedTokenAddresses(chainId?: number): string[] {
+	return TOKENS.filter(
+		(token) => token.unwrappedAddress && (chainId === undefined || token.chainId === chainId)
+	).map((token) => token.unwrappedAddress!);
 }
 
-export function getAllLegacyTokenAddresses(): string[] {
-	return TOKENS.filter((t) => t.legacyAddress).map((t) => t.legacyAddress!);
+export function getAllLegacyTokenAddresses(chainId?: number): string[] {
+	return TOKENS.filter(
+		(token) => token.legacyAddress && (chainId === undefined || token.chainId === chainId)
+	).map((token) => token.legacyAddress!);
 }
 
-/** Get all address variants (wrapped, unwrapped, legacy) for a single token, lowercased. */
 export function getTokenAddressVariants(token: CategorizedToken): string[] {
 	return [
 		token.address,
 		...(token.unwrappedAddress ? [token.unwrappedAddress] : []),
 		...(token.legacyAddress ? [token.legacyAddress] : [])
-	].map((a) => a.toLowerCase());
+	].map((address) => address.toLowerCase());
 }
 
-/** Get all token addresses across all tokens (wrapped + unwrapped + legacy), lowercased. */
-export function getAllTokenAddressesFlat(): string[] {
-	return TOKENS.flatMap((t) => getTokenAddressVariants(t));
+export function getAllTokenAddressesFlat(chainId?: number): string[] {
+	return TOKENS.filter((token) => chainId === undefined || token.chainId === chainId).flatMap(
+		(token) => getTokenAddressVariants(token)
+	);
 }

--- a/src/lib/dynamic/DynamicReactProvider.tsx
+++ b/src/lib/dynamic/DynamicReactProvider.tsx
@@ -43,6 +43,7 @@ interface DynamicBridgeProps {
 		value: string;
 		data?: string;
 	} | null;
+	chainId?: number;
 }
 
 // Token refresh interval (refresh every 50 minutes to be safe before 1 hour expiry)
@@ -55,7 +56,8 @@ function DynamicBridge({
 	triggerLogin,
 	triggerLogout,
 	triggerExportWallet,
-	triggerSendTransaction
+	triggerSendTransaction,
+	chainId
 }: Omit<DynamicBridgeProps, 'environmentId'>) {
 	const { sdkHasLoaded, user, primaryWallet, handleLogOut, setShowAuthFlow } = useDynamicContext();
 
@@ -152,8 +154,7 @@ function DynamicBridge({
 				return;
 			}
 
-			// Base chain ID
-			const BASE_CHAIN_ID = '8453';
+			let selectedChainId = chainId ? String(chainId) : undefined;
 
 			// Cache wallet and public clients for reuse (reset on each activeWallet change)
 			let cachedWalletClient: Awaited<ReturnType<typeof activeWallet.getWalletClient>> | null =
@@ -180,11 +181,11 @@ function DynamicBridge({
 					try {
 						console.log(
 							'[dynamic] Getting wallet client for chain',
-							BASE_CHAIN_ID,
+							selectedChainId,
 							'auth token present:',
 							!!authToken
 						);
-						cachedWalletClient = await activeWallet.getWalletClient(BASE_CHAIN_ID);
+						cachedWalletClient = await activeWallet.getWalletClient(selectedChainId);
 						console.log('[dynamic] Got wallet client:', cachedWalletClient ? 'success' : 'null');
 					} catch (error) {
 						console.error('[dynamic] Error getting wallet client:', error);
@@ -229,6 +230,12 @@ function DynamicBridge({
 
 					// Handle chain switching - Dynamic manages this internally
 					if (args.method === 'wallet_switchEthereumChain') {
+						const requested = (args.params?.[0] as { chainId?: string } | undefined)?.chainId;
+						if (requested) {
+							selectedChainId = String(Number.parseInt(requested, 16));
+							cachedWalletClient = null;
+							cachedPublicClient = null;
+						}
 						return null;
 					}
 
@@ -296,7 +303,7 @@ function DynamicBridge({
 			// Clear provider when wallet is not available
 			onWalletProviderReadyRef.current(null);
 		}
-	}, [activeWallet]);
+	}, [activeWallet, chainId]);
 
 	// Handle login trigger
 	useEffect(() => {
@@ -376,8 +383,8 @@ function DynamicBridge({
 		if (triggerSendTransaction && activeWallet && isEthereumWallet(activeWallet)) {
 			(async () => {
 				try {
-					// Get wallet client for Base chain
-					const walletClient = await activeWallet.getWalletClient('8453');
+					if (!chainId) throw new Error('No network selected');
+					const walletClient = await activeWallet.getWalletClient(String(chainId));
 					if (!walletClient) {
 						throw new Error('Wallet client not available');
 					}
@@ -401,7 +408,7 @@ function DynamicBridge({
 				}
 			})();
 		}
-	}, [triggerSendTransaction, activeWallet]);
+	}, [triggerSendTransaction, activeWallet, chainId]);
 
 	// This component doesn't render anything visible
 	return null;

--- a/src/lib/dynamic/DynamicReactProvider.tsx
+++ b/src/lib/dynamic/DynamicReactProvider.tsx
@@ -235,8 +235,13 @@ function DynamicBridge({
 							selectedChainId = String(Number.parseInt(requested, 16));
 							cachedWalletClient = null;
 							cachedPublicClient = null;
+							lastWalletClientAttempt = 0;
 						}
 						return null;
+					}
+
+					if (args.method === 'eth_chainId' && selectedChainId) {
+						return `0x${Number(selectedChainId).toString(16)}`;
 					}
 
 					// For transactions, use the wallet client
@@ -271,7 +276,6 @@ function DynamicBridge({
 
 					// For read methods, try the public client first (better RPC support)
 					const readMethods = [
-						'eth_chainId',
 						'eth_blockNumber',
 						'eth_getBalance',
 						'eth_getTransactionCount',

--- a/src/lib/dynamic/DynamicSvelteWrapper.svelte
+++ b/src/lib/dynamic/DynamicSvelteWrapper.svelte
@@ -17,6 +17,7 @@
 		type DynamicSession
 	} from '$lib/stores/dynamicStore';
 	import { setDynamicWalletProvider } from '$lib/services/walletService';
+	import { currentNetwork } from '$lib/stores';
 
 	// Prevent TypeScript warning about unused import (used via react: prefix)
 	used(DynamicReactProvider);
@@ -91,6 +92,7 @@
 		triggerLogout={$dynamicTriggerLogout}
 		triggerExportWallet={$dynamicTriggerExportWallet}
 		triggerSendTransaction={$dynamicTriggerSendTransaction}
+		chainId={$currentNetwork?.chainId}
 	/>
 {:else if browser && !environmentId}
 	<!-- No Dynamic environment ID configured -->

--- a/src/lib/queries/balances.ts
+++ b/src/lib/queries/balances.ts
@@ -10,6 +10,6 @@ import { queryClient } from '$lib/clients/queryClient';
 export function invalidateDashboardBalances() {
 	// Invalidate all balance-related queries
 	queryClient.invalidateQueries({ queryKey: ['walletHoldings'] });
-	queryClient.invalidateQueries({ queryKey: ['usdcWalletBalance'] });
-	queryClient.invalidateQueries({ queryKey: ['ethWalletBalance'] });
+	queryClient.invalidateQueries({ queryKey: ['paymentTokenWalletBalance'] });
+	queryClient.invalidateQueries({ queryKey: ['nativeWalletBalance'] });
 }

--- a/src/lib/queries/balances.ts
+++ b/src/lib/queries/balances.ts
@@ -13,3 +13,12 @@ export function invalidateDashboardBalances() {
 	queryClient.invalidateQueries({ queryKey: ['paymentTokenWalletBalance'] });
 	queryClient.invalidateQueries({ queryKey: ['nativeWalletBalance'] });
 }
+
+/** Refresh balances and trade-derived data after a confirmed market execution. */
+export function invalidateExecutedTradeQueries() {
+	invalidateDashboardBalances();
+	queryClient.invalidateQueries({ queryKey: ['tokenTradeActivity'] });
+	queryClient.invalidateQueries({ queryKey: ['takerTrades'] });
+	queryClient.invalidateQueries({ queryKey: ['batchTrades'] });
+	queryClient.invalidateQueries({ queryKey: ['costBasis'] });
+}

--- a/src/lib/queries/costBasis.ts
+++ b/src/lib/queries/costBasis.ts
@@ -68,7 +68,7 @@ function takerTradeToCostBasis(trade: ApiTradeByAddress, userAddress: string): C
  * Fetch all trades for a user from the REST API (paginated).
  * Combines maker trades (user's orders were filled) and taker trades (user executed market orders).
  */
-async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]> {
+async function fetchAllUserTrades(userAddress: string, chainId: number): Promise<CostBasisTrade[]> {
 	const PAGE_SIZE = 50;
 	const trades: CostBasisTrade[] = [];
 	const seen = new Set<string>();
@@ -77,7 +77,7 @@ async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]
 	let makerPage = 1;
 	let makerHasMore = true;
 	while (makerHasMore) {
-		const response = await apiGetTradesByAddress(userAddress, {
+		const response = await apiGetTradesByAddress(userAddress, chainId, {
 			page: makerPage,
 			pageSize: PAGE_SIZE
 		});
@@ -97,7 +97,7 @@ async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]
 	let takerPage = 1;
 	let takerHasMore = true;
 	while (takerHasMore) {
-		const response = await apiGetTakerTrades(userAddress, {
+		const response = await apiGetTakerTrades(userAddress, chainId, {
 			page: takerPage,
 			pageSize: PAGE_SIZE
 		});
@@ -134,14 +134,14 @@ export function createCostBasisQuery(network: Network | null, userAddress: strin
 			}
 
 			// Fetch all trades for the user via REST API
-			const trades = await fetchAllUserTrades(userAddress);
+			const trades = await fetchAllUserTrades(userAddress, network.chainId);
 
 			// Get payment token addresses for this network
 			const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[network.chainId] ?? [];
 			const paymentTokenAddresses = new Set(paymentTokens.map((t) => t.address.toLowerCase()));
 
 			// Calculate cost basis for all traded tokens
-			return calculateAllCostBases(trades, paymentTokenAddresses, userAddress);
+			return calculateAllCostBases(trades, paymentTokenAddresses, userAddress, network.chainId);
 		}
 	});
 }

--- a/src/lib/queries/costBasis.ts
+++ b/src/lib/queries/costBasis.ts
@@ -125,9 +125,8 @@ export function createCostBasisQuery(network: Network | null, userAddress: strin
 	return createQuery<Map<string, CostBasisData>>({
 		queryKey: ['costBasis', network?.id, userAddress],
 		enabled: Boolean(network && userAddress),
-		staleTime: 600_000, // 10 minutes - only refetch when stale
+		staleTime: Infinity,
 		refetchInterval: false, // No polling - fetch once on mount
-		refetchOnWindowFocus: true, // Refresh when user returns to tab (only if stale)
 		queryFn: async () => {
 			if (!network || !userAddress) {
 				return new Map();

--- a/src/lib/queries/exchangeRates.ts
+++ b/src/lib/queries/exchangeRates.ts
@@ -170,8 +170,8 @@ export function createExchangeRatesQuery(chainId: number | null | undefined) {
 	return createQuery<ExchangeRateLookup>({
 		queryKey: ['exchangeRates', chainId],
 		enabled: browser && Boolean(chainId),
-		staleTime: 60_000,
-		refetchOnWindowFocus: true,
+		staleTime: Infinity,
+		refetchInterval: 60_000,
 		queryFn: async () => {
 			if (!chainId) throw new Error('chainId is required');
 			const [apiTokens, wrapRatios] = await Promise.all([
@@ -199,7 +199,8 @@ export function createExchangeRateHistoryQuery(
 			options?.pageSize ?? 50
 		],
 		enabled: browser && Boolean(wrappedTokenAddress && chainId),
-		staleTime: 60_000,
+		staleTime: Infinity,
+		refetchInterval: 60_000,
 		retry: false,
 		queryFn: async () => {
 			if (!wrappedTokenAddress || !chainId) {

--- a/src/lib/queries/exchangeRates.ts
+++ b/src/lib/queries/exchangeRates.ts
@@ -2,7 +2,7 @@
  * Wrap-ratio (exchange-rate) data source.
  *
  * The REST API returns wrap-ratio rows with share/asset addresses. The website
- * composes display metadata from /v1/tokens so existing UI surfaces can keep
+ * composes display metadata from /v2/tokens so existing UI surfaces can keep
  * working with token refs instead of doing local chain/indexer reads.
  */
 import { browser } from '$app/environment';
@@ -17,8 +17,6 @@ import {
 import type { CategorizedToken } from '$lib/config/tokens';
 import { findApiTokenByAnyAddress, normalizeApiTokensForNetwork } from '$lib/queries/tokens';
 import { createQuery } from '@tanstack/svelte-query';
-
-const BASE_CHAIN_ID = 8453;
 
 export interface TokenRef {
 	address: string;
@@ -168,14 +166,18 @@ function warnWrapRatioErrors(response: ApiWrapRatiosResponse): void {
 	}
 }
 
-export function createExchangeRatesQuery(chainId: number = BASE_CHAIN_ID) {
+export function createExchangeRatesQuery(chainId: number | null | undefined) {
 	return createQuery<ExchangeRateLookup>({
 		queryKey: ['exchangeRates', chainId],
-		enabled: browser,
+		enabled: browser && Boolean(chainId),
 		staleTime: 60_000,
 		refetchOnWindowFocus: true,
 		queryFn: async () => {
-			const [apiTokens, wrapRatios] = await Promise.all([apiGetTokens(), apiGetWrapRatios()]);
+			if (!chainId) throw new Error('chainId is required');
+			const [apiTokens, wrapRatios] = await Promise.all([
+				apiGetTokens(chainId),
+				apiGetWrapRatios(chainId)
+			]);
 			warnWrapRatioErrors(wrapRatios);
 			const tokens = normalizeApiTokensForNetwork(apiTokens, chainId);
 			return buildLookup(wrapRatios.data.map((row) => mapApiWrapRatio(row, tokens)));
@@ -185,8 +187,8 @@ export function createExchangeRatesQuery(chainId: number = BASE_CHAIN_ID) {
 
 export function createExchangeRateHistoryQuery(
 	wrappedTokenAddress: string | null | undefined,
-	options?: { page?: number; pageSize?: number },
-	chainId: number = BASE_CHAIN_ID
+	chainId: number | null | undefined,
+	options?: { page?: number; pageSize?: number }
 ) {
 	return createQuery<ExchangeRateHistoryResponse>({
 		queryKey: [
@@ -196,16 +198,16 @@ export function createExchangeRateHistoryQuery(
 			options?.page ?? 1,
 			options?.pageSize ?? 50
 		],
-		enabled: browser && Boolean(wrappedTokenAddress),
+		enabled: browser && Boolean(wrappedTokenAddress && chainId),
 		staleTime: 60_000,
 		retry: false,
 		queryFn: async () => {
-			if (!wrappedTokenAddress) {
-				throw new Error('wrappedTokenAddress is required');
+			if (!wrappedTokenAddress || !chainId) {
+				throw new Error('wrappedTokenAddress and chainId are required');
 			}
 			const [apiTokens, history] = await Promise.all([
-				apiGetTokens(),
-				apiGetWrapRatioHistory(wrappedTokenAddress, options)
+				apiGetTokens(chainId),
+				apiGetWrapRatioHistory(wrappedTokenAddress, chainId, options)
 			]);
 			const tokens = normalizeApiTokensForNetwork(apiTokens, chainId);
 			return mapApiWrapRatioHistory(history, tokens);

--- a/src/lib/queries/tokens.ts
+++ b/src/lib/queries/tokens.ts
@@ -2,13 +2,25 @@ import { browser } from '$app/environment';
 import { createQuery } from '@tanstack/svelte-query';
 import { apiGetTokens, type ApiToken } from '$lib/api/st0xApi';
 import { isRateLimitError } from '$lib/clients/http';
-import type { CategorizedToken, TokenCategory } from '$lib/config/tokens';
+import {
+	CRYPTO_TOKENS,
+	TOKENS,
+	replaceTokenCatalog,
+	type CategorizedToken,
+	type TokenCategory
+} from '$lib/config/tokens';
 
 type ApiTokenExtensions = {
 	category?: unknown;
 	unwrappedAddress?: unknown;
 	legacyAddress?: unknown;
 	legacySymbol?: unknown;
+	previousSymbols?: unknown;
+	receiptAddress?: unknown;
+	priceFeedId?: unknown;
+	fallbackPrice?: unknown;
+	paymentToken?: unknown;
+	migrationOrderHash?: unknown;
 	tradingViewSymbol?: unknown;
 	tradingViewMarket?: unknown;
 };
@@ -19,6 +31,15 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function asString(value: unknown): string | undefined {
 	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return undefined;
+	return value;
 }
 
 function getApiChainId(token: ApiToken): number | null {
@@ -39,6 +60,7 @@ function getApiCategory(token: ApiToken): TokenCategory | null {
 
 function normalizeApiToken(token: ApiToken): CategorizedToken | null {
 	const chainId = getApiChainId(token);
+	const network = asRecord(token.network);
 	const category = getApiCategory(token);
 	if (
 		!chainId ||
@@ -54,17 +76,31 @@ function normalizeApiToken(token: ApiToken): CategorizedToken | null {
 
 	return {
 		chainId,
+		network: {
+			chainId,
+			key: asString(network?.key),
+			label: asString(network?.label),
+			networkId: asNumber(network?.networkId),
+			currency: asString(network?.currency)
+		},
 		address: token.address,
 		symbol: token.symbol,
 		decimals: token.decimals,
 		name: token.name ?? token.label ?? token.symbol,
 		logoUrl: asString(token['logo-uri']),
+		priceFeedId: asString(extensions.priceFeedId) ?? '',
+		fallbackPrice: asNumber(extensions.fallbackPrice),
+		paymentToken: extensions.paymentToken === true,
+		migrationOrderHash: asString(extensions.migrationOrderHash),
 		category,
 		tradingViewSymbol: asString(extensions.tradingViewSymbol),
 		tradingViewMarket: asString(extensions.tradingViewMarket),
 		unwrappedAddress: asString(extensions.unwrappedAddress),
 		legacyAddress: asString(extensions.legacyAddress),
 		legacySymbol: asString(extensions.legacySymbol),
+		previousSymbols: asStringArray(extensions.previousSymbols),
+		receiptAddress: asString(extensions.receiptAddress),
+		isin: asString(token.isin) ?? asString(asRecord(token.extensions)?.isin),
 		limitOrders: []
 	};
 }
@@ -73,14 +109,18 @@ export function normalizeApiTokensForNetwork(
 	apiTokens: ApiToken[],
 	chainId: number
 ): CategorizedToken[] {
+	return normalizeApiTokens(apiTokens).filter((token) => token.chainId === chainId);
+}
+
+export function normalizeApiTokens(apiTokens: ApiToken[]): CategorizedToken[] {
 	const seen = new Set<string>();
 	const result: CategorizedToken[] = [];
 
 	for (const apiToken of apiTokens) {
 		const normalized = normalizeApiToken(apiToken);
-		if (!normalized || normalized.chainId !== chainId) continue;
+		if (!normalized) continue;
 
-		const addressKey = normalized.address.toLowerCase();
+		const addressKey = `${normalized.chainId}:${normalized.address.toLowerCase()}`;
 		if (seen.has(addressKey)) continue;
 		seen.add(addressKey);
 		result.push(normalized);
@@ -113,11 +153,19 @@ export function createApiTokensQuery(chainId: number | null | undefined) {
 		enabled: Boolean(browser && chainId),
 		// The supported-token list is effectively static config; it does not need to be
 		// re-fetched on every mount/focus. Aggressive refetch here (staleTime:0 +
-		// refetchOnMount:'always' + refetchOnWindowFocus) fired /v1/tokens from ~9 mount
+		// refetchOnMount:'always' + refetchOnWindowFocus) fired /v2/tokens from ~9 mount
 		// sites and contributed to the upstream rate-limit storm.
 		staleTime: 5 * 60_000, // 5 minutes
 		retry: (failureCount, error) => !isRateLimitError(error) && failureCount < 2,
 		refetchOnWindowFocus: false,
-		queryFn: async () => normalizeApiTokensForNetwork(await apiGetTokens(), chainId as number)
+		queryFn: async () => {
+			if (!chainId) return [];
+			const catalog = normalizeApiTokens(await apiGetTokens(chainId));
+			const otherNetworks = [...TOKENS, ...CRYPTO_TOKENS].filter(
+				(token) => token.chainId !== chainId
+			);
+			replaceTokenCatalog([...otherNetworks, ...catalog]);
+			return catalog;
+		}
 	});
 }

--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -25,7 +25,7 @@ export function createTokenTradeActivityQuery(
 	// Resolve to wrapped (primary) address — the SFT subgraph returns the unwrapped
 	// vault address, but trades are indexed by the wrapped ERC20 token address.
 	const primaryAddress = tokenAddress
-		? (getTokenByAnyAddress(tokenAddress)?.address ?? tokenAddress).toLowerCase()
+		? (getTokenByAnyAddress(tokenAddress, network?.chainId)?.address ?? tokenAddress).toLowerCase()
 		: null;
 
 	return createQuery<TokenTradeActivityPayload>({
@@ -48,7 +48,14 @@ export function createTokenTradeActivityQuery(
 			let page = 1;
 
 			while (page <= 50) {
-				const response = await apiGetTradesByToken(primaryAddress!, page, PAGE_SIZE, from, now);
+				const response = await apiGetTradesByToken(
+					primaryAddress!,
+					network!.chainId,
+					page,
+					PAGE_SIZE,
+					from,
+					now
+				);
 				// `?? []` because the upstream REST API occasionally omits `trades`
 				// on a paginated response; `[].concat(undefined)` returns
 				// `[undefined]`, which then poisons every downstream consumer.
@@ -83,7 +90,7 @@ export function createBatchTradesQuery(
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
 		queryFn: async () => {
-			const response = await apiGetTradesBatch(orderHashes);
+			const response = await apiGetTradesBatch(orderHashes, network!.chainId);
 			const map = new Map<string, ApiTradeByAddress[]>();
 			for (const entry of response.tradesByOrderHash) {
 				map.set(entry.orderHash.toLowerCase(), entry.trades);
@@ -114,7 +121,10 @@ export function createTakerTradesQuery(
 			let page = 1;
 
 			while (page <= 10) {
-				const response = await apiGetTakerTrades(walletAddress!, { page, pageSize: PAGE_SIZE });
+				const response = await apiGetTakerTrades(walletAddress!, network!.chainId, {
+					page,
+					pageSize: PAGE_SIZE
+				});
 				allTrades = allTrades.concat(response.trades ?? []);
 				if (!response.pagination.hasMore) break;
 				page++;

--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -31,7 +31,7 @@ export function createTokenTradeActivityQuery(
 	return createQuery<TokenTradeActivityPayload>({
 		queryKey: ['tokenTradeActivity', network?.id, tokenAddress],
 		enabled: Boolean(network && primaryAddress),
-		staleTime: 600_000,
+		staleTime: Infinity,
 		refetchInterval: pollInterval,
 		// Don't retry on 429 — the next poll is the retry. Retrying here just piles more
 		// load onto an already-throttling upstream.
@@ -87,7 +87,7 @@ export function createBatchTradesQuery(
 	return createQuery<Map<string, ApiTradeByAddress[]>>({
 		queryKey: ['batchTrades', network?.id, sortedKey],
 		enabled: Boolean(network && orderHashes.length > 0),
-		staleTime: 600_000,
+		staleTime: Infinity,
 		refetchInterval: pollInterval,
 		queryFn: async () => {
 			const response = await apiGetTradesBatch(orderHashes, network!.chainId);
@@ -112,7 +112,7 @@ export function createTakerTradesQuery(
 	return createQuery<TakerTradesPayload>({
 		queryKey: ['takerTrades', network?.id, walletAddress],
 		enabled: Boolean(network && walletAddress),
-		staleTime: 600_000,
+		staleTime: Infinity,
 		refetchInterval: pollInterval,
 		retry: 2,
 		queryFn: async () => {

--- a/src/lib/queries/vaults.ts
+++ b/src/lib/queries/vaults.ts
@@ -128,9 +128,8 @@ export function createSingleSftQuery(
 	return createQuery<OffchainAssetReceiptVault | null>({
 		queryKey: ['sft', network?.id, tokenId],
 		enabled: Boolean(browser && network && tokenId),
-		staleTime: 30_000,
+		staleTime: Infinity,
 		refetchInterval: false,
-		refetchOnWindowFocus: true, // Only refetch on focus if stale
 		initialData: getCachedToken() ?? undefined,
 		initialDataUpdatedAt: getCachedTimestamp(),
 		queryFn: async () => {

--- a/src/lib/queries/vaults.ts
+++ b/src/lib/queries/vaults.ts
@@ -81,12 +81,13 @@ export function createSftsQuery(network: Network | null) {
 		staleTime: Infinity,
 		refetchInterval: false,
 		queryFn: async () => {
-			const response = await apiGetTokenDetails();
+			if (!network) return [];
+			const response = await apiGetTokenDetails(network.chainId);
 			if (response.errors.length) {
 				console.warn('Some token details failed to load', response.errors);
 			}
 			return response.data.map((summary) =>
-				tokenDetailsSummaryToVault(summary, undefined, network?.chainId)
+				tokenDetailsSummaryToVault(summary, undefined, network.chainId)
 			);
 		}
 	});
@@ -134,7 +135,9 @@ export function createSingleSftQuery(
 		initialDataUpdatedAt: getCachedTimestamp(),
 		queryFn: async () => {
 			if (!network || !tokenId) return null;
-			const detail = await apiGetTokenDetailsByAddress(tokenId, { activityLimit: 5 });
+			const detail = await apiGetTokenDetailsByAddress(tokenId, network.chainId, {
+				activityLimit: 5
+			});
 			return tokenDetailsSummaryToVault(detail, detail, network.chainId);
 		}
 	});

--- a/src/lib/seo/trade.ts
+++ b/src/lib/seo/trade.ts
@@ -14,7 +14,7 @@ export function buildTradeTitle(displayName: string): string {
 }
 
 export function buildTradeDescription(displayName: string): string {
-	return `Trade ${displayName} 24/7 on ST0x with on-chain execution and non-custodial settlement on Base.`;
+	return `Trade ${displayName} 24/7 on ST0x with on-chain execution and non-custodial settlement on supported networks.`;
 }
 
 export function getTradeSeoMetadata(pathname: string): TradeSeoMetadata | null {

--- a/src/lib/server/accessCodes.ts
+++ b/src/lib/server/accessCodes.ts
@@ -1,8 +1,5 @@
-import { createPublicClient, fallback, http } from 'viem';
-import { base } from 'viem/chains';
-import { env } from '$env/dynamic/private';
-import { dev } from '$app/environment';
-import { networks } from '$lib/config/networks';
+import { createPublicClient, defineChain, fallback, http } from 'viem';
+import type { Network } from '$lib/config/networks';
 import { recordRpcAttempt, reportChainExhausted } from '$lib/server/rpcMetrics';
 
 // SEC-01 / Phase 3 D-02: Same Alchemy key on both sides per D-02 (single key, single
@@ -11,20 +8,6 @@ import { recordRpcAttempt, reportChainExhausted } from '$lib/server/rpcMetrics';
 // (single source of truth in networks.ts). D-02b: module-load throw mirrors the
 // CRON_SECRET pattern at src/routes/api/cron/snapshots/+server.ts:45 — fires at cold
 // start in production, surfaces in Vercel Logs immediately rather than at first request.
-const PRIMARY_RPC_URL = env.BASE_RPC_URL;
-if (!dev && !PRIMARY_RPC_URL) {
-	throw new Error('[accessCodes] BASE_RPC_URL required in production');
-}
-
-// REL-02 / Plan 03-07: viem fallback Transport — same RPC_URLS shape as generator.ts:14.
-// PRIMARY_RPC_URL is prepended only when set (production); in dev we fall through to
-// networks[0].fallbackRpcUrls (which already starts with https://base-rpc.publicnode.com,
-// the prior dev fallback URL).
-const RPC_URLS = (PRIMARY_RPC_URL ? [PRIMARY_RPC_URL] : []).concat(networks[0].fallbackRpcUrls);
-
-// Create a public client for Base network for signature verification.
-// Supports ECDSA (EOA), EIP-1271 (Smart Contracts), and EIP-6492 (Undeployed).
-//
 // RESEARCH Pattern 3 + Pitfall 7 (multiplicative-retry trap): viem's fallback transport
 // already retries each underlying http() transport `retryCount` times with `retryDelay`
 // backoff before falling through to the next URL — do NOT add an outer retry wrapper
@@ -32,19 +15,11 @@ const RPC_URLS = (PRIMARY_RPC_URL ? [PRIMARY_RPC_URL] : []).concat(networks[0].f
 // primitive, e.g. generator.ts:callRpc). `rank: false` keeps deterministic ordering
 // (primary first); per-RPC ranking would reorder by latency, which is incompatible
 // with our preference for the paid Alchemy endpoint as the first attempt.
-const basePublicClient = createPublicClient({
-	chain: base,
-	transport: fallback(
-		RPC_URLS.map((url) => http(url)),
-		{ retryCount: 2, retryDelay: 200, rank: false }
-	)
-});
-
 // Verify a wallet signature for session login.
 // Supports: ECDSA (EOA), EIP-1271 (Smart Contract Wallets), EIP-6492 (Undeployed Counterfactual)
 //
 // OBS-04 instrumentation (D-09 + Plan 03-07): the `rpc_url` label is the synthetic
-// stable identifier `'fallback-chain-base'` — single per-call instrumentation per
+// stable identifier `fallback-chain-{chainId}` — single per-call instrumentation per
 // RESEARCH §"Pattern 3" + Open Question 4. viem's fallback transport handles the
 // per-transport retry / fall-through internally; per-RPC granularity in OBS-04 logs
 // is deferred to Phase 4 (custom wrapped Transport with per-attempt instrumentation).
@@ -56,21 +31,39 @@ const basePublicClient = createPublicClient({
 export async function verifyWalletSignature(
 	address: string,
 	message: string,
-	signature: `0x${string}`
+	signature: `0x${string}`,
+	network: Network
 ): Promise<boolean> {
+	const metricChain = `fallback-chain-${network.chainId}`;
+	const client = createPublicClient({
+		chain: defineChain({
+			id: network.chainId,
+			name: network.displayName,
+			nativeCurrency: {
+				name: network.currencySymbol,
+				symbol: network.currencySymbol,
+				decimals: 18
+			},
+			rpcUrls: { default: { http: [network.rpcUrl, ...network.fallbackRpcUrls] } }
+		}),
+		transport: fallback(
+			[network.rpcUrl, ...network.fallbackRpcUrls].map((url) => http(url)),
+			{ retryCount: 2, retryDelay: 200, rank: false }
+		)
+	});
 	const start = Date.now();
 	try {
 		// viem's publicClient.verifyMessage handles all signature types:
 		// - ECDSA for EOA wallets
 		// - EIP-1271 for deployed smart contract wallets (Safe, AA wallets)
 		// - EIP-6492 for undeployed counterfactual wallets
-		const valid = await basePublicClient.verifyMessage({
+		const valid = await client.verifyMessage({
 			address: address as `0x${string}`,
 			message,
 			signature
 		});
 		recordRpcAttempt({
-			rpc_url: 'fallback-chain-base',
+			rpc_url: metricChain,
 			fn: 'verifyWalletSignature',
 			ok: true,
 			status_or_error: valid ? 'verified' : 'mismatch',
@@ -80,7 +73,7 @@ export async function verifyWalletSignature(
 	} catch (error) {
 		const status_or_error = error instanceof Error ? error.message : 'Unknown verification error';
 		recordRpcAttempt({
-			rpc_url: 'fallback-chain-base',
+			rpc_url: metricChain,
 			fn: 'verifyWalletSignature',
 			ok: false,
 			status_or_error,
@@ -90,7 +83,7 @@ export async function verifyWalletSignature(
 		// times). Surface a chain-exhausted event for OBS-04 alerting.
 		await reportChainExhausted({
 			fn: 'verifyWalletSignature',
-			attempts: [{ rpc_url: 'fallback-chain-base', status_or_error }]
+			attempts: [{ rpc_url: metricChain, status_or_error }]
 		});
 		console.error('[accessCodes] Signature verification failed:', {
 			message: status_or_error

--- a/src/lib/server/applicationCatalog.ts
+++ b/src/lib/server/applicationCatalog.ts
@@ -1,0 +1,81 @@
+import { env } from '$env/dynamic/private';
+import {
+	buildNetworkCatalogFromRegistry,
+	replaceNetworkCatalog,
+	type Network
+} from '$lib/config/networks';
+import { getServerTokenCatalog } from '$lib/server/tokenCatalog';
+
+const CACHE_TTL_MS = 60_000;
+const REGISTRY_REPOSITORY_RAW_URL =
+	'https://raw.githubusercontent.com/ST0x-Technology/st0x.registry';
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+type RegistryMetadata = { source_commit?: unknown };
+
+let cachedNetworks: Network[] = [];
+let cacheExpiresAt = 0;
+let inFlight: Promise<Network[]> | null = null;
+
+function apiConfig(): { url: string; authorization: string } {
+	const url = env.ST0X_API_URL?.replace(/\/+$/, '');
+	const key = env.ST0X_API_KEY;
+	const secret = env.ST0X_API_SECRET;
+	if (!url || !key || !secret) throw new Error('ST0X REST API registry is not configured');
+	return { url, authorization: `Basic ${btoa(`${key}:${secret}`)}` };
+}
+
+async function fetchNetworkCatalog(): Promise<Network[]> {
+	const [tokens, config] = await Promise.all([
+		getServerTokenCatalog(),
+		Promise.resolve(apiConfig())
+	]);
+	const metadataResponse = await fetch(`${config.url}/registry`, {
+		headers: { Accept: 'application/json', Authorization: config.authorization },
+		cache: 'no-store'
+	});
+	if (!metadataResponse.ok) {
+		throw new Error(`Registry metadata request failed with HTTP ${metadataResponse.status}`);
+	}
+	const metadata = (await metadataResponse.json()) as RegistryMetadata;
+	const commit = metadata.source_commit;
+	if (typeof commit !== 'string' || !COMMIT_SHA_PATTERN.test(commit)) {
+		throw new Error('REST API registry metadata has no valid source commit');
+	}
+
+	const registryUrl = `${REGISTRY_REPOSITORY_RAW_URL}/${commit}/registry`;
+	const catalog = await buildNetworkCatalogFromRegistry(registryUrl, tokens);
+	replaceNetworkCatalog(catalog);
+	cachedNetworks = catalog;
+	cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+	return catalog;
+}
+
+export async function getServerNetworkCatalog(): Promise<Network[]> {
+	if (cachedNetworks.length > 0 && Date.now() < cacheExpiresAt) return cachedNetworks;
+	if (!inFlight) {
+		inFlight = fetchNetworkCatalog()
+			.catch((error) => {
+				if (cachedNetworks.length === 0) throw error;
+				console.warn('[network-catalog] Refresh failed; serving stale catalog:', error);
+				cacheExpiresAt = Date.now() + 10_000;
+				return cachedNetworks;
+			})
+			.finally(() => {
+				inFlight = null;
+			});
+	}
+	return inFlight;
+}
+
+export async function getServerApplicationCatalog() {
+	const [tokenCatalog, networkCatalog] = await Promise.all([
+		getServerTokenCatalog(),
+		getServerNetworkCatalog()
+	]);
+	return { tokenCatalog, networkCatalog };
+}
+
+export async function ensureServerApplicationCatalog(): Promise<void> {
+	await getServerApplicationCatalog();
+}

--- a/src/lib/server/applicationCatalog.ts
+++ b/src/lib/server/applicationCatalog.ts
@@ -5,6 +5,7 @@ import {
 	type Network
 } from '$lib/config/networks';
 import { getServerTokenCatalog } from '$lib/server/tokenCatalog';
+import { getSt0xGeneralApiConfig } from '$lib/server/st0xApiConfig';
 
 const CACHE_TTL_MS = 60_000;
 const REGISTRY_REPOSITORY_RAW_URL =
@@ -17,23 +18,22 @@ let cachedNetworks: Network[] = [];
 let cacheExpiresAt = 0;
 let inFlight: Promise<Network[]> | null = null;
 
-function apiConfig(): { url: string; authorization: string } {
-	const url = env.ST0X_API_URL?.replace(/\/+$/, '');
-	const key = env.ST0X_API_KEY;
-	const secret = env.ST0X_API_SECRET;
-	if (!url || !key || !secret) throw new Error('ST0X REST API registry is not configured');
-	return { url, authorization: `Basic ${btoa(`${key}:${secret}`)}` };
+function apiConfig() {
+	const config = getSt0xGeneralApiConfig(env);
+	if (!config) throw new Error('ST0X REST API registry is not configured');
+	return config;
 }
 
 async function fetchNetworkCatalog(): Promise<Network[]> {
-	const [tokens, config] = await Promise.all([
+	const config = apiConfig();
+	const [tokens, metadataResponse] = await Promise.all([
 		getServerTokenCatalog(),
-		Promise.resolve(apiConfig())
+		fetch(`${config.apiBase}/registry`, {
+			headers: { Accept: 'application/json', Authorization: config.authHeader },
+			cache: 'no-store',
+			signal: AbortSignal.timeout(10_000)
+		})
 	]);
-	const metadataResponse = await fetch(`${config.url}/registry`, {
-		headers: { Accept: 'application/json', Authorization: config.authorization },
-		cache: 'no-store'
-	});
 	if (!metadataResponse.ok) {
 		throw new Error(`Registry metadata request failed with HTTP ${metadataResponse.status}`);
 	}

--- a/src/lib/server/kv.ts
+++ b/src/lib/server/kv.ts
@@ -102,6 +102,8 @@ export const KV_KEYS = {
 
 // Types for snapshot block records
 export interface SnapshotBlockRecord {
+	/** Absent only on records created before multichain snapshot support. */
+	chainId?: number;
 	blockNumber: number;
 	timestamp: number;
 	date: string; // YYYY-MM-DD

--- a/src/lib/server/marketPrices.test.ts
+++ b/src/lib/server/marketPrices.test.ts
@@ -84,7 +84,7 @@ describe('fetchMarketPrices', () => {
 		]);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(fetchMock.mock.calls[0][0]).toBe(
-			'https://api.example.test/v1/prices?chainId=8453&at=1784800000'
+			'https://api.example.test/v2/prices?chainId=8453&at=1784800000'
 		);
 	});
 

--- a/src/lib/server/marketPrices.ts
+++ b/src/lib/server/marketPrices.ts
@@ -37,7 +37,7 @@ export async function fetchMarketPrices(
 	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 		let response: Response;
 		try {
-			response = await fetch(`${apiBase}/v1/prices?${params}`, {
+			response = await fetch(`${apiBase}/v2/prices?${params}`, {
 				headers: { Authorization: authHeader, Accept: 'application/json' },
 				signal: AbortSignal.timeout(options?.timeoutMs ?? 10_000)
 			});
@@ -48,7 +48,7 @@ export async function fetchMarketPrices(
 			}
 			continue;
 		}
-		logSt0xRequestBudget('v1/prices', credentialLabel, response);
+		logSt0xRequestBudget('v2/prices', credentialLabel, response);
 		if (response.ok) {
 			const body = (await response.json()) as ApiMarketPricesResponse;
 			return body.data;

--- a/src/lib/server/publicTradeActivity.test.ts
+++ b/src/lib/server/publicTradeActivity.test.ts
@@ -24,6 +24,7 @@ function trade(
 	outputAmount: string
 ): ApiTradeByAddress {
 	return {
+		chainId: 8453,
 		txHash,
 		inputAmount,
 		outputAmount,

--- a/src/lib/server/snapshots/generator.test.ts
+++ b/src/lib/server/snapshots/generator.test.ts
@@ -18,6 +18,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiMarketPrice } from '$lib/api/st0xApi';
 
+const TEST_NETWORK = {
+	chainId: 8453,
+	rpcUrl: 'https://rpc-primary.example/key',
+	fallbackRpcUrls: ['https://rpc-fallback-1.example', 'https://rpc-fallback-2.example']
+} as never;
+
 const { mockRecordRpcAttempt, mockReportChainExhausted, mockFetchMarketPrices } = vi.hoisted(
 	() => ({
 		mockRecordRpcAttempt: vi.fn(),
@@ -53,6 +59,10 @@ vi.mock('$lib/config/tokens', () => ({
 
 vi.mock('$lib/server/kv', () => ({
 	getRewardsExcludedWalletsSet: vi.fn(async () => new Set<string>())
+}));
+
+vi.mock('$lib/server/tokenCatalog', () => ({
+	ensureServerTokenCatalog: vi.fn(async () => undefined)
 }));
 
 vi.mock('./scraper', () => ({
@@ -97,7 +107,7 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 			jsonResponse({ result: '0xdeadbeef' })
 		);
 		const { callRpc } = await import('./generator');
-		const result = await callRpc('eth_blockNumber', []);
+		const result = await callRpc(TEST_NETWORK, 'eth_blockNumber', []);
 		expect(result).toBe('0xdeadbeef');
 		expect(mockRecordRpcAttempt).toHaveBeenCalledTimes(1);
 		expect(mockRecordRpcAttempt).toHaveBeenCalledWith(
@@ -112,7 +122,7 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 			.mockRejectedValueOnce(new Error('header not found'))
 			.mockResolvedValueOnce(jsonResponse({ result: '0xabc' }));
 		const { callRpc } = await import('./generator');
-		const result = await callRpc('eth_blockNumber', []);
+		const result = await callRpc(TEST_NETWORK, 'eth_blockNumber', []);
 		expect(result).toBe('0xabc');
 		// fetch called twice = 1 retry inside RPC #1, no fall-through to RPC #2
 		expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -133,7 +143,9 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 	it('Test 3: throws when all RPCs × all retries fail; reportChainExhausted fires once', async () => {
 		(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('header not found'));
 		const { callRpc } = await import('./generator');
-		await expect(callRpc('eth_blockNumber', [])).rejects.toThrow(/all .* RPCs exhausted/);
+		await expect(callRpc(TEST_NETWORK, 'eth_blockNumber', [])).rejects.toThrow(
+			/all .* RPCs exhausted/
+		);
 		// 3 RPCs × 1 outer record per RPC = 3 recordRpcAttempt calls (all failures)
 		expect(mockRecordRpcAttempt).toHaveBeenCalledTimes(3);
 		expect(
@@ -151,7 +163,9 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 	it('Test 4: empty result throws inside fetchOnce → retry → fall-through → exhaustion throws', async () => {
 		(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(jsonResponse({ result: null }));
 		const { callRpc } = await import('./generator');
-		await expect(callRpc('eth_blockNumber', [])).rejects.toThrow(/all .* RPCs exhausted/);
+		await expect(callRpc(TEST_NETWORK, 'eth_blockNumber', [])).rejects.toThrow(
+			/all .* RPCs exhausted/
+		);
 		expect(mockReportChainExhausted).toHaveBeenCalledTimes(1);
 		// Every per-RPC outcome was a failure
 		expect(mockRecordRpcAttempt).toHaveBeenCalledTimes(3);
@@ -182,7 +196,7 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 			throw new Error('header not found');
 		});
 		const { getBlockNumberForTimestamp } = await import('./generator');
-		await expect(getBlockNumberForTimestamp(1_700_000_000)).rejects.toThrow(
+		await expect(getBlockNumberForTimestamp(TEST_NETWORK, 1_700_000_000)).rejects.toThrow(
 			/no block lookup succeeded/
 		);
 	});
@@ -223,7 +237,7 @@ describe('REL-01 callRpc + getBlockNumberForTimestamp', () => {
 		});
 		const { getBlockNumberForTimestamp } = await import('./generator');
 		// Must reject — not resolve to a number (which would indicate a swallow regression).
-		const promise = getBlockNumberForTimestamp(1_700_000_000);
+		const promise = getBlockNumberForTimestamp(TEST_NETWORK, 1_700_000_000);
 		await expect(promise).rejects.toBeInstanceOf(Error);
 		await expect(promise).rejects.toThrow(/no block lookup succeeded/);
 	});
@@ -247,7 +261,7 @@ describe('snapshot market prices', () => {
 		]);
 		const { fetchSnapshotPrices } = await import('./generator');
 
-		const prices = await fetchSnapshotPrices(1_784_800_000);
+		const prices = await fetchSnapshotPrices(TEST_NETWORK, 1_784_800_000);
 
 		expect(mockFetchMarketPrices).toHaveBeenCalledWith(8453, { at: 1_784_800_000 });
 		expect(prices.get('0xabcd')?.midpoint).toBe('100');

--- a/src/lib/server/snapshots/generator.ts
+++ b/src/lib/server/snapshots/generator.ts
@@ -8,7 +8,7 @@ import { fetchAllVaultHoldings } from './vaults';
 import { fetchMarketPrices } from '$lib/server/marketPrices';
 import { getRewardsExcludedWalletsSet } from '$lib/server/kv';
 import type { Network } from '$lib/config/networks';
-import { TOKENS, getTokenAddressVariants, getTokenByAnyAddress } from '$lib/config/tokens';
+import { getTokenAddressVariants, getTokenByAnyAddress } from '$lib/config/tokens';
 import { recordRpcAttempt, reportChainExhausted } from '$lib/server/rpcMetrics';
 import { withRetry } from '$lib/utils/retry';
 import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
@@ -264,8 +264,10 @@ export async function generateAllTokenSnapshots(
 	network: Network,
 	blockNumber: number
 ): Promise<BlockSnapshot[]> {
-	await getServerApplicationCatalog();
-	const chainTokens = TOKENS.filter((token) => token.chainId === network.chainId);
+	const { tokenCatalog } = await getServerApplicationCatalog();
+	const chainTokens = tokenCatalog.filter(
+		(token) => token.category === 'ST0x' && token.chainId === network.chainId
+	);
 	const allTokenAddresses = chainTokens.flatMap((token) => getTokenAddressVariants(token));
 	// Get block timestamp first (needed for retained price lookup)
 	const timestamp = await getBlockTimestamp(network, blockNumber);

--- a/src/lib/server/snapshots/generator.ts
+++ b/src/lib/server/snapshots/generator.ts
@@ -2,22 +2,22 @@
 // Single source of truth for generating snapshots - used by both preview and cron
 
 import type { BlockSnapshot } from './types';
-import { fetchAllTransfers, ALL_TOKEN_ADDRESSES } from './scraper';
+import { fetchAllTransfers } from './scraper';
 import { generateSnapshot } from './processor';
 import { fetchAllVaultHoldings } from './vaults';
 import { fetchMarketPrices } from '$lib/server/marketPrices';
 import { getRewardsExcludedWalletsSet } from '$lib/server/kv';
-import { networks } from '$lib/config/networks';
+import type { Network } from '$lib/config/networks';
 import { TOKENS, getTokenAddressVariants, getTokenByAnyAddress } from '$lib/config/tokens';
 import { recordRpcAttempt, reportChainExhausted } from '$lib/server/rpcMetrics';
 import { withRetry } from '$lib/utils/retry';
-
-const RPC_URLS = [networks[0].rpcUrl, ...networks[0].fallbackRpcUrls];
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 export async function fetchSnapshotPrices(
+	network: Network,
 	timestamp: number
 ): Promise<Map<string, Awaited<ReturnType<typeof fetchMarketPrices>>[number]>> {
-	const prices = await fetchMarketPrices(networks[0].chainId, { at: timestamp });
+	const prices = await fetchMarketPrices(network.chainId, { at: timestamp });
 	return new Map(prices.map((price) => [price.assetAddress.toLowerCase(), price]));
 }
 
@@ -77,9 +77,14 @@ export async function fetchOnce(
  * via dashboard latency; only the per-RPC summary line is needed for OBS-04
  * volume budgeting.
  */
-export async function callRpc(method: string, params: unknown[]): Promise<unknown> {
+export async function callRpc(
+	network: Network,
+	method: string,
+	params: unknown[]
+): Promise<unknown> {
+	const rpcUrls = [network.rpcUrl, ...network.fallbackRpcUrls];
 	const attempts: Array<{ rpc_url: string; status_or_error: string }> = [];
-	for (const rpcUrl of RPC_URLS) {
+	for (const rpcUrl of rpcUrls) {
 		const start = Date.now();
 		try {
 			const result = await withRetry(() => fetchOnce(rpcUrl, method, params), 2, 200);
@@ -106,19 +111,22 @@ export async function callRpc(method: string, params: unknown[]): Promise<unknow
 	// Chain exhausted — every RPC × every retry failed. Telegram alert path
 	// fires unchanged via Plan 01-06 surface.
 	await reportChainExhausted({ fn: `callRpc:${method}`, attempts });
-	throw new Error(`callRpc(${method}) — all ${RPC_URLS.length} RPCs exhausted (with retry)`);
+	throw new Error(`callRpc(${method}) — all ${rpcUrls.length} RPCs exhausted (with retry)`);
 }
 
-export async function getBlockTimestamp(blockNumber: number): Promise<number> {
-	const result = await callRpc('eth_getBlockByNumber', [`0x${blockNumber.toString(16)}`, false]);
+export async function getBlockTimestamp(network: Network, blockNumber: number): Promise<number> {
+	const result = await callRpc(network, 'eth_getBlockByNumber', [
+		`0x${blockNumber.toString(16)}`,
+		false
+	]);
 	if (result && typeof result === 'object' && 'timestamp' in result) {
 		return parseInt((result as { timestamp: string }).timestamp, 16);
 	}
 	throw new Error('Failed to get block timestamp from any RPC');
 }
 
-export async function getCurrentBlockNumber(): Promise<number> {
-	const result = await callRpc('eth_blockNumber', []);
+export async function getCurrentBlockNumber(network: Network): Promise<number> {
+	const result = await callRpc(network, 'eth_blockNumber', []);
 	if (typeof result === 'string') {
 		return parseInt(result, 16);
 	}
@@ -143,8 +151,11 @@ export async function getCurrentBlockNumber(): Promise<number> {
  * still converge on neighboring blocks. The function-boundary throw fires only
  * when NO probe ever succeeded (smallestDiff still Infinity).
  */
-export async function getBlockNumberForTimestamp(targetTimestamp: number): Promise<number> {
-	const latestBlock = await getCurrentBlockNumber();
+export async function getBlockNumberForTimestamp(
+	network: Network,
+	targetTimestamp: number
+): Promise<number> {
+	const latestBlock = await getCurrentBlockNumber(network);
 
 	let left = 0;
 	let right = latestBlock;
@@ -155,7 +166,7 @@ export async function getBlockNumberForTimestamp(targetTimestamp: number): Promi
 		const mid = Math.floor((left + right) / 2);
 		let block: unknown;
 		try {
-			block = await callRpc('eth_getBlockByNumber', [`0x${mid.toString(16)}`, false]);
+			block = await callRpc(network, 'eth_getBlockByNumber', [`0x${mid.toString(16)}`, false]);
 		} catch {
 			// Single-block lookup miss — let the binary search converge on neighbors.
 			right = mid - 1;
@@ -182,7 +193,9 @@ export async function getBlockNumberForTimestamp(targetTimestamp: number): Promi
 
 	if (smallestDiff === Infinity) {
 		throw new Error(
-			`getBlockNumberForTimestamp(${targetTimestamp}) — no block lookup succeeded after ${RPC_URLS.length} RPCs`
+			`getBlockNumberForTimestamp(${targetTimestamp}) — no block lookup succeeded after ${
+				1 + network.fallbackRpcUrls.length
+			} RPCs`
 		);
 	}
 
@@ -195,41 +208,48 @@ export async function getBlockNumberForTimestamp(targetTimestamp: number): Promi
  */
 export async function generateTokenSnapshot(
 	tokenAddress: string,
-	blockNumber: number
+	blockNumber: number,
+	chainId: number
 ): Promise<BlockSnapshot> {
+	const { networkCatalog } = await getServerApplicationCatalog();
+	const network = networkCatalog.find((candidate) => candidate.chainId === chainId);
+	if (!network) throw new Error(`Unknown chain ${chainId}`);
 	const normalizedToken = tokenAddress.toLowerCase();
 
 	// Find the parent token config to get all address variants
-	const parentToken = getTokenByAnyAddress(normalizedToken);
+	const parentToken = getTokenByAnyAddress(normalizedToken, chainId);
 	const allAddresses = parentToken ? getTokenAddressVariants(parentToken) : [normalizedToken];
 	const wrappedAddress = parentToken?.address.toLowerCase() ?? normalizedToken;
 
 	// Get block timestamp
-	const timestamp = await getBlockTimestamp(blockNumber);
+	const timestamp = await getBlockTimestamp(network, blockNumber);
 
 	// Fetch transfers for all address variants up to target block
-	const transfers = await fetchAllTransfers(blockNumber, allAddresses);
+	const transfers = await fetchAllTransfers(blockNumber, allAddresses, network);
 
 	// The API returns the nearest retained midpoint at or before the block time.
-	const price = (await fetchSnapshotPrices(timestamp)).get(wrappedAddress);
+	const price = (await fetchSnapshotPrices(network, timestamp)).get(wrappedAddress);
 
 	// Fetch vault holdings for all address variants at the specific block
-	const vaultHoldings = await fetchAllVaultHoldings(allAddresses, blockNumber);
+	const vaultHoldings = await fetchAllVaultHoldings(allAddresses, blockNumber, network);
 
 	// Fetch excluded + pool wallets (both excluded from rewards)
 	const excludedWallets = Array.from(await getRewardsExcludedWalletsSet());
 
 	// Generate snapshot combining all address variants into one
-	return generateSnapshot(
-		transfers,
-		blockNumber,
-		timestamp,
-		wrappedAddress,
-		price,
-		vaultHoldings,
-		excludedWallets,
-		allAddresses
-	);
+	return {
+		...generateSnapshot(
+			transfers,
+			blockNumber,
+			timestamp,
+			wrappedAddress,
+			price,
+			vaultHoldings,
+			excludedWallets,
+			allAddresses
+		),
+		chainId
+	};
 }
 
 /**
@@ -240,33 +260,42 @@ export async function generateTokenSnapshot(
  * Each token produces ONE snapshot combining holdings across
  * wrapped, unwrapped, and legacy addresses.
  */
-export async function generateAllTokenSnapshots(blockNumber: number): Promise<BlockSnapshot[]> {
+export async function generateAllTokenSnapshots(
+	network: Network,
+	blockNumber: number
+): Promise<BlockSnapshot[]> {
+	await getServerApplicationCatalog();
+	const chainTokens = TOKENS.filter((token) => token.chainId === network.chainId);
+	const allTokenAddresses = chainTokens.flatMap((token) => getTokenAddressVariants(token));
 	// Get block timestamp first (needed for retained price lookup)
-	const timestamp = await getBlockTimestamp(blockNumber);
+	const timestamp = await getBlockTimestamp(network, blockNumber);
 
 	// Fetch transfers, prices, vault holdings, and excluded/pool wallets in parallel
 	const [transfers, prices, vaultHoldings, excludedSet] = await Promise.all([
-		fetchAllTransfers(blockNumber, ALL_TOKEN_ADDRESSES),
-		fetchSnapshotPrices(timestamp),
-		fetchAllVaultHoldings(ALL_TOKEN_ADDRESSES, blockNumber),
+		fetchAllTransfers(blockNumber, allTokenAddresses, network),
+		fetchSnapshotPrices(network, timestamp),
+		fetchAllVaultHoldings(allTokenAddresses, blockNumber, network),
 		getRewardsExcludedWalletsSet()
 	]);
 	const excludedWallets = Array.from(excludedSet);
 
 	// Generate ONE snapshot per canonical token, combining all address variants
-	return TOKENS.map((token) => {
+	return chainTokens.map((token) => {
 		const wrappedAddr = token.address.toLowerCase();
 		const allAddrs = getTokenAddressVariants(token);
 
-		return generateSnapshot(
-			transfers,
-			blockNumber,
-			timestamp,
-			wrappedAddr,
-			prices.get(wrappedAddr),
-			vaultHoldings,
-			excludedWallets,
-			allAddrs
-		);
+		return {
+			...generateSnapshot(
+				transfers,
+				blockNumber,
+				timestamp,
+				wrappedAddr,
+				prices.get(wrappedAddr),
+				vaultHoldings,
+				excludedWallets,
+				allAddrs
+			),
+			chainId: network.chainId
+		};
 	});
 }

--- a/src/lib/server/snapshots/scraper.test.ts
+++ b/src/lib/server/snapshots/scraper.test.ts
@@ -26,6 +26,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+const TEST_NETWORK = {
+	subgraph_url: 'https://subgraph.example/primary',
+	subgraph_urls_legacy: ['https://subgraph.example/legacy-1']
+} as never;
+
 // Provide a 2-subgraph network config (primary + 1 legacy) so the transient-failure
 // test can assert that a partial subgraph failure does not poison merged results.
 vi.mock('$lib/config/networks', () => ({
@@ -38,8 +43,11 @@ vi.mock('$lib/config/networks', () => ({
 }));
 
 vi.mock('$lib/config/tokens', () => ({
-	TOKENS: [{ address: '0xVAULT' }],
-	getAllTokenAddressesFlat: () => ['0xvault']
+	getTokenAddressVariants: (token: { address: string }) => [token.address.toLowerCase()],
+	onTokenCatalogChange: (listener: (tokens: { address: string }[]) => void) => {
+		listener([{ address: '0xVAULT' }]);
+		return () => undefined;
+	}
 }));
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
@@ -142,7 +150,7 @@ describe('scraper pagination boundary', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		// Primary subgraph: 2 shares fetches (full + short); 1 wrapped fetch (short terminates).
 		const primarySharesCalls = fetchMock.mock.calls.filter(
@@ -192,7 +200,7 @@ describe('scraper pagination boundary', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		const primarySharesCalls = fetchMock.mock.calls.filter(
 			(c: unknown[]) =>
@@ -233,7 +241,7 @@ describe('scraper pagination boundary', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		const wrappedCalls = fetchMock.mock.calls.filter(
 			(c: unknown[]) =>
@@ -282,7 +290,7 @@ describe('scraper legacy wrappedTokenTransfers fallback', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		// No throw escaped. sharesTransfers data is preserved.
 		expect(result.length).toBe(1);
@@ -332,7 +340,7 @@ describe('scraper transient subgraph failure', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		// Only the legacy subgraph's transfer survives.
 		expect(result.length).toBe(1);
@@ -369,7 +377,7 @@ describe('scraper transient subgraph failure', () => {
 		});
 
 		const { fetchAllTransfers } = await import('./scraper');
-		const result = await fetchAllTransfers(99_999_999);
+		const result = await fetchAllTransfers(99_999_999, ['0xvault'], TEST_NETWORK);
 
 		expect(result.length).toBe(1);
 		expect(warnSpy).toHaveBeenCalled();

--- a/src/lib/server/snapshots/scraper.ts
+++ b/src/lib/server/snapshots/scraper.ts
@@ -1,21 +1,30 @@
 // Scraper for fetching SFT transfers from the subgraph
 // Modeled after albion.rewards/src/processor.ts
 
-import { networks } from '$lib/config/networks';
-import { TOKENS, getAllTokenAddressesFlat } from '$lib/config/tokens';
+import type { Network } from '$lib/config/networks';
+import { getTokenAddressVariants, onTokenCatalogChange } from '$lib/config/tokens';
 import type { Transfer, SubgraphTransfer, SubgraphWrappedTokenTransfer } from './types';
 
 const BATCH_SIZE = 1000;
 
-// Get SFT subgraph URLs from network config (current + legacy)
-const SFT_SUBGRAPH_URL = networks[0].subgraph_url;
-const SFT_SUBGRAPH_URLS_LEGACY = networks[0].subgraph_urls_legacy ?? [];
-
 // Get all token addresses from config (lowercase)
-export const TOKEN_ADDRESSES = TOKENS.map((t) => t.address.toLowerCase());
+export const TOKEN_ADDRESSES: string[] = [];
 
 // All token addresses including unwrapped and legacy (for expanded snapshots)
-export const ALL_TOKEN_ADDRESSES = getAllTokenAddressesFlat();
+export const ALL_TOKEN_ADDRESSES: string[] = [];
+
+onTokenCatalogChange((tokens) => {
+	TOKEN_ADDRESSES.splice(
+		0,
+		TOKEN_ADDRESSES.length,
+		...tokens.map((token) => token.address.toLowerCase())
+	);
+	ALL_TOKEN_ADDRESSES.splice(
+		0,
+		ALL_TOKEN_ADDRESSES.length,
+		...tokens.flatMap((token) => getTokenAddressVariants(token))
+	);
+});
 
 /**
  * Fetch transfers from a specific SFT subgraph up to a specific block
@@ -254,16 +263,17 @@ async function fetchFromSubgraph(
  */
 export async function fetchAllTransfers(
 	untilBlock: number,
-	tokenAddresses: string[] = ALL_TOKEN_ADDRESSES
+	tokenAddresses: string[],
+	network: Network
 ): Promise<Transfer[]> {
-	const subgraphUrls = [SFT_SUBGRAPH_URL, ...SFT_SUBGRAPH_URLS_LEGACY];
+	const subgraphUrls = [network.subgraph_url, ...network.subgraph_urls_legacy].filter(Boolean);
 
 	console.log(
 		`[Scraper] Fetching transfers up to block ${untilBlock} for ${tokenAddresses.length} tokens from ${subgraphUrls.length} subgraph(s)`
 	);
 
 	// Query all subgraphs in parallel
-	const legacyUrlSet = new Set(SFT_SUBGRAPH_URLS_LEGACY);
+	const legacyUrlSet = new Set(network.subgraph_urls_legacy);
 	const results = await Promise.all(
 		subgraphUrls.map(async (url, i) => {
 			try {

--- a/src/lib/server/snapshots/types.ts
+++ b/src/lib/server/snapshots/types.ts
@@ -26,6 +26,8 @@ export interface SnapshotPrice {
 }
 
 export interface BlockSnapshot {
+	/** Present on multichain snapshots; absent only on historical legacy blobs. */
+	chainId?: number;
 	blockNumber: number;
 	timestamp: number;
 	generatedAt: string;

--- a/src/lib/server/snapshots/vaults.ts
+++ b/src/lib/server/snapshots/vaults.ts
@@ -1,20 +1,22 @@
 // Query vault holdings from the Rain orderbook subgraph
 // Used to attribute orderbook holdings to vault owners
 
-import { networks } from '$lib/config/networks';
-import { TOKENS } from '$lib/config/tokens';
+import type { Network } from '$lib/config/networks';
+import { onTokenCatalogChange } from '$lib/config/tokens';
 import { parseFloatHex } from '$lib/utils/tokenMath';
 
 const BATCH_SIZE = 1000;
 
-// Get orderbook subgraph URLs from network config (current + inactive/legacy)
-const ORDERBOOK_SUBGRAPH_URLS = [
-	networks[0].orderbook_subgraph_url,
-	...(networks[0].orderbook_subgraph_urls_inactive ?? [])
-].filter(Boolean);
-
 // Get token addresses for filtering
-const TOKEN_ADDRESSES = TOKENS.map((t) => t.address.toLowerCase());
+const TOKEN_ADDRESSES: string[] = [];
+
+onTokenCatalogChange((tokens) => {
+	TOKEN_ADDRESSES.splice(
+		0,
+		TOKEN_ADDRESSES.length,
+		...tokens.map((token) => token.address.toLowerCase())
+	);
+});
 
 interface SubgraphVault {
 	id: string;
@@ -187,22 +189,27 @@ async function fetchAllVaultHoldingsFromSubgraph(
  * @param blockNumber - If provided, queries vault state at this specific block
  */
 export async function fetchAllVaultHoldings(
-	tokenAddresses: string[] = TOKEN_ADDRESSES,
-	blockNumber?: number
+	tokenAddresses: string[],
+	blockNumber: number | undefined,
+	network: Network
 ): Promise<VaultHolding[]> {
+	const orderbookSubgraphUrls = [
+		network.orderbook_subgraph_url,
+		...network.orderbook_subgraph_urls_inactive
+	].filter(Boolean);
 	const deduped = new Map<string, VaultHolding>();
 
 	console.log(
 		`[Vaults] Fetching vault holdings for ${tokenAddresses.length} tokens${
 			blockNumber ? ` at block ${blockNumber}` : ''
-		} from ${ORDERBOOK_SUBGRAPH_URLS.length} orderbook subgraph(s)`
+		} from ${orderbookSubgraphUrls.length} orderbook subgraph(s)`
 	);
 	console.log(`[Vaults] Token addresses: ${tokenAddresses.join(', ')}`);
-	console.log(`[Vaults] Subgraph URLs: ${ORDERBOOK_SUBGRAPH_URLS.join(', ')}`);
+	console.log(`[Vaults] Subgraph URLs: ${orderbookSubgraphUrls.join(', ')}`);
 
 	try {
 		const results = await Promise.all(
-			ORDERBOOK_SUBGRAPH_URLS.map(async (url, i) => {
+			orderbookSubgraphUrls.map(async (url, i) => {
 				try {
 					const holdings = await fetchAllVaultHoldingsFromSubgraph(
 						url,
@@ -210,7 +217,7 @@ export async function fetchAllVaultHoldings(
 						blockNumber
 					);
 					console.log(
-						`[Vaults] Subgraph ${i + 1}/${ORDERBOOK_SUBGRAPH_URLS.length}: ${
+						`[Vaults] Subgraph ${i + 1}/${orderbookSubgraphUrls.length}: ${
 							holdings.length
 						} vault holdings`
 					);

--- a/src/lib/server/st0xApiConfig.ts
+++ b/src/lib/server/st0xApiConfig.ts
@@ -72,3 +72,16 @@ export function getSt0xActivityApiConfig(environment: St0xEnvironment): St0xApiC
 		'activity'
 	);
 }
+
+/** Resolve the general REST API credential used by catalog and registry requests. */
+export function getSt0xGeneralApiConfig(environment: St0xEnvironment): St0xApiConfig | null {
+	const url = environment.ST0X_API_URL;
+	const key = environment.ST0X_API_KEY;
+	const secret = environment.ST0X_API_SECRET;
+	if (!url || !key || !secret) return null;
+	return {
+		apiBase: url.replace(/\/+$/, ''),
+		authHeader: basicAuth(key, secret),
+		credentialLabel: 'general'
+	};
+}

--- a/src/lib/server/st0xTradesFetcher.test.ts
+++ b/src/lib/server/st0xTradesFetcher.test.ts
@@ -39,7 +39,7 @@ describe('createServerTradesQueryFetcher', () => {
 		await expect(fetchTrades(request)).resolves.toEqual(responseBody);
 		expect(fetchMock).toHaveBeenCalledOnce();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/trades/query',
+			'https://api.example.test/v2/trades/query',
 			expect.objectContaining({
 				method: 'POST',
 				headers: {

--- a/src/lib/server/st0xTradesFetcher.ts
+++ b/src/lib/server/st0xTradesFetcher.ts
@@ -49,7 +49,7 @@ export function createServerTradesQueryFetcher({
 		const timeout = setTimeout(() => requestController.abort(), timeoutMs);
 
 		try {
-			const response = await fetchFn(`${apiBase}/v1/trades/query`, {
+			const response = await fetchFn(`${apiBase}/v2/trades/query`, {
 				method: 'POST',
 				headers: {
 					Authorization: authHeader,
@@ -59,7 +59,7 @@ export function createServerTradesQueryFetcher({
 				body: JSON.stringify(request),
 				signal: requestController.signal
 			});
-			logSt0xRequestBudget('v1/trades/query', credentialLabel, response);
+			logSt0xRequestBudget('v2/trades/query', credentialLabel, response);
 			if (response.status === 429) {
 				rateLimitError = new St0xTradesRateLimitError(
 					parseRetryAfterMs(response.headers.get('Retry-After'))

--- a/src/lib/server/tokenCatalog.ts
+++ b/src/lib/server/tokenCatalog.ts
@@ -1,0 +1,70 @@
+import { env } from '$env/dynamic/private';
+import type { ApiToken } from '$lib/api/st0xApi';
+import { replaceTokenCatalog, type CategorizedToken } from '$lib/config/tokens';
+import { normalizeApiTokens } from '$lib/queries/tokens';
+
+const CACHE_TTL_MS = 60_000;
+
+let cachedTokens: CategorizedToken[] = [];
+let cacheExpiresAt = 0;
+let inFlight: Promise<CategorizedToken[]> | null = null;
+
+function getApiConfig(): { url: string; authorization: string } {
+	const url = env.ST0X_API_URL?.replace(/\/+$/, '');
+	const key = env.ST0X_API_KEY;
+	const secret = env.ST0X_API_SECRET;
+	if (!url || !key || !secret) {
+		throw new Error('ST0X REST API token catalog is not configured');
+	}
+
+	return {
+		url,
+		authorization: `Basic ${btoa(`${key}:${secret}`)}`
+	};
+}
+
+async function fetchTokenCatalog(): Promise<CategorizedToken[]> {
+	const config = getApiConfig();
+	const response = await fetch(`${config.url}/v2/tokens`, {
+		headers: {
+			Accept: 'application/json',
+			Authorization: config.authorization
+		}
+	});
+
+	if (!response.ok) {
+		throw new Error(`Token catalog request failed with HTTP ${response.status}`);
+	}
+
+	const tokens = normalizeApiTokens((await response.json()) as ApiToken[]);
+	const st0xTokens = tokens.filter((token) => token.category === 'ST0x');
+	if (st0xTokens.length === 0) {
+		throw new Error('Token catalog response did not contain any ST0x tokens');
+	}
+
+	replaceTokenCatalog(tokens);
+	cachedTokens = tokens;
+	cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+	return tokens;
+}
+
+export async function getServerTokenCatalog(): Promise<CategorizedToken[]> {
+	if (cachedTokens.length > 0 && Date.now() < cacheExpiresAt) return cachedTokens;
+	if (!inFlight) {
+		inFlight = fetchTokenCatalog()
+			.catch((error) => {
+				if (cachedTokens.length === 0) throw error;
+				console.warn('[token-catalog] Refresh failed; serving stale catalog:', error);
+				cacheExpiresAt = Date.now() + 10_000;
+				return cachedTokens;
+			})
+			.finally(() => {
+				inFlight = null;
+			});
+	}
+	return inFlight;
+}
+
+export async function ensureServerTokenCatalog(): Promise<void> {
+	await getServerTokenCatalog();
+}

--- a/src/lib/server/tokenCatalog.ts
+++ b/src/lib/server/tokenCatalog.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 import type { ApiToken } from '$lib/api/st0xApi';
 import { replaceTokenCatalog, type CategorizedToken } from '$lib/config/tokens';
 import { normalizeApiTokens } from '$lib/queries/tokens';
+import { getSt0xGeneralApiConfig } from '$lib/server/st0xApiConfig';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -9,34 +10,34 @@ let cachedTokens: CategorizedToken[] = [];
 let cacheExpiresAt = 0;
 let inFlight: Promise<CategorizedToken[]> | null = null;
 
-function getApiConfig(): { url: string; authorization: string } {
-	const url = env.ST0X_API_URL?.replace(/\/+$/, '');
-	const key = env.ST0X_API_KEY;
-	const secret = env.ST0X_API_SECRET;
-	if (!url || !key || !secret) {
+function getApiConfig() {
+	const config = getSt0xGeneralApiConfig(env);
+	if (!config) {
 		throw new Error('ST0X REST API token catalog is not configured');
 	}
-
-	return {
-		url,
-		authorization: `Basic ${btoa(`${key}:${secret}`)}`
-	};
+	return config;
 }
 
 async function fetchTokenCatalog(): Promise<CategorizedToken[]> {
 	const config = getApiConfig();
-	const response = await fetch(`${config.url}/v2/tokens`, {
+	const response = await fetch(`${config.apiBase}/v2/tokens`, {
 		headers: {
 			Accept: 'application/json',
-			Authorization: config.authorization
-		}
+			Authorization: config.authHeader
+		},
+		cache: 'no-store',
+		signal: AbortSignal.timeout(10_000)
 	});
 
 	if (!response.ok) {
 		throw new Error(`Token catalog request failed with HTTP ${response.status}`);
 	}
 
-	const tokens = normalizeApiTokens((await response.json()) as ApiToken[]);
+	const payload: unknown = await response.json();
+	if (!Array.isArray(payload)) {
+		throw new Error('Token catalog response is not an array');
+	}
+	const tokens = normalizeApiTokens(payload as ApiToken[]);
 	const st0xTokens = tokens.filter((token) => token.category === 'ST0x');
 	if (st0xTokens.length === 0) {
 		throw new Error('Token catalog response did not contain any ST0x tokens');

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -104,6 +104,7 @@ export function buildMarketSwapQuoteRequest(
 
 	return {
 		...(taker ? { taker } : {}),
+		chainId: input.network.chainId,
 		inputToken: inputToken.address,
 		outputToken: outputToken.address,
 		mode: isOutputAnchored ? 'buyUpTo' : 'spendUpTo',
@@ -130,6 +131,7 @@ function buildApprovalRetryRequest(
 	}
 	return {
 		taker: request.taker,
+		chainId: request.chainId,
 		inputToken: request.inputToken,
 		outputToken: request.outputToken,
 		mode: request.mode,
@@ -286,10 +288,13 @@ function validateReadyCalldata(
 const TRADE_INDEX_MAX_ATTEMPTS = 60;
 const TRADE_INDEX_POLL_INTERVAL_MS = 5_000;
 
-async function pollForIndexedTrade(hash: string): Promise<ApiTradesByTxResponse | null> {
+async function pollForIndexedTrade(
+	hash: string,
+	chainId: number
+): Promise<ApiTradesByTxResponse | null> {
 	for (let attempt = 0; attempt < TRADE_INDEX_MAX_ATTEMPTS; attempt++) {
 		try {
-			const response = await apiGetTradesByTx(hash);
+			const response = await apiGetTradesByTx(hash, chainId);
 			if (response.trades.length > 0) return response;
 		} catch (error) {
 			if (attempt === TRADE_INDEX_MAX_ATTEMPTS - 1) {
@@ -471,7 +476,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 		});
 		addTradeFlowBreadcrumb(flowContext('submission', 'take_market_order'), 'completed');
 		invalidateDashboardBalances();
-		const indexedTrade = await pollForIndexedTrade(hash);
+		const indexedTrade = await pollForIndexedTrade(hash, network.chainId);
 		let metadata: { marketOrderSummary: ReturnType<typeof buildMarketOrderSummary> } | undefined;
 		if (indexedTrade) {
 			try {

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -49,7 +49,6 @@ import {
 	DEFAULT_MARKET_ORDER_SLIPPAGE_BPS as DEFAULT_BPS,
 	MAX_SLIPPAGE_BPS as MAX_BPS
 } from '$lib/utils/marketOrderFill';
-import { isOutsideMarketHours } from '$lib/utils/marketHours';
 import {
 	decodeFunctionData,
 	erc20Abi,
@@ -426,9 +425,6 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 	};
 
 	try {
-		if (isOutsideMarketHours()) {
-			return failWith(new Error('Market is closed'));
-		}
 		const taker = getSignerAddress();
 		if (!taker) {
 			activeTradeErrorStage = 'signing';

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -18,7 +18,7 @@ import {
 	type ApiTradesByTxResponse
 } from '$lib/api/st0xApi';
 import type { Network } from '$lib/config/network';
-import { invalidateDashboardBalances } from '$lib/queries/balances';
+import { invalidateExecutedTradeQueries } from '$lib/queries/balances';
 import {
 	APPROVAL_TX_CONFIRMATIONS,
 	getSignerAddress,
@@ -49,6 +49,7 @@ import {
 	DEFAULT_MARKET_ORDER_SLIPPAGE_BPS as DEFAULT_BPS,
 	MAX_SLIPPAGE_BPS as MAX_BPS
 } from '$lib/utils/marketOrderFill';
+import { isOutsideMarketHours } from '$lib/utils/marketHours';
 import {
 	decodeFunctionData,
 	erc20Abi,
@@ -202,9 +203,15 @@ async function submitApprovals(
 		transactionStoreInternal.awaitWalletConfirmation(
 			`Awaiting wallet confirmation to approve ${approval.symbol || 'token'}...`
 		);
-		const hash = await sendTransaction({ to: transaction.token, data: transaction.data });
+		const hash = await sendTransaction({
+			to: transaction.token,
+			data: transaction.data,
+			chainId: network.chainId
+		});
 		transactionStoreInternal.awaitApprovalTx(hash);
-		await waitForTransaction(hash, { confirmations: APPROVAL_TX_CONFIRMATIONS });
+		await waitForTransaction(hash, network.chainId, {
+			confirmations: APPROVAL_TX_CONFIRMATIONS
+		});
 	}
 }
 
@@ -419,6 +426,9 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 	};
 
 	try {
+		if (isOutsideMarketHours()) {
+			return failWith(new Error('Market is closed'));
+		}
 		const taker = getSignerAddress();
 		if (!taker) {
 			activeTradeErrorStage = 'signing';
@@ -459,7 +469,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			order_side: orderSide.toLowerCase() as 'buy' | 'sell'
 		});
 		transactionStoreInternal.awaitWalletConfirmation('Awaiting wallet confirmation...');
-		const hash = await sendTransaction(transaction);
+		const hash = await sendTransaction({ ...transaction, chainId: network.chainId });
 		activeTradeErrorStage = 'confirmation';
 		trackTradeEvent('broadcast', {
 			order_type: 'market',
@@ -467,7 +477,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			asset_symbol: assetToken.symbol,
 			payment_symbol: paymentToken.symbol
 		});
-		await waitForTransaction(hash);
+		await waitForTransaction(hash, network.chainId);
 		trackTradeEvent('confirmed', {
 			order_type: 'market',
 			order_side: orderSide.toLowerCase() as 'buy' | 'sell',
@@ -475,7 +485,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			payment_symbol: paymentToken.symbol
 		});
 		addTradeFlowBreadcrumb(flowContext('submission', 'take_market_order'), 'completed');
-		invalidateDashboardBalances();
+		invalidateExecutedTradeQueries();
 		const indexedTrade = await pollForIndexedTrade(hash, network.chainId);
 		let metadata: { marketOrderSummary: ReturnType<typeof buildMarketOrderSummary> } | undefined;
 		if (indexedTrade) {

--- a/src/lib/services/walletService.ts
+++ b/src/lib/services/walletService.ts
@@ -11,6 +11,7 @@ import {
 import type { Hash, Hex } from 'viem';
 import { authMethod } from '$lib/stores/authStore';
 import { dynamicWalletAddress } from '$lib/stores/dynamicStore';
+import { currentNetwork } from '$lib/stores';
 import { withRetry } from '$lib/utils/retry';
 
 // Store for Dynamic wallet provider (set by React component)
@@ -57,11 +58,14 @@ export async function sendTransaction(params: {
 			throw new Error('Dynamic wallet address not available');
 		}
 
-		// Ensure we're on Base network (chain ID 8453)
+		const network = get(currentNetwork);
+		if (!network) throw new Error('No network selected');
+
+		// Keep the embedded wallet on the registry-backed network selected in the UI.
 		try {
 			await dynamicWalletProvider!.request({
 				method: 'wallet_switchEthereumChain',
-				params: [{ chainId: '0x2105' }] // 8453 in hex
+				params: [{ chainId: `0x${network.chainId.toString(16)}` }]
 			});
 		} catch {
 			// Chain might already be correct, or not supported - continue anyway
@@ -103,12 +107,15 @@ export async function sendTransaction(params: {
 		if (!config) {
 			throw new Error('Wagmi config not available');
 		}
+		const network = get(currentNetwork);
+		if (!network) throw new Error('No network selected');
 
 		const hash = await withRetry(() =>
 			wagmiSendTransaction(config, {
 				to: params.to,
 				data: params.data,
-				value: params.value
+				value: params.value,
+				chainId: network.chainId
 			})
 		);
 
@@ -133,10 +140,13 @@ export async function waitForTransaction(
 	if (!config) {
 		throw new Error('Wagmi config not available');
 	}
+	const network = get(currentNetwork);
+	if (!network) throw new Error('No network selected');
 
 	await withRetry(() =>
 		wagmiWaitForTransactionReceipt(config, {
 			hash,
+			chainId: network.chainId,
 			...(options?.confirmations != null ? { confirmations: options.confirmations } : {})
 		})
 	);

--- a/src/lib/services/walletService.ts
+++ b/src/lib/services/walletService.ts
@@ -11,7 +11,6 @@ import {
 import type { Hash, Hex } from 'viem';
 import { authMethod } from '$lib/stores/authStore';
 import { dynamicWalletAddress } from '$lib/stores/dynamicStore';
-import { currentNetwork } from '$lib/stores';
 import { withRetry } from '$lib/utils/retry';
 
 // Store for Dynamic wallet provider (set by React component)
@@ -43,6 +42,7 @@ export async function sendTransaction(params: {
 	to: `0x${string}`;
 	data?: Hex;
 	value?: bigint;
+	chainId: number;
 }): Promise<Hash> {
 	const method = get(authMethod);
 	const config = get(wagmiConfig);
@@ -58,17 +58,17 @@ export async function sendTransaction(params: {
 			throw new Error('Dynamic wallet address not available');
 		}
 
-		const network = get(currentNetwork);
-		if (!network) throw new Error('No network selected');
-
-		// Keep the embedded wallet on the registry-backed network selected in the UI.
-		try {
-			await dynamicWalletProvider!.request({
-				method: 'wallet_switchEthereumChain',
-				params: [{ chainId: `0x${network.chainId.toString(16)}` }]
-			});
-		} catch {
-			// Chain might already be correct, or not supported - continue anyway
+		// Bind the complete operation to the caller's captured chain. A failed switch
+		// must stop submission instead of allowing the transaction on another network.
+		await dynamicWalletProvider.request({
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: `0x${params.chainId.toString(16)}` }]
+		});
+		const activeChain = await dynamicWalletProvider.request({ method: 'eth_chainId' });
+		const activeChainId =
+			typeof activeChain === 'string' ? Number.parseInt(activeChain, 16) : Number.NaN;
+		if (activeChainId !== params.chainId) {
+			throw new Error(`Wallet did not switch to chain ${params.chainId}`);
 		}
 
 		// Build transaction params - let wallet handle gas estimation
@@ -107,15 +107,12 @@ export async function sendTransaction(params: {
 		if (!config) {
 			throw new Error('Wagmi config not available');
 		}
-		const network = get(currentNetwork);
-		if (!network) throw new Error('No network selected');
-
 		const hash = await withRetry(() =>
 			wagmiSendTransaction(config, {
 				to: params.to,
 				data: params.data,
 				value: params.value,
-				chainId: network.chainId
+				chainId: params.chainId
 			})
 		);
 
@@ -134,19 +131,17 @@ export const APPROVAL_TX_CONFIRMATIONS = 2;
  */
 export async function waitForTransaction(
 	hash: Hash,
+	chainId: number,
 	options?: { confirmations?: number }
 ): Promise<void> {
 	const config = get(wagmiConfig);
 	if (!config) {
 		throw new Error('Wagmi config not available');
 	}
-	const network = get(currentNetwork);
-	if (!network) throw new Error('No network selected');
-
 	await withRetry(() =>
 		wagmiWaitForTransactionReceipt(config, {
 			hash,
-			chainId: network.chainId,
+			chainId,
 			...(options?.confirmations != null ? { confirmations: options.confirmations } : {})
 		})
 	);

--- a/src/lib/services/wrapService.ts
+++ b/src/lib/services/wrapService.ts
@@ -14,6 +14,13 @@ import {
 	getWrappingMappingByWrappedAddress
 } from '$lib/config/tokenWrapping';
 import { sendTransaction } from '$lib/services/walletService';
+import { currentNetwork } from '$lib/stores';
+
+function selectedChainId(): number {
+	const chainId = get(currentNetwork)?.chainId;
+	if (!chainId) throw new Error('No network selected');
+	return chainId;
+}
 
 // ERC4626 Vault ABI (standard interface)
 const ERC4626_ABI = [
@@ -79,12 +86,14 @@ async function checkAllowance(
 ): Promise<boolean> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
+	const chainId = selectedChainId();
 
 	const allowance = await readContract(config, {
 		address: tokenAddress,
 		abi: erc20Abi,
 		functionName: 'allowance',
-		args: [ownerAddress, spenderAddress]
+		args: [ownerAddress, spenderAddress],
+		chainId
 	});
 
 	return allowance >= amount;
@@ -112,7 +121,7 @@ async function requestApproval(
 	// Wait for approval transaction to be confirmed
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	await waitForTransactionReceipt(config, { hash });
+	await waitForTransactionReceipt(config, { hash, chainId: selectedChainId() });
 
 	return hash;
 }
@@ -124,17 +133,19 @@ export async function previewWrap(
 	unwrappedTokenAddress: Address,
 	assetAmount: bigint
 ): Promise<bigint> {
-	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress);
+	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, selectedChainId());
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
+	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: mapping.wrappedToken.address as Address,
 		abi: ERC4626_ABI,
 		functionName: 'previewDeposit',
-		args: [assetAmount]
+		args: [assetAmount],
+		chainId
 	});
 }
 
@@ -145,17 +156,19 @@ export async function previewUnwrap(
 	wrappedTokenAddress: Address,
 	shareAmount: bigint
 ): Promise<bigint> {
-	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress);
+	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, selectedChainId());
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
+	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: wrappedTokenAddress,
 		abi: ERC4626_ABI,
 		functionName: 'previewRedeem',
-		args: [shareAmount]
+		args: [shareAmount],
+		chainId
 	});
 }
 
@@ -172,7 +185,7 @@ export async function wrapToken(
 	amount: bigint,
 	receiver: Address
 ): Promise<`0x${string}`> {
-	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress);
+	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, selectedChainId());
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const vaultAddress = mapping.wrappedToken.address as Address;
@@ -213,7 +226,7 @@ export async function unwrapToken(
 	receiver: Address,
 	owner: Address
 ): Promise<`0x${string}`> {
-	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress);
+	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, selectedChainId());
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	// No approval needed when redeeming own shares (receiver === owner)
@@ -237,12 +250,14 @@ export async function unwrapToken(
 export async function convertToShares(vaultAddress: Address, assetAmount: bigint): Promise<bigint> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
+	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: vaultAddress,
 		abi: ERC4626_ABI,
 		functionName: 'convertToShares',
-		args: [assetAmount]
+		args: [assetAmount],
+		chainId
 	});
 }
 
@@ -252,11 +267,13 @@ export async function convertToShares(vaultAddress: Address, assetAmount: bigint
 export async function convertToAssets(vaultAddress: Address, shareAmount: bigint): Promise<bigint> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
+	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: vaultAddress,
 		abi: ERC4626_ABI,
 		functionName: 'convertToAssets',
-		args: [shareAmount]
+		args: [shareAmount],
+		chainId
 	});
 }

--- a/src/lib/services/wrapService.ts
+++ b/src/lib/services/wrapService.ts
@@ -14,13 +14,6 @@ import {
 	getWrappingMappingByWrappedAddress
 } from '$lib/config/tokenWrapping';
 import { sendTransaction } from '$lib/services/walletService';
-import { currentNetwork } from '$lib/stores';
-
-function selectedChainId(): number {
-	const chainId = get(currentNetwork)?.chainId;
-	if (!chainId) throw new Error('No network selected');
-	return chainId;
-}
 
 // ERC4626 Vault ABI (standard interface)
 const ERC4626_ABI = [
@@ -82,12 +75,11 @@ async function checkAllowance(
 	tokenAddress: Address,
 	ownerAddress: Address,
 	spenderAddress: Address,
-	amount: bigint
+	amount: bigint,
+	chainId: number
 ): Promise<boolean> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	const chainId = selectedChainId();
-
 	const allowance = await readContract(config, {
 		address: tokenAddress,
 		abi: erc20Abi,
@@ -105,7 +97,8 @@ async function checkAllowance(
 async function requestApproval(
 	tokenAddress: Address,
 	spenderAddress: Address,
-	amount: bigint
+	amount: bigint,
+	chainId: number
 ): Promise<`0x${string}`> {
 	const data = encodeFunctionData({
 		abi: erc20Abi,
@@ -115,13 +108,14 @@ async function requestApproval(
 
 	const hash = await sendTransaction({
 		to: tokenAddress,
-		data
+		data,
+		chainId
 	});
 
 	// Wait for approval transaction to be confirmed
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	await waitForTransactionReceipt(config, { hash, chainId: selectedChainId() });
+	await waitForTransactionReceipt(config, { hash, chainId });
 
 	return hash;
 }
@@ -131,15 +125,14 @@ async function requestApproval(
  */
 export async function previewWrap(
 	unwrappedTokenAddress: Address,
-	assetAmount: bigint
+	assetAmount: bigint,
+	chainId: number
 ): Promise<bigint> {
-	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, selectedChainId());
+	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, chainId);
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	const chainId = selectedChainId();
-
 	return readContract(config, {
 		address: mapping.wrappedToken.address as Address,
 		abi: ERC4626_ABI,
@@ -154,15 +147,14 @@ export async function previewWrap(
  */
 export async function previewUnwrap(
 	wrappedTokenAddress: Address,
-	shareAmount: bigint
+	shareAmount: bigint,
+	chainId: number
 ): Promise<bigint> {
-	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, selectedChainId());
+	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, chainId);
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	const chainId = selectedChainId();
-
 	return readContract(config, {
 		address: wrappedTokenAddress,
 		abi: ERC4626_ABI,
@@ -183,19 +175,26 @@ export async function previewUnwrap(
 export async function wrapToken(
 	unwrappedTokenAddress: Address,
 	amount: bigint,
-	receiver: Address
+	receiver: Address,
+	chainId: number
 ): Promise<`0x${string}`> {
-	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, selectedChainId());
+	const mapping = getWrappingMappingByUnwrappedAddress(unwrappedTokenAddress, chainId);
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	const vaultAddress = mapping.wrappedToken.address as Address;
 
 	// 1. Check if approval is needed
-	const hasAllowance = await checkAllowance(unwrappedTokenAddress, receiver, vaultAddress, amount);
+	const hasAllowance = await checkAllowance(
+		unwrappedTokenAddress,
+		receiver,
+		vaultAddress,
+		amount,
+		chainId
+	);
 
 	// 2. Request approval if needed
 	if (!hasAllowance) {
-		await requestApproval(unwrappedTokenAddress, vaultAddress, amount);
+		await requestApproval(unwrappedTokenAddress, vaultAddress, amount, chainId);
 	}
 
 	// 3. Call deposit on the ERC4626 vault
@@ -207,7 +206,8 @@ export async function wrapToken(
 
 	return sendTransaction({
 		to: vaultAddress,
-		data
+		data,
+		chainId
 	});
 }
 
@@ -224,9 +224,10 @@ export async function unwrapToken(
 	wrappedTokenAddress: Address,
 	shares: bigint,
 	receiver: Address,
-	owner: Address
+	owner: Address,
+	chainId: number
 ): Promise<`0x${string}`> {
-	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, selectedChainId());
+	const mapping = getWrappingMappingByWrappedAddress(wrappedTokenAddress, chainId);
 	if (!mapping) throw new Error('No wrapping mapping found for token');
 
 	// No approval needed when redeeming own shares (receiver === owner)
@@ -240,17 +241,21 @@ export async function unwrapToken(
 
 	return sendTransaction({
 		to: wrappedTokenAddress,
-		data
+		data,
+		chainId
 	});
 }
 
 /**
  * Convert asset amount to share amount for a given vault
  */
-export async function convertToShares(vaultAddress: Address, assetAmount: bigint): Promise<bigint> {
+export async function convertToShares(
+	vaultAddress: Address,
+	assetAmount: bigint,
+	chainId: number
+): Promise<bigint> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: vaultAddress,
@@ -264,10 +269,13 @@ export async function convertToShares(vaultAddress: Address, assetAmount: bigint
 /**
  * Convert share amount to asset amount for a given vault
  */
-export async function convertToAssets(vaultAddress: Address, shareAmount: bigint): Promise<bigint> {
+export async function convertToAssets(
+	vaultAddress: Address,
+	shareAmount: bigint,
+	chainId: number
+): Promise<bigint> {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not available');
-	const chainId = selectedChainId();
 
 	return readContract(config, {
 		address: vaultAddress,

--- a/src/lib/stores/approvalStore.ts
+++ b/src/lib/stores/approvalStore.ts
@@ -14,7 +14,7 @@
  *     hits a load-balanced RPC should be wrapped with `withRetry`".
  *   - APPROVAL_TX_CONFIRMATIONS = 2 per CONVENTIONS.md "Confirmations &
  *     Transaction Hygiene". DO NOT lower — confirmations=1 races with
- *     short-tail re-orgs on Base/Arbitrum.
+ *     short-tail re-orgs on supported EVM networks.
  *
  * Pitfall-aware design (per 02-PATTERNS.md "Variation flag"):
  *   The existing inline approval code in transaction.ts interleaved

--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -56,7 +56,7 @@ export const isAuthenticated = derived(authMethod, ($authMethod) => $authMethod 
  * Check if user is on the wrong network (for wallet users)
  * Uses lazy import to avoid circular dependency initialization issues
  */
-let _currentNetworkStore: Readable<Network> | null = null;
+let _currentNetworkStore: Readable<Network | null> | null = null;
 
 export const wrongNetwork = derived(
 	[chainId, walletAddress],
@@ -67,9 +67,9 @@ export const wrongNetwork = derived(
 		let isActive = true;
 
 		// Helper to compute and set the value
-		const updateValue = ($currentNetwork: Network) => {
+		const updateValue = ($currentNetwork: Network | null) => {
 			if (isActive) {
-				set(!!($walletAddress && $chainId !== $currentNetwork.id));
+				set(!!($walletAddress && $currentNetwork && $chainId !== $currentNetwork.id));
 			}
 		};
 

--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -69,7 +69,14 @@ export const wrongNetwork = derived(
 		// Helper to compute and set the value
 		const updateValue = ($currentNetwork: Network | null) => {
 			if (isActive) {
-				set(!!($walletAddress && $currentNetwork && $chainId !== $currentNetwork.id));
+				set(
+					!!(
+						$walletAddress &&
+						$currentNetwork &&
+						$chainId != null &&
+						$chainId !== $currentNetwork.id
+					)
+				);
 			}
 		};
 

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -352,7 +352,8 @@ export const handleStrategyDeployment = async (
 
 		hash = await sendTransaction({
 			to: deploymentArgs.raindexAddress as `0x${string}`,
-			data: deploymentArgs.deploymentCalldata as Hex
+			data: deploymentArgs.deploymentCalldata as Hex,
+			chainId: network.chainId
 		});
 		if (submitContext) addTradeFlowBreadcrumb(submitContext, 'completed');
 		// OBS-07 (Plan 02-03 Task 2c): tx hash returned post-dispatch — emit
@@ -650,11 +651,14 @@ export const handleWithdraw = async (vault: RaindexVault) => {
 
 		hash = await sendTransaction({
 			to: vault.raindex as `0x${string}`,
-			data: vaultCalldatas.value.withdraw as Hex
+			data: vaultCalldatas.value.withdraw as Hex,
+			chainId: network.chainId
 		});
 		awaitWalletConfirmation(`Awaiting transaction confirmation...`);
 
-		await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
+		await waitForTransaction(hash, network.chainId, {
+			confirmations: TAKE_TX_CONFIRMATIONS
+		});
 
 		const $signer = get(walletAddress);
 		const raindexLink = {
@@ -687,7 +691,8 @@ export const handleWrapUnwrap = async (
 	amount: bigint,
 	userAddress: `0x${string}`,
 	tokenSymbol: string,
-	targetSymbol: string
+	targetSymbol: string,
+	chainId: number
 ) => {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not found');
@@ -699,13 +704,13 @@ export const handleWrapUnwrap = async (
 		awaitWalletConfirmation(`Awaiting wallet confirmation to ${mode} ${tokenSymbol}...`);
 
 		if (mode === 'wrap') {
-			hash = await wrapToken(tokenAddress, amount, userAddress);
+			hash = await wrapToken(tokenAddress, amount, userAddress, chainId);
 		} else {
-			hash = await unwrapToken(tokenAddress, amount, userAddress, userAddress);
+			hash = await unwrapToken(tokenAddress, amount, userAddress, userAddress, chainId);
 		}
 
 		awaitWalletConfirmation(`Awaiting transaction confirmation...`);
-		await waitForTransaction(hash);
+		await waitForTransaction(hash, chainId);
 
 		// Invalidate balance queries (same pattern as handleWithdraw)
 		invalidateDashboardBalances();
@@ -899,12 +904,13 @@ export const handleRemoveOrder = async (quote: {
 
 				const withdrawHash = await sendTransaction({
 					to: vault.raindex as `0x${string}`,
-					data: vaultCalldatas.value.withdraw as Hex
+					data: vaultCalldatas.value.withdraw as Hex,
+					chainId: network.chainId
 				});
 
 				awaitWalletConfirmation(`Awaiting withdrawal confirmation...`);
 
-				await waitForTransaction(withdrawHash);
+				await waitForTransaction(withdrawHash, network.chainId);
 			}
 		}
 
@@ -921,12 +927,13 @@ export const handleRemoveOrder = async (quote: {
 
 		const hash = await sendTransaction({
 			to: order.raindex as `0x${string}`,
-			data: removeCalldata.value as Hex
+			data: removeCalldata.value as Hex,
+			chainId: network.chainId
 		});
 
 		awaitWalletConfirmation('Awaiting transaction confirmation...');
 
-		await waitForTransaction(hash);
+		await waitForTransaction(hash, network.chainId);
 
 		const raindexLink = createRaindexLink(network.id, order.raindex, quote.orderHash);
 
@@ -1037,12 +1044,13 @@ export const handleWithdrawFromOrder = async (quote: {
 
 				const removeHash = await sendTransaction({
 					to: order.raindex as `0x${string}`,
-					data: removeCalldata.value as Hex
+					data: removeCalldata.value as Hex,
+					chainId: network.chainId
 				});
 
 				awaitWalletConfirmation('Awaiting deactivation confirmation...');
 
-				await waitForTransaction(removeHash);
+				await waitForTransaction(removeHash, network.chainId);
 			}
 		}
 
@@ -1164,12 +1172,13 @@ export const handleWithdrawFromOrder = async (quote: {
 
 			lastHash = await sendTransaction({
 				to: vault.raindex as `0x${string}`,
-				data: vaultCalldatas.value.withdraw as Hex
+				data: vaultCalldatas.value.withdraw as Hex,
+				chainId: network.chainId
 			});
 
 			awaitWalletConfirmation(`Awaiting transaction confirmation...`);
 
-			await waitForTransaction(lastHash);
+			await waitForTransaction(lastHash, network.chainId);
 		}
 
 		const chainId = network.id;

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -53,6 +53,7 @@ import { invalidateUserVaultQueries } from '$lib/queries/vaults';
 import { invalidateDashboardBalances } from '$lib/queries/balances';
 import { walletAddress } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
+import type { Network } from '$lib/config/network';
 import { rainlangConfirmationModal, reviewStrategyOnDeploy } from '$lib/stores';
 import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken } from '$lib/utils/tokenMath';
 import { ZERO_FLOAT_HEX } from '$lib/config/constants';
@@ -185,13 +186,19 @@ function createRaindexLink(
 	return { url, text: linkText };
 }
 
+function getSelectedNetwork(): Network {
+	const network = get(currentNetwork);
+	if (!network) throw new Error('No network selected');
+	return network;
+}
+
 export const handleStrategyDeployment = async (
 	deploymentArgs: DeploymentTransactionArgs,
 	assetTokenInfo?: AssetTokenInfo,
 	eventContext?: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'submission', 'wallet_config', network?.id);
@@ -276,7 +283,8 @@ export const handleStrategyDeployment = async (
 						abi: erc20Abi,
 						address: d.approval.token as `0x${string}`,
 						functionName: 'balanceOf',
-						args: [$signerAddress as Hex]
+						args: [$signerAddress as Hex],
+						chainId: network.chainId
 					})
 				)
 			)) as bigint[];
@@ -516,7 +524,7 @@ export const showRainlangConfirmation = async (
 export const handleDsfDeploy = async (args: MarketMakingDeploymentArgs) => {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not found');
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	awaitWalletConfirmation(`Preparing strategy...`);
 	const { composedRainlang, deploymentArgs } = await getMarketMakingDeploymentArgs(network, args);
 
@@ -528,7 +536,7 @@ export const handleDcaDeploy = async (
 	eventContext: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_dca', network?.id);
@@ -578,7 +586,7 @@ export const handleLimitDeploy = async (
 	eventContext: DeployEventContext
 ) => {
 	const config = get(wagmiConfig);
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	if (!config) {
 		const error = new Error('Wagmi config not found');
 		reportDeployFailure(error, eventContext, 'calldata', 'prepare_limit', network?.id);
@@ -635,7 +643,7 @@ export const handleWithdraw = async (vault: RaindexVault) => {
 	let hash: Hash;
 	try {
 		// Security: Validate orderbook address is trusted before sending transaction
-		const network = get(currentNetwork);
+		const network = getSelectedNetwork();
 		validateOrderbookAddress(vault.raindex, network);
 
 		awaitWalletConfirmation(`Awaiting wallet confirmation for withdrawal...`);
@@ -740,7 +748,7 @@ export const handleRemoveOrder = async (quote: {
 }) => {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not found');
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	const $signerAddress = get(walletAddress);
 
 	if (!$signerAddress) {
@@ -972,7 +980,7 @@ export const handleWithdrawFromOrder = async (quote: {
 }) => {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not found');
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	const $signerAddress = get(walletAddress);
 
 	if (!$signerAddress) {
@@ -1201,7 +1209,7 @@ export const handleWithdrawFromOrder = async (quote: {
 };
 
 export const handleFolioDeploy = async (args: FolioDeploymentArgs) => {
-	const network = get(currentNetwork);
+	const network = getSelectedNetwork();
 	awaitWalletConfirmation(`Preparing strategy...`);
 	const { composedRainlang, deploymentArgs } = await getFolioDeploymentArgs(network, args);
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -3,7 +3,7 @@ import type { OffchainAssetReceiptVault } from '$lib/types/OffchainAssetReceiptV
 import type { MetaV1S } from '$lib/types/OffchainAssetReceiptVault';
 import type { ApiTokenProofsResponse } from '$lib/api/st0xApi';
 import type { Network } from '$lib/config/network';
-import { networks } from '$lib/config/network';
+import { replaceNetworkCatalog } from '$lib/config/network';
 import type { MidpointPrice } from '$lib/queries/midpointPrices';
 import { createMidpointPricesQuery } from '$lib/queries/midpointPrices';
 import { createSftsQuery } from '$lib/queries/vaults';
@@ -17,11 +17,11 @@ function mapQueryData<T>(queryStore: QueryResultStore<T>, fallback: T) {
 }
 
 function createNetworkQueryStore<T>(
-	networkStore: Readable<Network>,
+	networkStore: Readable<Network | null>,
 	factory: (network: Network | null) => QueryResultStore<T>
 ): QueryResultStore<T> {
 	return derived(networkStore, ($network, set) => {
-		const queryStore = factory($network ?? null);
+		const queryStore = factory($network);
 		const unsubscribe = queryStore.subscribe(set);
 		return () => unsubscribe();
 	});
@@ -29,7 +29,21 @@ function createNetworkQueryStore<T>(
 
 export const sftMetadata = writable<MetaV1S[] | null>(null);
 export const tokenProofs = writable<ApiTokenProofsResponse | null>(null);
-export const currentNetwork = writable<Network>(networks[0]); // Base is default
+export const availableNetworks = writable<Network[]>([]);
+export const currentNetwork = writable<Network | null>(null);
+
+export function hydrateNetworkCatalog(catalog: readonly Network[]): void {
+	const next = [...catalog];
+	replaceNetworkCatalog(next);
+	availableNetworks.set(next);
+	currentNetwork.update((selected) => {
+		if (selected) {
+			const refreshed = next.find((network) => network.chainId === selected.chainId);
+			if (refreshed) return refreshed;
+		}
+		return next[0] ?? null;
+	});
+}
 
 // Re-export wrongNetwork from authStore to maintain backward compatibility
 export { wrongNetwork } from './authStore';
@@ -67,20 +81,21 @@ const REVIEW_STRATEGY_KEY = 'st0x_review_strategy_on_deploy';
 
 function createReviewStrategyStore() {
 	// Initialize from localStorage if available, default to false
-	const initialValue = browser ? localStorage.getItem(REVIEW_STRATEGY_KEY) === 'true' : false;
+	const hasStorage = browser && typeof localStorage !== 'undefined';
+	const initialValue = hasStorage ? localStorage.getItem(REVIEW_STRATEGY_KEY) === 'true' : false;
 	const { subscribe, set } = writable<boolean>(initialValue);
 
 	return {
 		subscribe,
 		set: (value: boolean) => {
-			if (browser) {
+			if (hasStorage) {
 				localStorage.setItem(REVIEW_STRATEGY_KEY, String(value));
 			}
 			set(value);
 		},
 		toggle: () => {
-			const newValue = browser ? localStorage.getItem(REVIEW_STRATEGY_KEY) !== 'true' : false;
-			if (browser) {
+			const newValue = hasStorage ? localStorage.getItem(REVIEW_STRATEGY_KEY) !== 'true' : false;
+			if (hasStorage) {
 				localStorage.setItem(REVIEW_STRATEGY_KEY, String(newValue));
 			}
 			set(newValue);

--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -516,10 +516,13 @@ export const handleAggregatedTakeOrdersCalldata = async (
 		awaitWalletConfirmation(`Awaiting wallet confirmation to approve ${approvalTokenSymbol}...`);
 		const approvalHash = await sendTransaction({
 			to: maybeApprovalInfo.token as `0x${string}`,
-			data: maybeApprovalInfo.calldata as Hex
+			data: maybeApprovalInfo.calldata as Hex,
+			chainId: network.chainId
 		});
 		awaitApprovalTx(approvalHash);
-		await waitForTransaction(approvalHash, { confirmations: APPROVAL_TX_CONFIRMATIONS });
+		await waitForTransaction(approvalHash, network.chainId, {
+			confirmations: APPROVAL_TX_CONFIRMATIONS
+		});
 		calldataWrapped = await fetchAggregatedTakeOrdersCalldata(takeRequest, { preferCache: false });
 		if (calldataWrapped.error || !calldataWrapped.value) {
 			transactionError(
@@ -569,10 +572,11 @@ export const handleAggregatedTakeOrdersCalldata = async (
 		awaitWalletConfirmation(`Awaiting wallet confirmation...`);
 		const hash = await sendTransaction({
 			to: raindex as `0x${string}`,
-			data: calldata as Hex
+			data: calldata as Hex,
+			chainId: network.chainId
 		});
 		awaitWalletConfirmation(`Awaiting transaction confirmation...`);
-		await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
+		await waitForTransaction(hash, network.chainId, { confirmations: TAKE_TX_CONFIRMATIONS });
 		await pollAndFinalizeTakeOrders([hash], primaryOrder, params, network);
 		return true;
 	} catch (txError) {
@@ -821,10 +825,13 @@ export const handleTakeOrders = async (
 						);
 						const approvalHash = await sendTransaction({
 							to: maybeApprovalInfo.token as `0x${string}`,
-							data: maybeApprovalInfo.calldata as Hex
+							data: maybeApprovalInfo.calldata as Hex,
+							chainId: network.chainId
 						});
 						awaitApprovalTx(approvalHash);
-						await waitForTransaction(approvalHash, { confirmations: APPROVAL_TX_CONFIRMATIONS });
+						await waitForTransaction(approvalHash, network.chainId, {
+							confirmations: APPROVAL_TX_CONFIRMATIONS
+						});
 						readyCalldataResult = await orderToExecute.getTakeCalldata(
 							Number(getMakerInputIOIndex(orderConfig)),
 							Number(getMakerOutputIOIndex(orderConfig)),
@@ -841,10 +848,13 @@ export const handleTakeOrders = async (
 					);
 					const approvalHash = await sendTransaction({
 						to: maybeApprovalInfo.token as `0x${string}`,
-						data: maybeApprovalInfo.calldata as Hex
+						data: maybeApprovalInfo.calldata as Hex,
+						chainId: network.chainId
 					});
 					awaitApprovalTx(approvalHash);
-					await waitForTransaction(approvalHash, { confirmations: APPROVAL_TX_CONFIRMATIONS });
+					await waitForTransaction(approvalHash, network.chainId, {
+						confirmations: APPROVAL_TX_CONFIRMATIONS
+					});
 					readyCalldataResult = await orderToExecute.getTakeCalldata(
 						Number(getMakerInputIOIndex(orderConfig)),
 						Number(getMakerOutputIOIndex(orderConfig)),
@@ -925,7 +935,8 @@ export const handleTakeOrders = async (
 
 			hash = await sendTransaction({
 				to: readyCalldataResult.value.takeOrdersInfo.raindex as `0x${string}`,
-				data: readyCalldataResult.value.takeOrdersInfo.calldata as Hex
+				data: readyCalldataResult.value.takeOrdersInfo.calldata as Hex,
+				chainId: network.chainId
 			});
 
 			console.log(`${TX_LOG_PREFIX} Order ${orderIndex + 1} transaction submitted`, {
@@ -934,7 +945,7 @@ export const handleTakeOrders = async (
 			});
 
 			awaitWalletConfirmation(`Awaiting transaction confirmation${batchLabel}...`, progressData);
-			await waitForTransaction(hash, { confirmations: TAKE_TX_CONFIRMATIONS });
+			await waitForTransaction(hash, network.chainId, { confirmations: TAKE_TX_CONFIRMATIONS });
 
 			console.log(`${TX_LOG_PREFIX} Order ${orderIndex + 1} transaction confirmed`, { hash });
 

--- a/src/lib/utils/costBasis.ts
+++ b/src/lib/utils/costBasis.ts
@@ -204,7 +204,8 @@ export function calculateCostBasisForToken(
 export function calculateAllCostBases(
 	trades: CostBasisTrade[],
 	paymentTokenAddresses: Set<string>,
-	userAddress: string
+	userAddress: string,
+	chainId?: number
 ): Map<string, CostBasisData> {
 	const costBasisMap = new Map<string, CostBasisData>();
 
@@ -240,7 +241,7 @@ export function calculateAllCostBases(
 	// wrapped token has no trades yet (i.e. is not already in the map).
 	for (const [tokenAddress, costBasis] of Array.from(costBasisMap.entries())) {
 		// Check if this is an old (legacy) token with a migration to a new wrapped token
-		const migrationMapping = getMigrationMappingByAddress(tokenAddress);
+		const migrationMapping = getMigrationMappingByAddress(tokenAddress, chainId);
 		if (!migrationMapping) continue;
 		if (costBasis.totalAcquired <= 0) continue;
 

--- a/src/lib/utils/tokenMath.ts
+++ b/src/lib/utils/tokenMath.ts
@@ -511,10 +511,11 @@ const RAINDEX_BASE_URL = 'https://v6.raindex.finance';
  * Generate a Raindex URL for an order
  */
 export function getRaindexOrderUrl(
-	chainId: number,
+	chainId: number | undefined,
 	orderbookId: string,
 	orderHash: string
 ): string {
+	if (chainId === undefined) return '#';
 	return `${RAINDEX_BASE_URL}/orders/${chainId}-${orderbookId}-${orderHash}`;
 }
 
@@ -522,15 +523,16 @@ export function getRaindexOrderUrl(
  * Generate a Raindex URL for a vault
  * Format: {chainId}-{orderbookId}-{vaultSubgraphId}
  *
- * @param chainId - Network chain ID (e.g., 8453 for Base)
+ * @param chainId - Network chain ID from the active registry
  * @param orderbookId - Orderbook contract address
  * @param vaultSubgraphId - The vault's unique subgraph identifier (vault.id), NOT the vault slot number (vault.vaultId)
  */
 export function getRaindexVaultUrl(
-	chainId: number,
+	chainId: number | undefined,
 	orderbookId: string,
 	vaultSubgraphId: string
 ): string {
+	if (chainId === undefined) return '#';
 	const normalizedId = vaultSubgraphId.startsWith('0x') ? vaultSubgraphId : `0x${vaultSubgraphId}`;
 	return `${RAINDEX_BASE_URL}/vaults/${chainId}-${orderbookId}-${normalizedId}`;
 }

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -225,8 +225,11 @@
 		}
 	}
 
-	// Basescan URL for wallet
-	$: basescanUrl = $walletAddress ? `https://basescan.org/address/${$walletAddress}` : '';
+	// Registry-backed explorer URL for the connected wallet on the selected network.
+	$: walletExplorerUrl =
+		$walletAddress && $currentNetwork
+			? `${$currentNetwork.blockExplorer}/address/${$walletAddress}`
+			: '';
 
 	// Dust threshold for vaults and token balances (in token units)
 	const DUST_THRESHOLD = 0.0001;
@@ -370,12 +373,15 @@
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
 				staleTime: QUERY_STALE_TIME_MS,
 				queryFn: async () => {
-					if (!$sfts || !$walletAddress || !$wagmiConfig) return [];
+					if (!$sfts || !$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
 
 					// Token details already normalize to wrapped addresses, but token lookup keeps
 					// legacy/unwrapped variants safe for older cached rows.
 					const sftsWithWrappedAddresses = $sfts.map((sft) => {
-						const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
+						const tokenConfig = findApiTokenByAnyAddress(
+							ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
+							sft.address
+						);
 						return {
 							...sft,
 							wrappedAddress: tokenConfig?.address ?? sft.address
@@ -387,7 +393,8 @@
 						abi: erc20Abi,
 						address: sft.wrappedAddress as `0x${string}`,
 						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`]
+						args: [$walletAddress as `0x${string}`],
+						chainId: $currentNetwork.chainId
 					}));
 
 					try {
@@ -402,7 +409,10 @@
 								walletBalance = result.result as bigint;
 							}
 
-							const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
+							const tokenConfig = findApiTokenByAnyAddress(
+								ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
+								sft.address
+							);
 
 							return {
 								id: sft.id,
@@ -416,7 +426,10 @@
 					} catch (error) {
 						console.error('Multicall failed for wallet holdings:', error);
 						return $sfts.map((sft) => {
-							const tokenConfig = findApiTokenByAnyAddress(ALL_TOKENS, sft.address);
+							const tokenConfig = findApiTokenByAnyAddress(
+								ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
+								sft.address
+							);
 							return {
 								id: sft.id,
 								address: tokenConfig?.address ?? sft.address,
@@ -432,12 +445,12 @@
 		)
 	);
 
-	// Query USDC wallet balance via multicall
+	// Query configured payment-token balances via multicall.
 	const usdcBalanceQuery = createQuery(
 		derived(
 			[isAuthenticated, walletAddress, currentNetwork, wagmiConfig],
 			([$isAuthenticated, $walletAddress, $currentNetwork, $wagmiConfig]) => ({
-				queryKey: ['usdcWalletBalance', $walletAddress, $currentNetwork?.chainId],
+				queryKey: ['paymentTokenWalletBalance', $walletAddress, $currentNetwork?.chainId],
 				enabled: !!($isAuthenticated && $walletAddress && $currentNetwork && $wagmiConfig),
 				refetchOnMount: 'always' as const,
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
@@ -450,7 +463,8 @@
 						abi: erc20Abi,
 						address: token.address as `0x${string}`,
 						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`]
+						args: [$walletAddress as `0x${string}`],
+						chainId: $currentNetwork.chainId
 					}));
 
 					try {
@@ -472,7 +486,7 @@
 							})
 							.filter((balance): balance is NonNullable<typeof balance> => balance !== null);
 					} catch (error) {
-						console.error('Multicall failed for USDC balance:', error);
+						console.error('Multicall failed for payment-token balances:', error);
 						return [];
 					}
 				}
@@ -480,32 +494,33 @@
 		)
 	);
 
-	// Query native ETH balance
-	const ethBalanceQuery = createQuery(
+	// Query the selected network's native currency balance.
+	const nativeBalanceQuery = createQuery(
 		derived(
 			[isAuthenticated, walletAddress, currentNetwork, wagmiConfig],
 			([$isAuthenticated, $walletAddress, $currentNetwork, $wagmiConfig]) => ({
-				queryKey: ['ethWalletBalance', $walletAddress, $currentNetwork?.chainId],
+				queryKey: ['nativeWalletBalance', $walletAddress, $currentNetwork?.chainId],
 				enabled: !!($isAuthenticated && $walletAddress && $currentNetwork && $wagmiConfig),
 				refetchOnMount: 'always' as const,
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
 				staleTime: QUERY_STALE_TIME_MS,
 				queryFn: async () => {
-					if (!$walletAddress || !$wagmiConfig) return null;
+					if (!$walletAddress || !$currentNetwork || !$wagmiConfig) return null;
 					try {
 						const balance = await getBalance($wagmiConfig, {
-							address: $walletAddress as `0x${string}`
+							address: $walletAddress as `0x${string}`,
+							chainId: $currentNetwork.chainId
 						});
 						return {
-							id: 'eth',
+							id: `native:${$currentNetwork.chainId}`,
 							address: 'native',
-							name: 'Ethereum',
-							symbol: 'ETH',
+							name: `${$currentNetwork.displayName} native currency`,
+							symbol: $currentNetwork.currencySymbol,
 							walletBalance: balance.value,
 							decimals: 18
 						};
 					} catch (error) {
-						console.error('Failed to fetch ETH balance:', error);
+						console.error('Failed to fetch native currency balance:', error);
 						return null;
 					}
 				}
@@ -524,14 +539,15 @@
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
 				staleTime: QUERY_STALE_TIME_MS,
 				queryFn: async () => {
-					if (!$walletAddress || !$wagmiConfig) return [];
-					const oldTokenAddresses = getAllOldTokenAddresses();
+					if (!$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
+					const oldTokenAddresses = getAllOldTokenAddresses($currentNetwork.chainId);
 
 					const contracts = oldTokenAddresses.map((address) => ({
 						abi: erc20Abi,
 						address: address as `0x${string}`,
 						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`]
+						args: [$walletAddress as `0x${string}`],
+						chainId: $currentNetwork.chainId
 					}));
 
 					try {
@@ -540,7 +556,7 @@
 							.map((address, index) => {
 								const result = results[index];
 								if (result.status === 'success') {
-									const mapping = getMigrationMappingByAddress(address);
+									const mapping = getMigrationMappingByAddress(address, $currentNetwork.chainId);
 									return {
 										address,
 										walletBalance: result.result as bigint,
@@ -585,14 +601,15 @@
 				refetchInterval: QUERY_POLL_INTERVAL_MS,
 				staleTime: QUERY_STALE_TIME_MS,
 				queryFn: async () => {
-					if (!$walletAddress || !$wagmiConfig) return [];
-					const unwrappedAddresses = getAllUnwrappedTokenAddresses();
+					if (!$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
+					const unwrappedAddresses = getAllUnwrappedTokenAddresses($currentNetwork.chainId);
 
 					const contracts = unwrappedAddresses.map((address) => ({
 						abi: erc20Abi,
 						address: address as `0x${string}`,
 						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`]
+						args: [$walletAddress as `0x${string}`],
+						chainId: $currentNetwork.chainId
 					}));
 
 					try {
@@ -601,7 +618,10 @@
 							.map((address, index) => {
 								const result = results[index];
 								if (result.status === 'success') {
-									const mapping = getWrappingMappingByUnwrappedAddress(address);
+									const mapping = getWrappingMappingByUnwrappedAddress(
+										address,
+										$currentNetwork.chainId
+									);
 									return {
 										address,
 										walletBalance: result.result as bigint,
@@ -793,14 +813,13 @@
 		return new Set(paymentTokens.map((t) => t.address.toLowerCase()));
 	})();
 
-	// Build funds holdings (payment tokens + ETH)
-	// Always show USDC even if balance is 0
+	// Build funds holdings (payment tokens + native currency).
 	$: fundsHoldings = (() => {
 		const funds = portfolioHoldings.filter((h) =>
 			paymentTokenAddresses.has(h.address.toLowerCase())
 		);
 
-		// Ensure USDC is always shown (even with 0 balance)
+		// Ensure configured payment tokens are always shown, even with a zero balance.
 		for (const token of paymentTokens) {
 			const exists = funds.some((f) => f.address.toLowerCase() === token.address.toLowerCase());
 			if (!exists) {
@@ -815,7 +834,7 @@
 					totalBalance: 0,
 					walletBalanceNum: 0,
 					vaultBalanceNum: 0,
-					price: 1, // USDC is pegged to $1
+					price: 1,
 					value: 0,
 					priceChange: 0,
 					priceChangePercent: 0,
@@ -829,22 +848,22 @@
 			}
 		}
 
-		// Add ETH if we have a balance
-		const ethData = $ethBalanceQuery?.data;
-		if (ethData && ethData.walletBalance > 0n) {
-			const walletBalanceNum = parseFloat(formatUnits(ethData.walletBalance, 18));
+		// Add the selected network's native currency if it has a balance.
+		const nativeData = $nativeBalanceQuery?.data;
+		if (nativeData && nativeData.walletBalance > 0n) {
+			const walletBalanceNum = parseFloat(formatUnits(nativeData.walletBalance, 18));
 			funds.unshift({
-				id: 'eth',
+				id: nativeData.id,
 				address: 'native',
-				name: 'Ethereum',
-				symbol: 'ETH',
-				walletBalance: ethData.walletBalance,
+				name: nativeData.name,
+				symbol: nativeData.symbol,
+				walletBalance: nativeData.walletBalance,
 				vaultBalance: 0n,
 				decimals: 18,
 				totalBalance: walletBalanceNum,
 				walletBalanceNum,
 				vaultBalanceNum: 0,
-				price: 0, // ETH price not tracked in our feeds
+				price: 0, // Native-currency prices are not part of the ST0x feed.
 				value: 0,
 				priceChange: 0,
 				priceChangePercent: 0,
@@ -875,7 +894,7 @@
 		return oldTokens
 			.filter((token) => !unwrappedAddresses.has(token.address.toLowerCase()))
 			.map((token) => {
-				const mapping = getMigrationMappingByAddress(token.address);
+				const mapping = getMigrationMappingByAddress(token.address, $currentNetwork?.chainId);
 				const quote = mapping
 					? findQuoteForSymbol(mapping.newToken.symbol, $priceFeedsQuery?.data ?? [], ALL_TOKENS)
 					: null;
@@ -897,7 +916,10 @@
 		const tokens = $unwrappedTokenBalancesQuery?.data ?? [];
 		return tokens
 			.map((token) => {
-				const mapping = getWrappingMappingByUnwrappedAddress(token.address);
+				const mapping = getWrappingMappingByUnwrappedAddress(
+					token.address,
+					$currentNetwork?.chainId
+				);
 				// Use the wrapped token's price since they're 1:1
 				const quote = mapping
 					? findQuoteForSymbol(
@@ -930,9 +952,8 @@
 	$: costBasisQuery = createCostBasisQuery($currentNetwork, $walletAddress);
 
 	// Wrap-ratio lookup so the Holdings table can flip wt↔t when the user
-	// toggles `holdingsDenom`. Backed by the hardcoded SGOV fixture today;
-	// will switch to the live /v1/tokens/exchange-rates API when it ships.
-	const exchangeRatesQuery = createExchangeRatesQuery();
+	// toggles `holdingsDenom`. Data is scoped to the selected registry chain.
+	$: exchangeRatesQuery = createExchangeRatesQuery($currentNetwork?.chainId);
 	$: holdingsRatesLookup = $exchangeRatesQuery?.data ?? null;
 	$: resolveHoldingRatio = (address: string): number =>
 		$holdingsDenom === 'unwrapped' ? resolveRatio(holdingsRatesLookup, address) : 1;
@@ -1165,13 +1186,13 @@
 									</svg>
 								{/if}
 							</button>
-							<!-- Basescan link -->
+							<!-- Network explorer link -->
 							<a
-								href={basescanUrl}
+								href={walletExplorerUrl}
 								target="_blank"
 								rel="noopener noreferrer"
 								class="icon-trigger rounded p-1 text-text-3 hover:bg-surface-2 hover:text-text-2"
-								title="View on Basescan"
+								title="View on block explorer"
 							>
 								<Icon name="arrowUpRight" className="icon-slide-up h-3.5 w-3.5" />
 							</a>
@@ -1312,14 +1333,18 @@
 										</thead>
 										<tbody>
 											{#each fundsHoldings as holding}
-												{@const isEth = holding.address === 'native'}
+												{@const isNative = holding.address === 'native'}
 												{@const isUsdc = holding.symbol === 'USDC'}
-												{@const paymentToken = isEth
+												{@const paymentToken = isNative
 													? null
 													: paymentTokens.find(
 															(t) => t.address.toLowerCase() === holding.address.toLowerCase()
 														)}
-												{@const logoUrl = isEth ? '/images/ETH.svg' : paymentToken?.logoUrl}
+												{@const logoUrl = isNative
+													? holding.symbol === 'ETH'
+														? '/images/ETH.svg'
+														: undefined
+													: paymentToken?.logoUrl}
 												{@const decimalsForDisplay = holding.decimals === 6 ? 2 : 4}
 												<tr class="border-t border-line hover:bg-overlay-hover">
 													<td class="sticky left-0 bg-surface-1 px-2 py-2 sm:px-4 sm:py-3">
@@ -1550,7 +1575,7 @@
 																variant="primary"
 																on:click={() => goto(`/trade/${holding.id}`)}>Trade</Button
 															>
-															{#if getWrappingMappingByWrappedAddress(holding.address) && holding.walletBalanceNum > 0}
+															{#if getWrappingMappingByWrappedAddress(holding.address, $currentNetwork?.chainId) && holding.walletBalanceNum > 0}
 																<Button
 																	size="sm"
 																	variant="secondary"
@@ -1813,7 +1838,7 @@
 															>
 															<a
 																href={getRaindexVaultUrl(
-																	$currentNetwork?.chainId ?? 8453,
+																	$currentNetwork?.chainId,
 																	vault.raindex.id,
 																	vault.id
 																)}
@@ -1924,7 +1949,7 @@
 														<td class="hidden py-2 pr-2 sm:table-cell sm:py-3 sm:pr-4">
 															<a
 																href={getRaindexVaultUrl(
-																	$currentNetwork?.chainId ?? 8453,
+																	$currentNetwork?.chainId,
 																	vault.raindex.id,
 																	vault.id
 																)}
@@ -2027,12 +2052,12 @@
 									<p class="text-sm text-text-2">Raw blockchain transactions from your wallet</p>
 								</div>
 								<a
-									href={basescanUrl}
+									href={walletExplorerUrl}
 									target="_blank"
 									rel="noopener noreferrer"
 									class="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 								>
-									View all on Basescan
+									View all on block explorer
 									<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path
 											stroke-linecap="round"
@@ -2045,8 +2070,8 @@
 							</div>
 							<div class="rounded-lg border border-line bg-surface-2 p-6 text-center">
 								<p class="text-sm text-text-2">
-									Transaction history is available on Basescan. Click the link above to view all
-									your wallet transactions.
+									Transaction history is available on the selected network's block explorer. Click
+									the link above to view all your wallet transactions.
 								</p>
 							</div>
 						</div>

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -44,7 +44,7 @@
 	import { createExchangeRatesQuery, resolveRatio } from '$lib/queries/exchangeRates';
 	import { holdingsDenom } from '$lib/stores/panelDenomStore';
 	import { manualCostBasisStore, type ManualCostBasisEntry } from '$lib/stores/manualCostBasis';
-	import { derived } from 'svelte/store';
+	import { derived, type Readable } from 'svelte/store';
 	import { onDestroy } from 'svelte';
 	import transactionStore from '$lib/stores/transaction';
 	import OrdersTable from '$lib/components/orders/OrdersTable.svelte';
@@ -74,13 +74,23 @@
 	// Default vault ID (0x1 padded to 32 bytes)
 	const DEFAULT_VAULT_ID = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
-	$: apiTokensQuery = createApiTokensQuery($currentNetwork?.chainId);
+	type ApiTokensQueryValue = ReturnType<typeof createApiTokensQuery> extends Readable<infer Value>
+		? Value
+		: never;
+	const apiTokensQuery = derived(
+		currentNetwork,
+		($network, set) => {
+			const query = createApiTokensQuery($network?.chainId);
+			return query.subscribe(set);
+		},
+		undefined as ApiTokensQueryValue | undefined
+	);
 	// Default to [] (not undefined): the createQuery(derived(...)) closures below run
 	// at component init, BEFORE these reactive statements first flush. Reading
 	// ALL_TOKENS.length on an undefined value there threw an intermittent
 	// "Cannot read properties of undefined (reading 'length')" on dashboard load.
 	let ALL_TOKENS: CategorizedToken[] = [];
-	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
+	$: ALL_TOKENS = $apiTokensQuery?.data ?? [];
 	let paymentTokens: CategorizedToken[] = [];
 	$: paymentTokens = ALL_TOKENS.filter((token) => token.category === 'CRYPTO');
 
@@ -358,139 +368,162 @@
 	// We query balances on wrapped token addresses from the REST API token list since those are traded.
 	const walletHoldingsQuery = createQuery(
 		derived(
-			[isAuthenticated, walletAddress, sfts, currentNetwork, wagmiConfig],
-			([$isAuthenticated, $walletAddress, $sfts, $currentNetwork, $wagmiConfig]) => ({
-				queryKey: ['walletHoldings', $walletAddress, $currentNetwork?.id, $sfts?.length],
-				enabled: !!(
-					$isAuthenticated &&
-					$walletAddress &&
-					$sfts &&
-					$currentNetwork &&
-					$wagmiConfig &&
-					ALL_TOKENS.length
-				),
-				refetchOnMount: 'always' as const,
-				refetchInterval: QUERY_POLL_INTERVAL_MS,
-				staleTime: QUERY_STALE_TIME_MS,
-				queryFn: async () => {
-					if (!$sfts || !$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
+			[isAuthenticated, walletAddress, sfts, currentNetwork, wagmiConfig, apiTokensQuery],
+			([
+				$isAuthenticated,
+				$walletAddress,
+				$sfts,
+				$currentNetwork,
+				$wagmiConfig,
+				$apiTokensQuery
+			]) => {
+				const chainTokens = $apiTokensQuery?.data ?? [];
+				const catalogKey = chainTokens
+					.map((token) => `${token.chainId}:${token.address.toLowerCase()}`)
+					.join(',');
+				return {
+					queryKey: [
+						'walletHoldings',
+						$walletAddress,
+						$currentNetwork?.id,
+						$sfts?.length,
+						catalogKey
+					],
+					enabled: !!(
+						$isAuthenticated &&
+						$walletAddress &&
+						$sfts &&
+						$currentNetwork &&
+						$wagmiConfig &&
+						chainTokens.length
+					),
+					refetchOnMount: 'always' as const,
+					refetchInterval: QUERY_POLL_INTERVAL_MS,
+					staleTime: QUERY_STALE_TIME_MS,
+					queryFn: async () => {
+						if (!$sfts || !$walletAddress || !$currentNetwork || !$wagmiConfig) return [];
 
-					// Token details already normalize to wrapped addresses, but token lookup keeps
-					// legacy/unwrapped variants safe for older cached rows.
-					const sftsWithWrappedAddresses = $sfts.map((sft) => {
-						const tokenConfig = findApiTokenByAnyAddress(
-							ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
-							sft.address
-						);
-						return {
-							...sft,
-							wrappedAddress: tokenConfig?.address ?? sft.address
-						};
-					});
-
-					// Build multicall contracts array for all wrapped token balances
-					const contracts = sftsWithWrappedAddresses.map((sft) => ({
-						abi: erc20Abi,
-						address: sft.wrappedAddress as `0x${string}`,
-						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`],
-						chainId: $currentNetwork.chainId
-					}));
-
-					try {
-						// Single multicall for all token balances
-						const results = await readContracts($wagmiConfig, { contracts });
-
-						return sftsWithWrappedAddresses.map((sft, index) => {
-							const result = results[index];
-							let walletBalance = 0n;
-
-							if (result.status === 'success') {
-								walletBalance = result.result as bigint;
-							}
-
-							const tokenConfig = findApiTokenByAnyAddress(
-								ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
-								sft.address
-							);
-
+						// Token details already normalize to wrapped addresses, but token lookup keeps
+						// legacy/unwrapped variants safe for older cached rows.
+						const sftsWithWrappedAddresses = $sfts.map((sft) => {
+							const tokenConfig = findApiTokenByAnyAddress(chainTokens, sft.address);
 							return {
-								id: sft.id,
-								address: sft.wrappedAddress, // Use wrapped address
-								name: tokenConfig?.name ?? sft.name,
-								symbol: tokenConfig?.symbol ?? sft.symbol,
-								walletBalance,
-								decimals: 18
+								...sft,
+								wrappedAddress: tokenConfig?.address ?? sft.address
 							};
 						});
-					} catch (error) {
-						console.error('Multicall failed for wallet holdings:', error);
-						return $sfts.map((sft) => {
-							const tokenConfig = findApiTokenByAnyAddress(
-								ALL_TOKENS.filter((token) => token.chainId === $currentNetwork.chainId),
-								sft.address
-							);
-							return {
-								id: sft.id,
-								address: tokenConfig?.address ?? sft.address,
-								name: tokenConfig?.name ?? sft.name,
-								symbol: tokenConfig?.symbol ?? sft.symbol,
-								walletBalance: 0n,
-								decimals: 18
-							};
-						});
+
+						// Build multicall contracts array for all wrapped token balances
+						const contracts = sftsWithWrappedAddresses.map((sft) => ({
+							abi: erc20Abi,
+							address: sft.wrappedAddress as `0x${string}`,
+							functionName: 'balanceOf' as const,
+							args: [$walletAddress as `0x${string}`],
+							chainId: $currentNetwork.chainId
+						}));
+
+						try {
+							// Single multicall for all token balances
+							const results = await readContracts($wagmiConfig, { contracts });
+
+							return sftsWithWrappedAddresses.map((sft, index) => {
+								const result = results[index];
+								let walletBalance = 0n;
+
+								if (result.status === 'success') {
+									walletBalance = result.result as bigint;
+								}
+
+								const tokenConfig = findApiTokenByAnyAddress(chainTokens, sft.address);
+
+								return {
+									id: sft.id,
+									address: sft.wrappedAddress, // Use wrapped address
+									name: tokenConfig?.name ?? sft.name,
+									symbol: tokenConfig?.symbol ?? sft.symbol,
+									walletBalance,
+									decimals: 18
+								};
+							});
+						} catch (error) {
+							console.error('Multicall failed for wallet holdings:', error);
+							return $sfts.map((sft) => {
+								const tokenConfig = findApiTokenByAnyAddress(chainTokens, sft.address);
+								return {
+									id: sft.id,
+									address: tokenConfig?.address ?? sft.address,
+									name: tokenConfig?.name ?? sft.name,
+									symbol: tokenConfig?.symbol ?? sft.symbol,
+									walletBalance: 0n,
+									decimals: 18
+								};
+							});
+						}
 					}
-				}
-			})
+				};
+			}
 		)
 	);
 
 	// Query configured payment-token balances via multicall.
 	const usdcBalanceQuery = createQuery(
 		derived(
-			[isAuthenticated, walletAddress, currentNetwork, wagmiConfig],
-			([$isAuthenticated, $walletAddress, $currentNetwork, $wagmiConfig]) => ({
-				queryKey: ['paymentTokenWalletBalance', $walletAddress, $currentNetwork?.chainId],
-				enabled: !!($isAuthenticated && $walletAddress && $currentNetwork && $wagmiConfig),
-				refetchOnMount: 'always' as const,
-				refetchInterval: QUERY_POLL_INTERVAL_MS,
-				staleTime: QUERY_STALE_TIME_MS,
-				queryFn: async () => {
-					if (!$currentNetwork || !$walletAddress || !$wagmiConfig) return [];
-					if (paymentTokens.length === 0) return [];
+			[isAuthenticated, walletAddress, currentNetwork, wagmiConfig, apiTokensQuery],
+			([$isAuthenticated, $walletAddress, $currentNetwork, $wagmiConfig, $apiTokensQuery]) => {
+				const activePaymentTokens = ($apiTokensQuery?.data ?? []).filter(
+					(token) => token.category === 'CRYPTO'
+				);
+				const catalogKey = activePaymentTokens
+					.map((token) => `${token.chainId}:${token.address.toLowerCase()}`)
+					.join(',');
+				return {
+					queryKey: [
+						'paymentTokenWalletBalance',
+						$walletAddress,
+						$currentNetwork?.chainId,
+						catalogKey
+					],
+					enabled: !!($isAuthenticated && $walletAddress && $currentNetwork && $wagmiConfig),
+					refetchOnMount: 'always' as const,
+					refetchInterval: QUERY_POLL_INTERVAL_MS,
+					staleTime: QUERY_STALE_TIME_MS,
+					queryFn: async () => {
+						if (!$currentNetwork || !$walletAddress || !$wagmiConfig) return [];
+						if (activePaymentTokens.length === 0) return [];
 
-					const contracts = paymentTokens.map((token) => ({
-						abi: erc20Abi,
-						address: token.address as `0x${string}`,
-						functionName: 'balanceOf' as const,
-						args: [$walletAddress as `0x${string}`],
-						chainId: $currentNetwork.chainId
-					}));
+						const contracts = activePaymentTokens.map((token) => ({
+							abi: erc20Abi,
+							address: token.address as `0x${string}`,
+							functionName: 'balanceOf' as const,
+							args: [$walletAddress as `0x${string}`],
+							chainId: $currentNetwork.chainId
+						}));
 
-					try {
-						const results = await readContracts($wagmiConfig, { contracts });
-						return paymentTokens
-							.map((token, index) => {
-								const result = results[index];
-								if (result.status === 'success') {
-									return {
-										id: token.address,
-										address: token.address,
-										name: token.name,
-										symbol: token.symbol,
-										walletBalance: result.result as bigint,
-										decimals: token.decimals
-									};
-								}
-								return null;
-							})
-							.filter((balance): balance is NonNullable<typeof balance> => balance !== null);
-					} catch (error) {
-						console.error('Multicall failed for payment-token balances:', error);
-						return [];
+						try {
+							const results = await readContracts($wagmiConfig, { contracts });
+							return activePaymentTokens
+								.map((token, index) => {
+									const result = results[index];
+									if (result.status === 'success') {
+										return {
+											id: token.address,
+											address: token.address,
+											name: token.name,
+											symbol: token.symbol,
+											walletBalance: result.result as bigint,
+											decimals: token.decimals
+										};
+									}
+									return null;
+								})
+								.filter((balance): balance is NonNullable<typeof balance> => balance !== null);
+						} catch (error) {
+							console.error('Multicall failed for payment-token balances:', error);
+							return [];
+						}
 					}
-				}
-			})
+				};
+			}
 		)
 	);
 

--- a/src/routes/(main)/markets/+page.ts
+++ b/src/routes/(main)/markets/+page.ts
@@ -7,5 +7,5 @@ export const load = () => ({
 	assets: getSeoAssets(),
 	title: 'Tokenized Stocks, ETFs & Commodities | ST0x Markets',
 	description:
-		'Browse tokenized stocks, ETFs and commodities on ST0x, with 24/7 on-chain execution and non-custodial settlement on Base.'
+		'Browse tokenized stocks, ETFs and commodities on ST0x, with 24/7 on-chain execution and non-custodial settlement on supported networks.'
 });

--- a/src/routes/(main)/markets/[symbol]/+page.svelte
+++ b/src/routes/(main)/markets/[symbol]/+page.svelte
@@ -51,7 +51,7 @@
 						Trade tokenized {asset.companyName}
 					</h1>
 					<p class="mt-2 text-lg text-gray-400">
-						{asset.ticker} · {asset.tokenSymbol} on Base
+						{asset.ticker} · {asset.tokenSymbol} on ST0x
 					</p>
 				</div>
 			</div>
@@ -81,8 +81,8 @@
 						underlying listed {asset.instrumentLabel}. The issued asset token is a claim against S01
 						Issuer GmbH on the terms set out in its base prospectus; holders are unsecured
 						contractual creditors of the Issuer. On ST0x it trades as
-						<span class="font-mono text-gray-200">{asset.tokenSymbol}</span>, a vault wrapper on
-						Base whose exchange rate to the issued token can change over time.
+						<span class="font-mono text-gray-200">{asset.tokenSymbol}</span>, a vault wrapper whose
+						exchange rate to the issued token can change over time.
 					</p>
 				</div>
 
@@ -98,8 +98,8 @@
 							vaults you control; ST0x never takes custody.
 						</li>
 						<li>
-							<span class="font-medium text-white">On-chain &amp; composable.</span> Settle on Base
-							and use your tokenized {asset.ticker} across DeFi.
+							<span class="font-medium text-white">On-chain &amp; composable.</span> Settle on the
+							selected network and use your tokenized {asset.ticker} across DeFi.
 						</li>
 						<li>
 							<span class="font-medium text-white">Intent-based execution.</span> Orders are placed on-chain

--- a/src/routes/(main)/markets/[symbol]/+page.ts
+++ b/src/routes/(main)/markets/[symbol]/+page.ts
@@ -14,7 +14,7 @@ export const load = ({ params }) => {
 	}
 
 	const title = `Trade Tokenized ${asset.companyName} (${asset.ticker}) 24/7 | ST0x`;
-	const description = `Buy and sell tokenized ${asset.companyName} (${asset.ticker}) on ST0x with 24/7 on-chain execution and non-custodial settlement on Base.`;
+	const description = `Buy and sell tokenized ${asset.companyName} (${asset.ticker}) on ST0x with 24/7 on-chain execution and non-custodial settlement on supported networks.`;
 
 	return { asset, title, description };
 };

--- a/src/routes/(main)/platform-metrics/+page.svelte
+++ b/src/routes/(main)/platform-metrics/+page.svelte
@@ -8,6 +8,7 @@
 	import Table from '$lib/components/ui/table/Table.svelte';
 	import InfoBlock from '$lib/components/ui/InfoBlock.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { derived } from 'svelte/store';
 	import { onMount, onDestroy } from 'svelte';
 	import { findQuoteForSymbol } from '$lib/utils/tradingViewSymbols';
@@ -329,10 +330,13 @@
 	): number | null {
 		const restPrice = symbol ? findNetworkQuote(symbol, networkId)?.close ?? null : null;
 		if (restPrice != null) return restPrice;
+		const configuredToken = tokenAddress ? tokenForNetwork(networkId, tokenAddress) : undefined;
+		if (configuredToken?.fallbackPrice != null && configuredToken.fallbackPrice > 0) {
+			return configuredToken.fallbackPrice;
+		}
+		if (symbol && ['USD', 'USDC', 'USDT'].includes(symbol.toUpperCase())) return 1;
 
-		const network = networks.find((candidate) => candidate.chainId === networkId);
-		const paymentTokenAddress = normalizeAddress(network?.defaultPaymentToken?.address);
-		return tokenAddress && normalizeAddress(tokenAddress) === paymentTokenAddress ? 1 : null;
+		return null;
 	}
 
 	function vaultBalanceToNumber(vault: RaindexVault): number {
@@ -425,7 +429,13 @@
 						return hash ? orderHashHasTStockInput.get(hash) === true : false;
 					});
 					if (hasTStockInputOrder) {
-						total += balance; // USDC value is 1:1
+						const tokenInfo = tokenForNetwork(networkId, address);
+						const price = getNetworkPrice(
+							networkId,
+							address,
+							tokenInfo?.symbol ?? vault.token.symbol
+						);
+						if (price != null) total += balance * price;
 					}
 				}
 			});
@@ -600,8 +610,8 @@
 	// header "Live · N markets" pill. Derived from existing per-network active sets.
 	$: liveMarketCount = (() => {
 		const markets = new Set<string>();
-		activeTokensByNetwork.forEach((set) => {
-			set.forEach((address) => markets.add(address));
+		activeTokensByNetwork.forEach((set, chainId) => {
+			set.forEach((address) => markets.add(`${chainId}:${address}`));
 		});
 		return markets.size;
 	})();
@@ -753,13 +763,15 @@
 							<tr class="hover:bg-overlay-hover">
 								<td class="sticky left-0 p-2 sm:p-3 sm:text-sm">
 									<div class="flex items-center gap-2 sm:gap-3">
-										<img
-											src={stats.network.icon.startsWith('/')
-												? stats.network.icon
-												: '/images/ETH.svg'}
-											alt={stats.network.displayName}
-											class="h-8 w-8 rounded-full sm:h-10 sm:w-10"
-										/>
+										{#if stats.network.icon.startsWith('/')}
+											<img
+												src={stats.network.icon}
+												alt={stats.network.displayName}
+												class="h-8 w-8 rounded-full sm:h-10 sm:w-10"
+											/>
+										{:else}
+											<Icon name="blocks" className="h-8 w-8 text-text-3 sm:h-10 sm:w-10" />
+										{/if}
 										<div class="min-w-0">
 											<div class="truncate font-medium">{stats.network.displayName}</div>
 											<div class="hidden text-xs text-text-2 sm:block">{stats.network.name}</div>

--- a/src/routes/(main)/platform-metrics/+page.svelte
+++ b/src/routes/(main)/platform-metrics/+page.svelte
@@ -29,6 +29,7 @@
 		latest: {
 			totalTvl: number;
 			tokenTvl: Record<string, number>;
+			networks: { chainId: number; blockNumber: number; totalTvl: number }[];
 		} | null;
 	}
 
@@ -59,7 +60,11 @@
 			);
 			return tokens.filter(
 				(token, index, self) =>
-					index === self.findIndex((t) => t.address.toLowerCase() === token.address.toLowerCase())
+					index ===
+					self.findIndex(
+						(t) =>
+							t.chainId === token.chainId && t.address.toLowerCase() === token.address.toLowerCase()
+					)
 			);
 		}
 	});
@@ -243,12 +248,27 @@
 	// Token metadata helpers
 	$: ALL_TOKENS = $apiTokensQuery.data ?? [];
 
-	let tokenLookup: TokenLookup<CategorizedToken> = createTokenLookup([]);
-	$: tokenLookup = createTokenLookup(ALL_TOKENS);
+	let tokenLookupsByNetwork = new Map<number, TokenLookup<CategorizedToken>>();
+	$: tokenLookupsByNetwork = new Map(
+		networks.map((network) => [
+			network.chainId,
+			createTokenLookup(ALL_TOKENS.filter((token) => token.chainId === network.chainId))
+		])
+	);
 
-	// Create canonical token set (both ST0x and Crypto tokens)
-	$: canonicalTokens = new Set<string>(
-		ALL_TOKENS.map((token) => normalizeAddress(token.address)).filter(Boolean) as string[]
+	function tokenForNetwork(chainId: number, address: string | null | undefined) {
+		return tokenLookupsByNetwork.get(chainId)?.(address);
+	}
+
+	$: canonicalTokensByNetwork = new Map(
+		networks.map((network) => [
+			network.chainId,
+			new Set(
+				ALL_TOKENS.filter((token) => token.chainId === network.chainId)
+					.map((token) => normalizeAddress(token.address))
+					.filter(Boolean) as string[]
+			)
+		])
 	);
 
 	// Map per-network server response by chainId for quick lookup
@@ -268,7 +288,8 @@
 
 		orderbookStates.forEach(({ network, query }) => {
 			const set = map.get(network.chainId);
-			if (!set) return;
+			const canonicalTokens = canonicalTokensByNetwork.get(network.chainId);
+			if (!set || !canonicalTokens) return;
 			const summary = query?.data?.summary ?? {};
 			Object.keys(summary).forEach((address) => {
 				const normalised = normalizeAddress(address);
@@ -281,10 +302,12 @@
 		// Add tokens that had trades (per-network) from the server aggregate
 		tradeActivityByChain.forEach((entry, chainId) => {
 			const set = map.get(chainId);
-			if (!set) return;
+			const canonicalTokens = canonicalTokensByNetwork.get(chainId);
+			if (!set || !canonicalTokens) return;
 			entry.tokens.forEach((row) => {
-				if (row.trades > 0 && canonicalTokens.has(row.address)) {
-					set.add(row.address);
+				const normalised = normalizeAddress(row.address);
+				if (row.trades > 0 && normalised && canonicalTokens.has(normalised)) {
+					set.add(normalised);
 				}
 			});
 		});
@@ -321,17 +344,27 @@
 	$: totalTrades = tradeActivity?.totals.totalTrades ?? 0;
 
 	// Build a set of tStock addresses for identification
-	$: tStockAddresses = new Set<string>(
-		ALL_TOKENS.filter((t) => t.category === 'ST0x')
-			.map((t) => normalizeAddress(t.address))
-			.filter(Boolean) as string[]
+	$: tStockAddressesByNetwork = new Map(
+		networks.map((network) => [
+			network.chainId,
+			new Set(
+				ALL_TOKENS.filter((token) => token.chainId === network.chainId && token.category === 'ST0x')
+					.map((token) => normalizeAddress(token.address))
+					.filter(Boolean) as string[]
+			)
+		])
 	);
 
 	// Build payment token addresses for each network
-	$: paymentTokenAddresses = new Set<string>(
-		networks
-			.map((n) => normalizeAddress(n.defaultPaymentToken?.address))
-			.filter(Boolean) as string[]
+	$: paymentTokenAddressesByNetwork = new Map(
+		networks.map((network) => [
+			network.chainId,
+			new Set(
+				network.paymentTokens
+					.map((token) => normalizeAddress(token.address))
+					.filter(Boolean) as string[]
+			)
+		])
 	);
 
 	// Calculate DEX Liquidity:
@@ -344,7 +377,8 @@
 		// First, build a map of orderHash -> whether order has a tStock as input
 		// This is done by looking at all vaults' ordersAsInput
 		const orderHashHasTStockInput = new Map<string, boolean>();
-		vaultsByNetwork.forEach((vaults) => {
+		vaultsByNetwork.forEach((vaults, networkId) => {
+			const tStockAddresses = tStockAddressesByNetwork.get(networkId) ?? new Set<string>();
 			vaults.forEach((vault) => {
 				const address = normalizeAddress(vault.token.address);
 				const isTStock = address ? tStockAddresses.has(address) : false;
@@ -362,6 +396,9 @@
 
 		// Now calculate DEX liquidity
 		vaultsByNetwork.forEach((vaults, networkId) => {
+			const tStockAddresses = tStockAddressesByNetwork.get(networkId) ?? new Set<string>();
+			const paymentTokenAddresses =
+				paymentTokenAddressesByNetwork.get(networkId) ?? new Set<string>();
 			vaults.forEach((vault) => {
 				const address = normalizeAddress(vault.token.address);
 				if (!address) return;
@@ -376,7 +413,7 @@
 
 				if (isTStock) {
 					// Part 1: tStock in output vaults - get USDC value
-					const tokenInfo = tokenLookup(address);
+					const tokenInfo = tokenForNetwork(networkId, address);
 					const symbol = tokenInfo?.symbol ?? vault.token.symbol;
 					const price = getNetworkPrice(networkId, address, symbol) ?? 0;
 					total += balance * price;
@@ -410,6 +447,7 @@
 	}
 
 	$: networkStats = networks.map<NetworkStat>((network) => {
+		const tStockAddresses = tStockAddressesByNetwork.get(network.chainId) ?? new Set<string>();
 		const vaults = getActiveVaultsForNetwork(network.chainId);
 		const allNetworkVaults = vaultsByNetwork.get(network.chainId) ?? [];
 
@@ -430,7 +468,7 @@
 		// Calculate TVL using aggregated balances - one price lookup per token
 		let tvl = 0;
 		tokenBalances.forEach((balance, address) => {
-			const tokenInfo = tokenLookup(address);
+			const tokenInfo = tokenForNetwork(network.chainId, address);
 			const symbol = tokenInfo?.symbol;
 			const price = getNetworkPrice(network.chainId, address, symbol) ?? 0;
 			tvl += balance * price;
@@ -468,7 +506,7 @@
 			if (!hasOrdersAsOutput) return;
 
 			if (isTStock) {
-				const tokenInfo = tokenLookup(address);
+				const tokenInfo = tokenForNetwork(network.chainId, address);
 				const symbol = tokenInfo?.symbol ?? vault.token.symbol;
 				const price = getNetworkPrice(network.chainId, address, symbol) ?? 0;
 				networkDexLiquidity += balance * price;
@@ -499,7 +537,7 @@
 		let networkTvl = 0;
 		ALL_TOKENS.filter((t) => t.chainId === network.chainId && t.category === 'ST0x').forEach(
 			(token) => {
-				const tokenTvl = adminTokenTvl[token.symbol] ?? 0;
+				const tokenTvl = adminTokenTvl[`${network.chainId}:${token.symbol}`] ?? 0;
 				networkTvl += tokenTvl;
 			}
 		);
@@ -587,8 +625,8 @@
 						Platform metrics
 					</h1>
 					<p class="mt-2 max-w-xl text-[15px] text-text-2">
-						Onchain activity across st0x — every figure is read from Base mainnet and refreshes each
-						block.
+						Onchain activity across st0x — every figure is read from the active registry networks
+						and refreshes each block.
 					</p>
 				</div>
 				<div
@@ -716,11 +754,9 @@
 								<td class="sticky left-0 p-2 sm:p-3 sm:text-sm">
 									<div class="flex items-center gap-2 sm:gap-3">
 										<img
-											src={stats.network.chainId === 42161
-												? '/images/ARB.svg'
-												: stats.network.chainId === 8453
-													? '/images/BASE.svg'
-													: '/images/ETH.svg'}
+											src={stats.network.icon.startsWith('/')
+												? stats.network.icon
+												: '/images/ETH.svg'}
 											alt={stats.network.displayName}
 											class="h-8 w-8 rounded-full sm:h-10 sm:w-10"
 										/>

--- a/src/routes/(main)/trade/[id]/+layout.ts
+++ b/src/routes/(main)/trade/[id]/+layout.ts
@@ -3,13 +3,18 @@ import type { ApiToken } from '$lib/api/st0xApi';
 import { findApiTokenByAnyAddress, normalizeApiTokensForNetwork } from '$lib/queries/tokens';
 import { getTokenByAnyAddress } from '$lib/config/tokens';
 import { buildTradeDescription, buildTradeTitle, getTradeSeoMetadata } from '$lib/seo/trade';
+import { currentNetwork } from '$lib/stores';
+import { get } from 'svelte/store';
 
 export const ssr = false;
 export const prerender = false;
 
-export async function load({ params, fetch }) {
+export async function load({ params, fetch, parent }) {
 	const tokenId = params.id;
-	const staticToken = getTokenByAnyAddress(tokenId);
+	const parentData = await parent();
+	const chainId = get(currentNetwork)?.chainId ?? parentData.networkCatalog?.[0]?.chainId;
+	if (!chainId) return getTradeSeoMetadata(`/trade/${tokenId}`) ?? {};
+	const staticToken = getTokenByAnyAddress(tokenId, chainId);
 	if (staticToken && staticToken.address.toLowerCase() !== tokenId.toLowerCase()) {
 		throw redirect(301, `/trade/${staticToken.address}`);
 	}
@@ -22,7 +27,7 @@ export async function load({ params, fetch }) {
 
 	const fallbackMetadata = getTradeSeoMetadata(`/trade/${tokenId}`);
 
-	const response = await fetch('/api/st0x/v1/tokens');
+	const response = await fetch(`/api/st0x/v2/tokens?chainId=${chainId}`);
 	if (!response.ok) {
 		return {
 			title: fallbackMetadata?.title,
@@ -30,7 +35,7 @@ export async function load({ params, fetch }) {
 		};
 	}
 
-	const tokens = normalizeApiTokensForNetwork((await response.json()) as ApiToken[], 8453);
+	const tokens = normalizeApiTokensForNetwork((await response.json()) as ApiToken[], chainId);
 	const token = findApiTokenByAnyAddress(tokens, tokenId);
 	if (token && token.address.toLowerCase() !== tokenId.toLowerCase()) {
 		throw redirect(301, `/trade/${token.address}`);

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -120,7 +120,7 @@
 		currentToken?.address ?? null
 	);
 	let midpointPricesQuery = createMidpointPricesQuery($currentNetwork);
-	const exchangeRatesQuery = createExchangeRatesQuery();
+	$: exchangeRatesQuery = createExchangeRatesQuery($currentNetwork?.chainId);
 	$: {
 		orderbookQuotesQuery = createTokenOrderbookQuotesQuery(
 			$currentNetwork,
@@ -341,14 +341,15 @@
 	$: walletBalanceQuery = createQuery({
 		queryKey: ['walletBalance', $currentNetwork?.id, currentToken?.address, $walletAddress],
 		queryFn: async () => {
-			if (!currentToken?.address || !$walletAddress || !$wagmiConfig) {
+			if (!currentToken?.address || !$walletAddress || !$currentNetwork || !$wagmiConfig) {
 				return 0n;
 			}
 			const balance = await readContract($wagmiConfig, {
 				abi: erc20Abi,
 				address: currentToken.address as `0x${string}`,
 				functionName: 'balanceOf',
-				args: [$walletAddress as `0x${string}`]
+				args: [$walletAddress as `0x${string}`],
+				chainId: $currentNetwork.chainId
 			});
 			return balance as bigint;
 		},
@@ -958,7 +959,7 @@
 							>{currentApiToken?.symbol ?? currentToken.symbol}</span
 						>
 						<span class="text-text-muted">·</span>
-						<span>Wrapped tStock on {$currentNetwork.displayName}</span>
+						<span>Wrapped tStock on {$currentNetwork?.displayName ?? 'the selected network'}</span>
 					</div>
 				</div>
 				<WrapRatioChip
@@ -1404,7 +1405,7 @@
 															.toString(16)
 															.padStart(64, '0')}`}
 														{@const raindexUrl = getRaindexVaultUrl(
-															$currentNetwork?.chainId ?? 8453,
+															$currentNetwork?.chainId,
 															vault.raindex,
 															vault.id
 														)}
@@ -1554,8 +1555,8 @@
 									<div>
 										<div class="sm:hidden">
 											<ExternalLink
-												href="{$currentNetwork.blockExplorer}/token/{currentApiToken?.address ??
-													tokenId}"
+												href="{$currentNetwork?.blockExplorer ??
+													'https://blockscan.com'}/token/{currentApiToken?.address ?? tokenId}"
 												label={currentApiToken?.address ?? tokenId}
 												truncate={{ start: 0, end: 6 }}
 												className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
@@ -1563,8 +1564,8 @@
 										</div>
 										<div class="hidden sm:block">
 											<ExternalLink
-												href="{$currentNetwork.blockExplorer}/token/{currentApiToken?.address ??
-													tokenId}"
+												href="{$currentNetwork?.blockExplorer ??
+													'https://blockscan.com'}/token/{currentApiToken?.address ?? tokenId}"
 												label={truncateAddress(currentApiToken?.address ?? tokenId)}
 												className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 											/>
@@ -1577,7 +1578,8 @@
 										<div>
 											<div class="sm:hidden">
 												<ExternalLink
-													href="{$currentNetwork.blockExplorer}/token/{currentApiToken.unwrappedAddress}"
+													href="{$currentNetwork?.blockExplorer ??
+														'https://blockscan.com'}/token/{currentApiToken.unwrappedAddress}"
 													label={currentApiToken.unwrappedAddress}
 													truncate={{ start: 0, end: 6 }}
 													className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
@@ -1585,7 +1587,8 @@
 											</div>
 											<div class="hidden sm:block">
 												<ExternalLink
-													href="{$currentNetwork.blockExplorer}/token/{currentApiToken.unwrappedAddress}"
+													href="{$currentNetwork?.blockExplorer ??
+														'https://blockscan.com'}/token/{currentApiToken.unwrappedAddress}"
 													label={truncateAddress(currentApiToken.unwrappedAddress)}
 													className="flex items-center gap-1 font-mono text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
 												/>
@@ -1595,7 +1598,7 @@
 								{/if}
 								<div class="flex justify-between py-2.5">
 									<span class="text-text-2">Network</span>
-									<span>{$currentNetwork.displayName}</span>
+									<span>{$currentNetwork?.displayName ?? 'Unknown network'}</span>
 								</div>
 								<div class="flex justify-between py-2.5">
 									<span class="text-text-2">Symbol</span>
@@ -1964,8 +1967,8 @@
 								{/if}
 								<div class="flex items-center gap-1 text-xs text-text-2 sm:gap-2 sm:text-sm">
 									<span>On</span>
-									<img src="/images/BASE.svg" alt="Base" class="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-									<span>{$currentNetwork.displayName}</span>
+									<img src="/images/ETH.svg" alt="Network" class="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+									<span>{$currentNetwork?.displayName ?? 'Unknown network'}</span>
 								</div>
 								{#if hasRatio}
 									<label

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -1967,7 +1967,15 @@
 								{/if}
 								<div class="flex items-center gap-1 text-xs text-text-2 sm:gap-2 sm:text-sm">
 									<span>On</span>
-									<img src="/images/ETH.svg" alt="Network" class="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+									{#if $currentNetwork?.icon.startsWith('/')}
+										<img
+											src={$currentNetwork.icon}
+											alt={$currentNetwork.displayName}
+											class="h-3.5 w-3.5 sm:h-4 sm:w-4"
+										/>
+									{:else}
+										<Icon name="blocks" className="h-3.5 w-3.5 text-text-3 sm:h-4 sm:w-4" />
+									{/if}
 									<span>{$currentNetwork?.displayName ?? 'Unknown network'}</span>
 								</div>
 								{#if hasRatio}

--- a/src/routes/(main)/trade/[id]/proofs/+layout.svelte
+++ b/src/routes/(main)/trade/[id]/proofs/+layout.svelte
@@ -12,8 +12,8 @@
 
 	$: query = createQuery({
 		queryKey: ['getTokenProofs', id, $currentNetwork?.id],
-		enabled: Boolean(browser && id),
-		queryFn: () => apiGetTokenProofs(id)
+		enabled: Boolean(browser && id && $currentNetwork),
+		queryFn: () => apiGetTokenProofs(id, $currentNetwork!.chainId)
 	});
 
 	$: if ($query && $query.data) {
@@ -34,7 +34,9 @@
 				(wrappedAddress && v.address?.toLowerCase() === wrappedAddress)
 		);
 		if ($query?.data) {
-			const token = getTokenByAnyAddress(id) ?? getTokenByAnyAddress($query.data.address);
+			const token =
+				getTokenByAnyAddress(id, $currentNetwork?.chainId) ??
+				getTokenByAnyAddress($query.data.address, $currentNetwork?.chainId);
 			currentToken.set({
 				...(foundInSfts ?? {}),
 				id: $query.data.address,

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,4 @@
+import type { LayoutServerLoad } from './$types';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
+
+export const load: LayoutServerLoad = async () => getServerApplicationCatalog();

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,11 @@
-import type { LayoutServerLoad } from './$types';
 import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
+import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async () => getServerApplicationCatalog();
+export const load: LayoutServerLoad = async () => {
+	try {
+		return { ...(await getServerApplicationCatalog()), catalogUnavailable: false };
+	} catch (error) {
+		console.error('[layout] Application catalog unavailable:', error);
+		return { tokenCatalog: [], networkCatalog: [], catalogUnavailable: true };
+	}
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,11 @@
 	import type { Network } from '$lib/config/networks';
 	import { hydrateNetworkCatalog } from '$lib/stores';
 
-	export let data: { tokenCatalog?: CategorizedToken[]; networkCatalog?: Network[] };
+	export let data: {
+		tokenCatalog?: CategorizedToken[];
+		networkCatalog?: Network[];
+		catalogUnavailable?: boolean;
+	};
 
 	function hydrateCatalogs(tokens: CategorizedToken[], networkCatalog: Network[]): void {
 		replaceTokenCatalog(tokens);
@@ -146,7 +150,8 @@
 
 		const configuredNetworks = data.networkCatalog ?? [];
 		if (configuredNetworks.length === 0) {
-			throw new Error('The active registry contains no wallet networks');
+			console.error('[wallet] The application catalog contains no wallet networks');
+			return;
 		}
 		const chains = configuredNetworks.map((network) =>
 			defineChain({
@@ -268,6 +273,14 @@
 </svelte:head>
 
 <QueryClientProvider client={queryClient}>
+	{#if data.catalogUnavailable}
+		<div
+			class="border-b border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-center text-sm text-yellow-200"
+			role="alert"
+		>
+			Network data is temporarily unavailable. Trading and wallet actions are disabled.
+		</div>
+	{/if}
 	<!-- Dynamic SDK wrapper (invisible, handles auth state) -->
 	{#if DynamicSvelteWrapper}
 		<svelte:component this={DynamicSvelteWrapper} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,24 @@
 	import { browser } from '$app/environment';
 	import { env as publicEnv } from '$env/dynamic/public';
 	import { removeInjectedTradeSeoHead, syncTradeRobotsMeta } from '$lib/seo/trade';
+	import { replaceTokenCatalog, type CategorizedToken } from '$lib/config/tokens';
+	import type { Network } from '$lib/config/networks';
+	import { hydrateNetworkCatalog } from '$lib/stores';
+
+	export let data: { tokenCatalog?: CategorizedToken[]; networkCatalog?: Network[] };
+
+	function hydrateCatalogs(tokens: CategorizedToken[], networkCatalog: Network[]): void {
+		replaceTokenCatalog(tokens);
+		hydrateNetworkCatalog(networkCatalog);
+		for (const chainId of new Set(tokens.map((token) => token.chainId))) {
+			queryClient.setQueryData(
+				['st0xApiTokens', chainId],
+				tokens.filter((token) => token.chainId === chainId)
+			);
+		}
+	}
+
+	$: hydrateCatalogs(data.tokenCatalog ?? [], data.networkCatalog ?? []);
 
 	// Site-wide SEO defaults. Pages override the title via their own <svelte:head>
 	// (Svelte keeps the last <title>), or by returning `title`/`description` from a
@@ -100,27 +118,21 @@
 	}
 
 	const initWallet = async () => {
-		// svelte-wagmi's defaultConfig uses bare `http()` → public Base RPCs that
-		// rate-limit under load. Build the same stores/modal setup with an explicit
-		// fallback transport using the active registry's ordered Base RPC list.
+		// Build wagmi from every network and ordered RPC list in the active registry.
 		const [
 			{ wagmiConfig, web3Modal, wagmiLoaded, configuredConnectors, init },
-			{ base },
 			{ injected, walletConnect },
 			{ createConfig, reconnect },
 			{ createWeb3Modal },
 			{ createClientRpcTransport },
-			{ getBrowserRaindexRpcUrls },
-			{ networks }
+			{ defineChain }
 		] = await Promise.all([
 			import('svelte-wagmi'),
-			import('@wagmi/core/chains'),
 			import('@wagmi/connectors'),
 			import('@wagmi/core'),
 			import('@web3modal/wagmi'),
 			import('$lib/config/clientRpc'),
-			import('$lib/clients/raindexSettings'),
-			import('$lib/config/networks')
+			import('viem')
 		]);
 
 		const projectId = publicEnv?.PUBLIC_WALLETCONNECT_ID || '';
@@ -132,27 +144,38 @@
 
 		configuredConnectors.set(connectorsList);
 
-		const configuredBaseNetwork = networks.find((network) => network.chainId === base.id);
-		const configuredBaseRpcUrls = configuredBaseNetwork
-			? [configuredBaseNetwork.rpcUrl, ...configuredBaseNetwork.fallbackRpcUrls]
-			: base.rpcUrls.default.http;
-		let rpcUrls: readonly string[];
-		try {
-			rpcUrls = await getBrowserRaindexRpcUrls(base.id);
-		} catch (error) {
-			// Wallet connectivity should survive a temporary registry outage.
-			// The statically configured list is an emergency fallback only; successful
-			// registry loads always use the complete operator-controlled list.
-			console.warn('[wallet] Failed to load registry RPCs; using configured Base RPCs:', error);
-			rpcUrls = configuredBaseRpcUrls;
+		const configuredNetworks = data.networkCatalog ?? [];
+		if (configuredNetworks.length === 0) {
+			throw new Error('The active registry contains no wallet networks');
 		}
+		const chains = configuredNetworks.map((network) =>
+			defineChain({
+				id: network.chainId,
+				name: network.displayName,
+				nativeCurrency: {
+					name: network.currencySymbol,
+					symbol: network.currencySymbol,
+					decimals: 18
+				},
+				rpcUrls: {
+					default: { http: [network.rpcUrl, ...network.fallbackRpcUrls] }
+				},
+				blockExplorers: {
+					default: { name: 'Blockscan', url: network.blockExplorer }
+				}
+			})
+		);
+		const transports = Object.fromEntries(
+			configuredNetworks.map((network) => [
+				network.chainId,
+				createClientRpcTransport([network.rpcUrl, ...network.fallbackRpcUrls])
+			])
+		);
 
 		const config = createConfig({
-			chains: [base],
+			chains: chains as [(typeof chains)[number], ...typeof chains],
 			connectors: connectorsList,
-			transports: {
-				[base.id]: createClientRpcTransport(rpcUrls)
-			}
+			transports
 		});
 
 		wagmiConfig.set(config);

--- a/src/routes/api/auth/session/+server.ts
+++ b/src/routes/api/auth/session/+server.ts
@@ -5,6 +5,7 @@ import { rateLimiters, applyRateLimit } from '$lib/server/rateLimit';
 import { verifyWalletSignature } from '$lib/server/accessCodes';
 import { verifySessionLoginChallenge } from '$lib/server/signatureChallenge';
 import { createSession } from '$lib/server/walletSession';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 // SEC-03 / Plan 03-08a: verify the user's signature over the 'session_login'
 // nonce → mint an HttpOnly + Secure + SameSite=Strict 'session' cookie bound
@@ -19,7 +20,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	if (rateLimitResponse) return rateLimitResponse;
 
 	try {
-		const { address, nonce, signature } = await request.json();
+		const { address, nonce, signature, chainId: requestedChainId } = await request.json();
 
 		if (!address || typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
 			return json({ error: 'Invalid wallet address' }, { status: 400 });
@@ -39,10 +40,19 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			);
 		}
 
+		const { networkCatalog } = await getServerApplicationCatalog();
+		if (requestedChainId === undefined && networkCatalog.length !== 1) {
+			return json({ error: 'chainId is required' }, { status: 400 });
+		}
+		const chainId = requestedChainId ?? networkCatalog[0]?.chainId;
+		const network = networkCatalog.find((candidate) => candidate.chainId === chainId);
+		if (!network) return json({ error: 'Unsupported chainId' }, { status: 400 });
+
 		const valid = await verifyWalletSignature(
 			address,
 			challenge.message,
-			signature as `0x${string}`
+			signature as `0x${string}`,
+			network
 		);
 		if (!valid) {
 			return json({ success: false, error: 'Signature verification failed' }, { status: 401 });

--- a/src/routes/api/auth/session/+server.ts
+++ b/src/routes/api/auth/session/+server.ts
@@ -19,8 +19,23 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	const rateLimitResponse = await applyRateLimit(request, rateLimiters.authStrict, 'session-login');
 	if (rateLimitResponse) return rateLimitResponse;
 
+	let body: unknown;
 	try {
-		const { address, nonce, signature, chainId: requestedChainId } = await request.json();
+		body = await request.json();
+	} catch {
+		return json({ error: 'Invalid request body' }, { status: 400 });
+	}
+
+	try {
+		if (!body || typeof body !== 'object' || Array.isArray(body)) {
+			return json({ error: 'Invalid request body' }, { status: 400 });
+		}
+		const {
+			address,
+			nonce,
+			signature,
+			chainId: requestedChainId
+		} = body as Record<string, unknown>;
 
 		if (!address || typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
 			return json({ error: 'Invalid wallet address' }, { status: 400 });
@@ -41,6 +56,9 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		}
 
 		const { networkCatalog } = await getServerApplicationCatalog();
+		if (requestedChainId !== undefined && !Number.isSafeInteger(requestedChainId)) {
+			return json({ error: 'chainId must be an integer' }, { status: 400 });
+		}
 		if (requestedChainId === undefined && networkCatalog.length !== 1) {
 			return json({ error: 'chainId is required' }, { status: 400 });
 		}
@@ -69,7 +87,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		});
 
 		return json({ success: true, walletAddress: address.toLowerCase(), expiresAt });
-	} catch {
-		return json({ error: 'Invalid request body' }, { status: 400 });
+	} catch (error) {
+		console.error('[auth/session] Session creation failed:', error);
+		return json({ error: 'Unable to create session' }, { status: 500 });
 	}
 };

--- a/src/routes/api/auth/session/server.test.ts
+++ b/src/routes/api/auth/session/server.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	verifyWalletSignature: vi.fn(),
+	verifySessionLoginChallenge: vi.fn(),
+	createSession: vi.fn(),
+	getServerApplicationCatalog: vi.fn()
+}));
+
+vi.mock('$app/environment', () => ({ dev: true }));
+vi.mock('$lib/server/rateLimit', () => ({
+	rateLimiters: { authStrict: {} },
+	applyRateLimit: vi.fn(async () => null)
+}));
+vi.mock('$lib/server/accessCodes', () => ({
+	verifyWalletSignature: mocks.verifyWalletSignature
+}));
+vi.mock('$lib/server/signatureChallenge', () => ({
+	verifySessionLoginChallenge: mocks.verifySessionLoginChallenge
+}));
+vi.mock('$lib/server/walletSession', () => ({ createSession: mocks.createSession }));
+vi.mock('$lib/server/applicationCatalog', () => ({
+	getServerApplicationCatalog: mocks.getServerApplicationCatalog
+}));
+
+import { POST } from './+server';
+
+const ADDRESS = '0x1111111111111111111111111111111111111111';
+const NETWORK = { id: 8453, chainId: 8453 };
+type SessionEvent = Parameters<typeof POST>[0];
+
+function event(body: unknown): SessionEvent {
+	return {
+		request: new Request('http://localhost/api/auth/session', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body)
+		}),
+		cookies: { set: vi.fn() }
+	} as unknown as SessionEvent;
+}
+
+function validBody(chainId: unknown = 8453) {
+	return { address: ADDRESS, nonce: 'nonce', signature: '0xsignature', chainId };
+}
+
+describe('/api/auth/session', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.verifySessionLoginChallenge.mockResolvedValue({ valid: true, message: 'challenge' });
+		mocks.getServerApplicationCatalog.mockResolvedValue({
+			tokenCatalog: [],
+			networkCatalog: [NETWORK, { id: 10, chainId: 10 }]
+		});
+		mocks.verifyWalletSignature.mockResolvedValue(true);
+		mocks.createSession.mockResolvedValue({ sessionId: 'session', expiresAt: 123 });
+	});
+
+	it.each([null, '8453', 8453.5, Number.NaN])(
+		'rejects an invalid chainId value: %s',
+		async (chainId) => {
+			const response = await POST(event(validBody(chainId)));
+
+			expect(response.status).toBe(400);
+			expect(await response.json()).toEqual({ error: 'chainId must be an integer' });
+			expect(mocks.verifyWalletSignature).not.toHaveBeenCalled();
+		}
+	);
+
+	it('verifies a valid numeric chain against the requested network', async () => {
+		const response = await POST(event(validBody()));
+
+		expect(response.status).toBe(200);
+		expect(mocks.verifyWalletSignature).toHaveBeenCalledWith(
+			ADDRESS,
+			'challenge',
+			'0xsignature',
+			NETWORK
+		);
+	});
+
+	it('reports catalog failures as server errors rather than malformed JSON', async () => {
+		mocks.getServerApplicationCatalog.mockRejectedValue(new Error('catalog unavailable'));
+
+		const response = await POST(event(validBody()));
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({ error: 'Unable to create session' });
+	});
+});

--- a/src/routes/api/cron/snapshots/+server.ts
+++ b/src/routes/api/cron/snapshots/+server.ts
@@ -21,6 +21,7 @@ import {
 	type SnapshotBlockRecord,
 	type DailySnapshotRecord
 } from '$lib/server/kv';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 // Pick a random block within a range
 function pickRandomBlock(startBlock: number, endBlock: number): number {
@@ -67,54 +68,52 @@ export const GET: RequestHandler = async ({ request }) => {
 		console.log(`[Cron] Generating snapshots for ${dateStr}`);
 		console.log(`[Cron] Timestamp range: ${startTimestamp} - ${endTimestamp}`);
 
-		// Get block range for yesterday
-		const startBlock = await getBlockNumberForTimestamp(startTimestamp);
-		const endBlock = await getBlockNumberForTimestamp(endTimestamp);
+		const { networkCatalog } = await getServerApplicationCatalog();
+		const storedBlobs: { chainId: number; block: number; token: string; url: string }[] = [];
+		const blockRecords: SnapshotBlockRecord[] = [];
 
-		console.log(`[Cron] Block range: ${startBlock} - ${endBlock}`);
-
-		// Pick 2 random blocks - one from first half of day, one from second half
-		const [block1, block2] = pickRandomBlocksFromHalves(startBlock, endBlock);
-
-		console.log(`[Cron] Selected blocks: ${block1} (first half), ${block2} (second half)`);
-
-		const storedBlobs: { block: number; token: string; url: string }[] = [];
-
-		// Process a single block: generate snapshots, upload to blob.
-		// Per-wallet points calculation removed in Phase 1 (DEPR-02 D-03).
-		const processBlock = async (blockNumber: number) => {
-			const [snapshots, timestamp] = await Promise.all([
-				generateAllTokenSnapshots(blockNumber),
-				getBlockTimestamp(blockNumber)
+		for (const network of networkCatalog) {
+			const [startBlock, endBlock] = await Promise.all([
+				getBlockNumberForTimestamp(network, startTimestamp),
+				getBlockNumberForTimestamp(network, endTimestamp)
 			]);
-
-			console.log(`[Cron] Generated ${snapshots.length} token snapshots for block ${blockNumber}`);
-
-			// Upload all token snapshots in parallel
-			const blobResults = await Promise.all(
-				snapshots.map(async (snapshot) => {
-					const blobPath = `snapshots/${snapshot.tokenSymbol}/${blockNumber}.json`;
-					const blob = await put(blobPath, JSON.stringify(snapshot, null, 2), {
-						access: 'public',
-						contentType: 'application/json'
-					});
-					console.log(`[Cron] Stored ${snapshot.tokenSymbol} at block ${blockNumber}`);
-					return { block: blockNumber, token: snapshot.tokenSymbol, url: blob.url };
-				})
+			const [block1, block2] = pickRandomBlocksFromHalves(startBlock, endBlock);
+			console.log(
+				`[Cron] Chain ${network.chainId} selected blocks: ${block1} (first half), ${block2} (second half)`
 			);
 
-			storedBlobs.push(...blobResults);
+			const processBlock = async (blockNumber: number): Promise<SnapshotBlockRecord> => {
+				const [snapshots, timestamp] = await Promise.all([
+					generateAllTokenSnapshots(network, blockNumber),
+					getBlockTimestamp(network, blockNumber)
+				]);
+				const blobResults = await Promise.all(
+					snapshots.map(async (snapshot) => {
+						const blobPath = `snapshots/${network.chainId}/${snapshot.tokenSymbol}/${blockNumber}.json`;
+						const blob = await put(blobPath, JSON.stringify(snapshot, null, 2), {
+							access: 'public',
+							contentType: 'application/json'
+						});
+						return {
+							chainId: network.chainId,
+							block: blockNumber,
+							token: snapshot.tokenSymbol,
+							url: blob.url
+						};
+					})
+				);
+				storedBlobs.push(...blobResults);
+				return {
+					chainId: network.chainId,
+					blockNumber,
+					timestamp,
+					date: dateStr,
+					generatedAt: new Date().toISOString()
+				};
+			};
 
-			return {
-				blockNumber,
-				timestamp,
-				date: dateStr,
-				generatedAt: new Date().toISOString()
-			} satisfies SnapshotBlockRecord;
-		};
-
-		// Generate both blocks in parallel
-		const blockRecords = await Promise.all([processBlock(block1), processBlock(block2)]);
+			blockRecords.push(...(await Promise.all([processBlock(block1), processBlock(block2)])));
+		}
 
 		// Store block records in KV
 		const kv = await getKv();

--- a/src/routes/api/cron/snapshots/+server.ts
+++ b/src/routes/api/cron/snapshots/+server.ts
@@ -131,8 +131,9 @@ export const GET: RequestHandler = async ({ request }) => {
 			const allBlocks = (await kvGet<SnapshotBlockRecord[]>(KV_KEYS.snapshotBlocks())) || [];
 			allBlocks.push(...blockRecords);
 
-			// Keep only last 365 days worth of blocks (730 records at 2 per day)
-			const trimmedBlocks = allBlocks.slice(-730);
+			// Retain a full year independently of how many networks are active.
+			const retentionCutoff = Math.floor(now.getTime() / 1000) - 365 * 24 * 60 * 60;
+			const trimmedBlocks = allBlocks.filter((record) => record.timestamp >= retentionCutoff);
 			await kvSet(KV_KEYS.snapshotBlocks(), trimmedBlocks);
 
 			console.log(`[Cron] Stored block records in KV`);

--- a/src/routes/api/public/prices/+server.ts
+++ b/src/routes/api/public/prices/+server.ts
@@ -20,6 +20,7 @@ import {
 } from '$lib/server/marketPrices';
 import type { MidpointPrice } from '$lib/utils/midpointPrice';
 import { logQueryFailure, errorMessage } from '$lib/utils/monitoring';
+import { ensureServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 export type PublicPricesResponse =
 	| PublicPricesSnapshot
@@ -50,6 +51,7 @@ async function computePrices(): Promise<PublicPricesSnapshot> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
+	await ensureServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 

--- a/src/routes/api/public/prices/+server.ts
+++ b/src/routes/api/public/prices/+server.ts
@@ -51,7 +51,6 @@ async function computePrices(): Promise<PublicPricesSnapshot> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
-	await ensureServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 
@@ -70,6 +69,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
+		await ensureServerApplicationCatalog();
 		const cached = await getCachedPublicPrices(computePrices);
 
 		return json(cached.value, {

--- a/src/routes/api/public/prices/server.test.ts
+++ b/src/routes/api/public/prices/server.test.ts
@@ -24,6 +24,10 @@ vi.mock('$lib/server/kv', () => ({
 	}
 }));
 
+vi.mock('$lib/server/applicationCatalog', () => ({
+	ensureServerApplicationCatalog: vi.fn(async () => undefined)
+}));
+
 import { env } from '$env/dynamic/private';
 import { networks } from '$lib/config/network';
 import { clearPublicPricesMemoryCache } from '$lib/server/publicPricesCache';
@@ -65,7 +69,7 @@ describe('/api/public/prices', () => {
 		expect(response.status).toBe(200);
 		expect(fetchMock).toHaveBeenCalledTimes(networks.length);
 		for (const [url, init] of fetchMock.mock.calls) {
-			expect(String(url)).toMatch(/^https:\/\/api\.example\.test\/v1\/prices\?chainId=\d+$/);
+			expect(String(url)).toMatch(/^https:\/\/api\.example\.test\/v2\/prices\?chainId=\d+$/);
 			if (!init) throw new Error('Expected batch request options');
 			const headers = init.headers as Record<string, string>;
 			expect(headers.Authorization).toBe('Basic cHJpY2VzLWtleTpwcmljZXMtc2VjcmV0');

--- a/src/routes/api/public/trade-activity/+server.ts
+++ b/src/routes/api/public/trade-activity/+server.ts
@@ -18,6 +18,7 @@ import {
 	St0xTradesRateLimitError
 } from '$lib/server/st0xTradesFetcher';
 import { getSt0xActivityApiConfig } from '$lib/server/st0xApiConfig';
+import { ensureServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 export type {
 	NetworkTradeStats,
@@ -51,6 +52,7 @@ async function computeTradeActivity(): Promise<PublicTradeActivitySnapshot> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
+	await ensureServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 

--- a/src/routes/api/public/trade-activity/+server.ts
+++ b/src/routes/api/public/trade-activity/+server.ts
@@ -52,7 +52,6 @@ async function computeTradeActivity(): Promise<PublicTradeActivitySnapshot> {
 }
 
 export const GET: RequestHandler = async ({ request }) => {
-	await ensureServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 
@@ -71,6 +70,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
+		await ensureServerApplicationCatalog();
 		const data = await getCachedPublicTradeActivity(computeTradeActivity);
 		return json(data, {
 			headers: {

--- a/src/routes/api/public/trade-activity/server.test.ts
+++ b/src/routes/api/public/trade-activity/server.test.ts
@@ -19,6 +19,10 @@ vi.mock('$lib/server/kv', () => ({
 	getKv: vi.fn(async () => null)
 }));
 
+vi.mock('$lib/server/applicationCatalog', () => ({
+	ensureServerApplicationCatalog: vi.fn(async () => undefined)
+}));
+
 import { env } from '$env/dynamic/private';
 import { PUBLIC_TRADE_ACTIVITY_REFRESH_TIMEOUT_MS } from '$lib/server/publicTradeActivity';
 import { clearPublicTradeActivityMemoryCache } from '$lib/server/publicTradeActivityCache';
@@ -67,7 +71,7 @@ describe('/api/public/trade-activity', () => {
 		expect(response.status).toBe(200);
 		expect(fetchMock).toHaveBeenCalled();
 		for (const [url, init] of fetchMock.mock.calls) {
-			expect(url).toBe('https://api.example.test/v1/trades/query');
+			expect(url).toBe('https://api.example.test/v2/trades/query');
 			if (!init) throw new Error('Expected batch request options');
 			const headers = init.headers as Record<string, string>;
 			expect(headers.Authorization).toBe('Basic YWN0aXZpdHkta2V5OmFjdGl2aXR5LXNlY3JldA==');

--- a/src/routes/api/public/tvl/+server.ts
+++ b/src/routes/api/public/tvl/+server.ts
@@ -17,6 +17,8 @@ interface PublicTvlResponse {
 		totalTvl: number;
 		tokenTvl: Record<string, number>;
 		networks: { chainId: number; blockNumber: number; totalTvl: number }[];
+		/** @deprecated Use the matching entry in `networks`. Present only for one-network catalogs. */
+		blockNumber?: number;
 	} | null;
 }
 
@@ -37,10 +39,14 @@ async function fetchSnapshot(
 			const prefixes = [`snapshots/${chainId}/${symbol}/${blockNumber}.json`];
 			if (allowLegacySnapshots) prefixes.push(`snapshots/${symbol}/${blockNumber}.json`);
 			for (const prefix of prefixes) {
-				const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
-				if (blobs.length === 0) continue;
-				const response = await fetch(blobs[0].url);
-				if (response.ok) return await response.json();
+				try {
+					const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
+					if (blobs.length === 0) continue;
+					const response = await fetch(blobs[0].url, { signal: AbortSignal.timeout(10_000) });
+					if (response.ok) return await response.json();
+				} catch (error) {
+					console.error(`[Public TVL] Error fetching snapshot prefix ${prefix}:`, error);
+				}
 			}
 		} catch (error) {
 			console.error(
@@ -117,15 +123,28 @@ async function computeAggregateTvl(networkCatalog: Network[]): Promise<PublicTvl
 	if (results.length === 0) return { success: true, latest: null };
 	const tokenTvl = Object.assign({}, ...results.map((result) => result.tokenTvl));
 	const totalTvl = results.reduce((sum, result) => sum + result.totalTvl, 0);
+	const singleNetwork = results.length === 1 ? results[0] : null;
+	if (singleNetwork) {
+		// Preserve the original public contract while the deployment has one network.
+		// Qualified keys remain canonical and avoid collisions once more networks are configured.
+		for (const [qualifiedKey, value] of Object.entries(singleNetwork.tokenTvl)) {
+			const symbol = qualifiedKey.slice(qualifiedKey.indexOf(':') + 1);
+			tokenTvl[symbol] = value;
+		}
+	}
 
 	return {
 		success: true,
-		latest: { totalTvl, tokenTvl, networks: results.map((result) => result.network) }
+		latest: {
+			totalTvl,
+			tokenTvl,
+			networks: results.map((result) => result.network),
+			...(singleNetwork ? { blockNumber: singleNetwork.network.blockNumber } : {})
+		}
 	};
 }
 
 export const GET: RequestHandler = async ({ request }) => {
-	const { networkCatalog } = await getServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 
@@ -144,6 +163,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	}
 
 	try {
+		const { networkCatalog } = await getServerApplicationCatalog();
 		const data = await withConditionalCache<PublicTvlResponse>(
 			CACHE_KEYS.publicTvl(),
 			() => computeAggregateTvl(networkCatalog),

--- a/src/routes/api/public/tvl/+server.ts
+++ b/src/routes/api/public/tvl/+server.ts
@@ -6,99 +6,126 @@ import { withConditionalCache, CACHE_KEYS, CACHE_TTL } from '$lib/server/cache';
 import { kvGet, KV_KEYS, type SnapshotBlockRecord } from '$lib/server/kv';
 import { list } from '@vercel/blob';
 import type { BlockSnapshot } from '$lib/server/snapshots/types';
-import { TOKENS } from '$lib/config/tokens';
+import { getTokensByNetwork, type CategorizedToken } from '$lib/config/tokens';
 import { env } from '$env/dynamic/private';
-
-const tokenSymbols = TOKENS.map((t) => t.symbol);
-const previousSymbolsByToken = new Map<string, string[]>(
-	TOKENS.filter((t) => t.previousSymbols?.length).map((t) => [t.symbol, t.previousSymbols!])
-);
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
+import type { Network } from '$lib/config/networks';
 
 interface PublicTvlResponse {
 	success: boolean;
 	latest: {
 		totalTvl: number;
 		tokenTvl: Record<string, number>;
+		networks: { chainId: number; blockNumber: number; totalTvl: number }[];
 	} | null;
 }
 
 async function fetchSnapshot(
-	tokenSymbol: string,
-	blockNumber: number
+	chainId: number,
+	token: CategorizedToken,
+	blockNumber: number,
+	allowLegacySnapshots: boolean
 ): Promise<BlockSnapshot | null> {
 	if (!env.BLOB_READ_WRITE_TOKEN) {
 		return null;
 	}
 
-	const candidates = [tokenSymbol, ...(previousSymbolsByToken.get(tokenSymbol) ?? [])];
+	const candidates = [token.symbol, ...(token.previousSymbols ?? [])];
 
 	for (const symbol of candidates) {
 		try {
-			const prefix = `snapshots/${symbol}/${blockNumber}.json`;
-			const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
-
-			if (blobs.length === 0) continue;
-
-			const response = await fetch(blobs[0].url);
-			if (!response.ok) continue;
-
-			return await response.json();
+			const prefixes = [`snapshots/${chainId}/${symbol}/${blockNumber}.json`];
+			if (allowLegacySnapshots) prefixes.push(`snapshots/${symbol}/${blockNumber}.json`);
+			for (const prefix of prefixes) {
+				const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
+				if (blobs.length === 0) continue;
+				const response = await fetch(blobs[0].url);
+				if (response.ok) return await response.json();
+			}
 		} catch (error) {
-			console.error(`[Public TVL] Error fetching snapshot ${symbol}/${blockNumber}:`, error);
+			console.error(
+				`[Public TVL] Error fetching snapshot ${chainId}/${symbol}/${blockNumber}:`,
+				error
+			);
 		}
 	}
 
 	return null;
 }
 
-async function computeAggregateTvl(): Promise<PublicTvlResponse> {
+async function computeNetworkTvl(
+	network: Network,
+	latestBlock: SnapshotBlockRecord,
+	allowLegacySnapshots: boolean
+): Promise<{
+	totalTvl: number;
+	tokenTvl: Record<string, number>;
+	network: { chainId: number; blockNumber: number; totalTvl: number };
+}> {
+	const tokens = getTokensByNetwork(network.chainId);
+	const snapshots = await Promise.all(
+		tokens.map((token) =>
+			fetchSnapshot(network.chainId, token, latestBlock.blockNumber, allowLegacySnapshots)
+		)
+	);
+	const tokenTvl: Record<string, number> = {};
+	let totalTvl = 0;
+	for (let index = 0; index < snapshots.length; index++) {
+		const snapshot = snapshots[index];
+		const token = tokens[index];
+		let value = 0;
+		if (snapshot) {
+			const price = snapshot.price?.price ?? 0;
+			for (const balanceStr of Object.values(snapshot.balances)) {
+				const balance = BigInt(balanceStr);
+				if (balance > 0n) value += (Number(balance) / 10 ** token.decimals) * price;
+			}
+		}
+		tokenTvl[`${network.chainId}:${token.symbol}`] = value;
+		totalTvl += value;
+	}
+	return {
+		totalTvl,
+		tokenTvl,
+		network: { chainId: network.chainId, blockNumber: latestBlock.blockNumber, totalTvl }
+	};
+}
+
+async function computeAggregateTvl(networkCatalog: Network[]): Promise<PublicTvlResponse> {
 	const allBlocks = (await kvGet<SnapshotBlockRecord[]>(KV_KEYS.snapshotBlocks())) || [];
 
 	if (allBlocks.length === 0) {
 		return { success: true, latest: null };
 	}
 
-	// Get the latest block
-	const sorted = [...allBlocks].sort((a, b) => b.timestamp - a.timestamp);
-	const latestBlock = sorted[0];
-
-	// Fetch all token snapshots in parallel
-	const snapshots = await Promise.all(
-		tokenSymbols.map((symbol) => fetchSnapshot(symbol, latestBlock.blockNumber))
-	);
-
-	const tokenTvl: Record<string, number> = {};
-	let totalTvl = 0;
-
-	for (let i = 0; i < snapshots.length; i++) {
-		const snapshot = snapshots[i];
-		const symbol = tokenSymbols[i];
-
-		if (!snapshot) {
-			tokenTvl[symbol] = 0;
-			continue;
-		}
-
-		const price = snapshot.price?.price ?? 0;
-		let tokenTotal = 0;
-
-		for (const balanceStr of Object.values(snapshot.balances)) {
-			const balance = BigInt(balanceStr);
-			if (balance <= 0n) continue;
-			tokenTotal += (Number(balance) / 1e18) * price;
-		}
-
-		tokenTvl[symbol] = tokenTotal;
-		totalTvl += tokenTotal;
+	const allowLegacySnapshots = networkCatalog.length === 1;
+	const latestByChain = new Map<number, SnapshotBlockRecord>();
+	for (const network of networkCatalog) {
+		const candidates = allBlocks.filter(
+			(block) =>
+				block.chainId === network.chainId || (allowLegacySnapshots && block.chainId === undefined)
+		);
+		const latest = candidates.sort((left, right) => right.timestamp - left.timestamp)[0];
+		if (latest) latestByChain.set(network.chainId, latest);
 	}
+	const results = await Promise.all(
+		networkCatalog.flatMap((network) => {
+			const latest = latestByChain.get(network.chainId);
+			return latest ? [computeNetworkTvl(network, latest, allowLegacySnapshots)] : [];
+		})
+	);
+	if (results.length === 0) return { success: true, latest: null };
+	const tokenTvl = Object.assign({}, ...results.map((result) => result.tokenTvl));
+	const totalTvl = results.reduce((sum, result) => sum + result.totalTvl, 0);
 
 	return {
 		success: true,
-		latest: { totalTvl, tokenTvl }
+		latest: { totalTvl, tokenTvl, networks: results.map((result) => result.network) }
 	};
 }
 
 export const GET: RequestHandler = async ({ request }) => {
+	const { networkCatalog } = await getServerApplicationCatalog();
 	const clientIp = getClientIp(request);
 	const rateLimit = await rateLimiters.publicApi(`public-api:${clientIp}`);
 
@@ -119,7 +146,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	try {
 		const data = await withConditionalCache<PublicTvlResponse>(
 			CACHE_KEYS.publicTvl(),
-			computeAggregateTvl,
+			() => computeAggregateTvl(networkCatalog),
 			(result) => result.success && result.latest !== null && result.latest.totalTvl > 0,
 			CACHE_TTL.LONG
 		);

--- a/src/routes/api/public/tvl/+server.ts
+++ b/src/routes/api/public/tvl/+server.ts
@@ -123,7 +123,7 @@ async function computeAggregateTvl(networkCatalog: Network[]): Promise<PublicTvl
 	if (results.length === 0) return { success: true, latest: null };
 	const tokenTvl = Object.assign({}, ...results.map((result) => result.tokenTvl));
 	const totalTvl = results.reduce((sum, result) => sum + result.totalTvl, 0);
-	const singleNetwork = results.length === 1 ? results[0] : null;
+	const singleNetwork = networkCatalog.length === 1 && results.length === 1 ? results[0] : null;
 	if (singleNetwork) {
 		// Preserve the original public contract while the deployment has one network.
 		// Qualified keys remain canonical and avoid collisions once more networks are configured.

--- a/src/routes/api/public/tvl/server.test.ts
+++ b/src/routes/api/public/tvl/server.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	kvGet: vi.fn(),
+	list: vi.fn(),
+	getServerApplicationCatalog: vi.fn(),
+	getTokensByNetwork: vi.fn()
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: { BLOB_READ_WRITE_TOKEN: 'blob-token' } }));
+vi.mock('$lib/server/rateLimit', () => ({
+	getClientIp: () => '127.0.0.1',
+	rateLimiters: {
+		publicApi: vi.fn(async () => ({ allowed: true, remaining: 99, resetAt: Date.now() + 60_000 }))
+	}
+}));
+vi.mock('$lib/server/cache', () => ({
+	withConditionalCache: vi.fn(async (_key, load) => load()),
+	CACHE_KEYS: { publicTvl: () => 'public-tvl' },
+	CACHE_TTL: { LONG: 3600 }
+}));
+vi.mock('$lib/server/kv', () => ({
+	kvGet: mocks.kvGet,
+	KV_KEYS: { snapshotBlocks: () => 'snapshot-blocks' }
+}));
+vi.mock('@vercel/blob', () => ({ list: mocks.list }));
+vi.mock('$lib/server/applicationCatalog', () => ({
+	getServerApplicationCatalog: mocks.getServerApplicationCatalog
+}));
+vi.mock('$lib/config/tokens', () => ({
+	getTokensByNetwork: mocks.getTokensByNetwork
+}));
+
+import { GET } from './+server';
+
+type TvlEvent = Parameters<typeof GET>[0];
+const network = { id: 8453, chainId: 8453 };
+const token = {
+	chainId: 8453,
+	address: '0x1111111111111111111111111111111111111111',
+	symbol: 'wtTEST',
+	decimals: 18,
+	category: 'ST0x'
+};
+
+describe('/api/public/tvl compatibility', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getServerApplicationCatalog.mockResolvedValue({
+			tokenCatalog: [token],
+			networkCatalog: [network]
+		});
+		mocks.getTokensByNetwork.mockReturnValue([token]);
+		mocks.kvGet.mockResolvedValue([
+			{ chainId: 8453, blockNumber: 123, timestamp: 1_700_000_000, date: '2026-08-11' }
+		]);
+		mocks.list.mockResolvedValue({ blobs: [{ url: 'https://blob.example/snapshot.json' }] });
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							balances: { '0xholder': '2000000000000000000' },
+							price: { price: 5 }
+						}),
+						{ status: 200 }
+					)
+			)
+		);
+	});
+
+	it('returns canonical chain-qualified fields and legacy fields for one network', async () => {
+		const response = await GET({
+			request: new Request('http://localhost/api/public/tvl')
+		} as TvlEvent);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.latest).toMatchObject({
+			totalTvl: 10,
+			blockNumber: 123,
+			tokenTvl: { '8453:wtTEST': 10, wtTEST: 10 },
+			networks: [{ chainId: 8453, blockNumber: 123, totalTvl: 10 }]
+		});
+		expect(fetch).toHaveBeenCalledWith(
+			'https://blob.example/snapshot.json',
+			expect.objectContaining({ signal: expect.any(AbortSignal) })
+		);
+	});
+});

--- a/src/routes/api/public/tvl/server.test.ts
+++ b/src/routes/api/public/tvl/server.test.ts
@@ -88,4 +88,20 @@ describe('/api/public/tvl compatibility', () => {
 			expect.objectContaining({ signal: expect.any(AbortSignal) })
 		);
 	});
+
+	it('omits legacy fields when multiple networks are configured but only one has a snapshot', async () => {
+		mocks.getServerApplicationCatalog.mockResolvedValue({
+			tokenCatalog: [token],
+			networkCatalog: [network, { id: 10, chainId: 10 }]
+		});
+
+		const response = await GET({
+			request: new Request('http://localhost/api/public/tvl')
+		} as TvlEvent);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.latest.tokenTvl).toEqual({ '8453:wtTEST': 10 });
+		expect(body.latest).not.toHaveProperty('blockNumber');
+	});
 });

--- a/src/routes/api/snapshots/get/+server.ts
+++ b/src/routes/api/snapshots/get/+server.ts
@@ -3,42 +3,59 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { list } from '@vercel/blob';
 import { env } from '$env/dynamic/private';
-import { TOKENS } from '$lib/config/tokens';
+import { TOKENS, onTokenCatalogChange } from '$lib/config/tokens';
 import { TOKEN_MIGRATION_MAPPINGS } from '$lib/config/tokenMigration';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
-const LEGACY_BY_WRAPPED = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.newToken.symbol.toLowerCase(), m.oldToken.symbol])
-);
-const WRAPPED_BY_LEGACY = new Map(
-	TOKEN_MIGRATION_MAPPINGS.map((m) => [m.oldToken.symbol.toLowerCase(), m.newToken.symbol])
-);
-const LEGACY_SYMBOLS = new Set([
-	...TOKEN_MIGRATION_MAPPINGS.map((m) => m.oldToken.symbol.toLowerCase()),
-	...TOKENS.flatMap((t) => t.previousSymbols ?? []).map((s) => s.toLowerCase())
-]);
+const LEGACY_BY_WRAPPED = new Map<string, string>();
+const WRAPPED_BY_LEGACY = new Map<string, string>();
+const LEGACY_SYMBOLS = new Set<string>();
 
 // Build a map from current/legacy symbols to their historical (previous) symbols
 // e.g., 'wtspym' -> ['wtSPLG', 'tSPLG']
 const PREVIOUS_SYMBOLS_BY_CURRENT = new Map<string, string[]>();
-for (const t of TOKENS) {
-	if (t.previousSymbols?.length) {
-		PREVIOUS_SYMBOLS_BY_CURRENT.set(t.symbol.toLowerCase(), t.previousSymbols);
-		// Also map the legacy symbol to previous symbols
-		if (t.legacySymbol) {
-			PREVIOUS_SYMBOLS_BY_CURRENT.set(t.legacySymbol.toLowerCase(), t.previousSymbols);
-		}
-	}
-}
 
 // Reverse map: previous symbol -> canonical (current wrapped) symbol
 const CANONICAL_BY_PREVIOUS = new Map<string, string>();
-for (const t of TOKENS) {
-	if (t.previousSymbols?.length) {
-		for (const prev of t.previousSymbols) {
-			CANONICAL_BY_PREVIOUS.set(prev.toLowerCase(), t.symbol);
+
+onTokenCatalogChange((tokens) => {
+	LEGACY_BY_WRAPPED.clear();
+	WRAPPED_BY_LEGACY.clear();
+	LEGACY_SYMBOLS.clear();
+	PREVIOUS_SYMBOLS_BY_CURRENT.clear();
+	CANONICAL_BY_PREVIOUS.clear();
+
+	for (const mapping of TOKEN_MIGRATION_MAPPINGS) {
+		LEGACY_BY_WRAPPED.set(
+			`${mapping.chainId}:${mapping.newToken.symbol.toLowerCase()}`,
+			mapping.oldToken.symbol
+		);
+		WRAPPED_BY_LEGACY.set(
+			`${mapping.chainId}:${mapping.oldToken.symbol.toLowerCase()}`,
+			mapping.newToken.symbol
+		);
+		LEGACY_SYMBOLS.add(`${mapping.chainId}:${mapping.oldToken.symbol.toLowerCase()}`);
+	}
+
+	for (const token of tokens) {
+		for (const previousSymbol of token.previousSymbols ?? []) {
+			LEGACY_SYMBOLS.add(`${token.chainId}:${previousSymbol.toLowerCase()}`);
+			CANONICAL_BY_PREVIOUS.set(`${token.chainId}:${previousSymbol.toLowerCase()}`, token.symbol);
+		}
+		if (token.previousSymbols?.length) {
+			PREVIOUS_SYMBOLS_BY_CURRENT.set(
+				`${token.chainId}:${token.symbol.toLowerCase()}`,
+				token.previousSymbols
+			);
+			if (token.legacySymbol) {
+				PREVIOUS_SYMBOLS_BY_CURRENT.set(
+					`${token.chainId}:${token.legacySymbol.toLowerCase()}`,
+					token.previousSymbols
+				);
+			}
 		}
 	}
-}
+});
 
 function uniqueSymbols(symbols: string[]): string[] {
 	const seen = new Set<string>();
@@ -54,15 +71,16 @@ function uniqueSymbols(symbols: string[]): string[] {
 	return out;
 }
 
-function getTokenSymbolCandidates(tokenSymbol: string): string[] {
+function getTokenSymbolCandidates(chainId: number, tokenSymbol: string): string[] {
 	const symbol = tokenSymbol.trim();
 	const lower = symbol.toLowerCase();
+	const key = `${chainId}:${lower}`;
 	const candidates: string[] = [symbol];
 
-	const mappedLegacy = LEGACY_BY_WRAPPED.get(lower);
+	const mappedLegacy = LEGACY_BY_WRAPPED.get(key);
 	if (mappedLegacy) candidates.push(mappedLegacy);
 
-	const mappedWrapped = WRAPPED_BY_LEGACY.get(lower);
+	const mappedWrapped = WRAPPED_BY_LEGACY.get(key);
 	if (mappedWrapped) candidates.push(mappedWrapped);
 
 	// Generic fallbacks (covers default wtXXX <-> tXXX naming)
@@ -70,28 +88,59 @@ function getTokenSymbolCandidates(tokenSymbol: string): string[] {
 	if (symbol.startsWith('t')) candidates.push(`wt${symbol.slice(1)}`);
 
 	// Historical symbol names (e.g., wtSPYM -> wtSPLG, tSPLG)
-	const prevSymbols = PREVIOUS_SYMBOLS_BY_CURRENT.get(lower);
+	const prevSymbols = PREVIOUS_SYMBOLS_BY_CURRENT.get(key);
 	if (prevSymbols) candidates.push(...prevSymbols);
 
 	return uniqueSymbols(candidates);
 }
 
-function getCanonicalSymbol(symbol: string): string {
+function getCanonicalSymbol(chainId: number, symbol: string): string {
+	const key = `${chainId}:${symbol.toLowerCase()}`;
 	// Check if this is a previous/renamed symbol
-	const canonical = CANONICAL_BY_PREVIOUS.get(symbol.toLowerCase());
+	const canonical = CANONICAL_BY_PREVIOUS.get(key);
 	if (canonical) return canonical;
-	return WRAPPED_BY_LEGACY.get(symbol.toLowerCase()) ?? symbol;
+	return WRAPPED_BY_LEGACY.get(key) ?? symbol;
 }
 
-function getAllSnapshotTokenSymbols(): string[] {
+function getAllSnapshotTokenSymbols(chainId: number): string[] {
 	return uniqueSymbols([
-		...TOKENS.map((t) => t.symbol),
-		...TOKEN_MIGRATION_MAPPINGS.map((m) => m.oldToken.symbol),
-		...TOKENS.flatMap((t) => t.previousSymbols ?? [])
+		...TOKENS.filter((token) => token.chainId === chainId).map((token) => token.symbol),
+		...TOKEN_MIGRATION_MAPPINGS.filter((mapping) => mapping.chainId === chainId).map(
+			(mapping) => mapping.oldToken.symbol
+		),
+		...TOKENS.filter((token) => token.chainId === chainId).flatMap(
+			(token) => token.previousSymbols ?? []
+		)
 	]);
 }
 
 export const GET: RequestHandler = async ({ url }) => {
+	const { networkCatalog } = await getServerApplicationCatalog();
+	const requestedChain = url.searchParams.get('chainId');
+	const chainId = requestedChain === null ? networkCatalog[0]?.chainId : Number(requestedChain);
+	if (requestedChain === null && networkCatalog.length !== 1) {
+		return json({ error: 'Missing chainId parameter' }, { status: 400 });
+	}
+	if (
+		!Number.isSafeInteger(chainId) ||
+		!networkCatalog.some((network) => network.chainId === chainId)
+	) {
+		return json({ error: 'Unsupported chainId parameter' }, { status: 400 });
+	}
+	const snapshotPrefix = (symbol: string, blockNumber: string) =>
+		`snapshots/${chainId}/${symbol}/${blockNumber}.json`;
+	const allowLegacySnapshots = networkCatalog.length === 1;
+	const legacySnapshotPrefix = (symbol: string, blockNumber: string) =>
+		`snapshots/${symbol}/${blockNumber}.json`;
+	const findSnapshot = async (symbol: string, blockNumber: string) => {
+		const prefixes = [snapshotPrefix(symbol, blockNumber)];
+		if (allowLegacySnapshots) prefixes.push(legacySnapshotPrefix(symbol, blockNumber));
+		for (const prefix of prefixes) {
+			const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
+			if (blobs[0]) return blobs[0];
+		}
+		return null;
+	};
 	// Check if Blob token is available (required for Vercel Blob storage)
 	if (!env.BLOB_READ_WRITE_TOKEN) {
 		return json(
@@ -110,12 +159,10 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		// If token is specified, get that specific snapshot
 		if (tokenSymbol) {
-			const candidateSymbols = getTokenSymbolCandidates(tokenSymbol);
+			const candidateSymbols = getTokenSymbolCandidates(chainId, tokenSymbol);
 			const lookupResults = await Promise.all(
 				candidateSymbols.map(async (symbol) => {
-					const prefix = `snapshots/${symbol}/${blockNumber}.json`;
-					const { blobs } = await list({ prefix, limit: 1, token: env.BLOB_READ_WRITE_TOKEN });
-					return { symbol, blob: blobs[0] ?? null };
+					return { symbol, blob: await findSnapshot(symbol, blockNumber) };
 				})
 			);
 			const match = lookupResults.find((r) => r.blob);
@@ -142,6 +189,7 @@ export const GET: RequestHandler = async ({ url }) => {
 			return json({
 				success: true,
 				blockNumber: parseInt(blockNumber),
+				chainId,
 				token: tokenSymbol,
 				resolvedToken: match.symbol,
 				url: match.blob.url,
@@ -151,36 +199,31 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		// If no token specified, get all token snapshots for this block
 		// Query each token's specific blob path in parallel to avoid pagination issues
-		const tokenSymbols = getAllSnapshotTokenSymbols();
+		const tokenSymbols = getAllSnapshotTokenSymbols(chainId);
 
 		const snapshotsRaw = (
 			await Promise.all(
 				tokenSymbols.map(async (symbol) => {
-					const prefix = `snapshots/${symbol}/${blockNumber}.json`;
 					try {
-						const { blobs } = await list({
-							prefix,
-							limit: 1,
-							token: env.BLOB_READ_WRITE_TOKEN
-						});
-						if (blobs.length === 0) return null;
+						const blob = await findSnapshot(symbol, blockNumber);
+						if (!blob) return null;
 
-						const response = await fetch(blobs[0].url);
+						const response = await fetch(blob.url);
 						if (!response.ok)
 							return {
 								token: symbol,
-								canonicalToken: getCanonicalSymbol(symbol),
-								isLegacy: LEGACY_SYMBOLS.has(symbol.toLowerCase()),
-								url: blobs[0].url,
+								canonicalToken: getCanonicalSymbol(chainId, symbol),
+								isLegacy: LEGACY_SYMBOLS.has(`${chainId}:${symbol.toLowerCase()}`),
+								url: blob.url,
 								snapshot: null
 							};
 
 						const data = await response.json();
 						return {
 							token: symbol,
-							canonicalToken: getCanonicalSymbol(symbol),
-							isLegacy: LEGACY_SYMBOLS.has(symbol.toLowerCase()),
-							url: blobs[0].url,
+							canonicalToken: getCanonicalSymbol(chainId, symbol),
+							isLegacy: LEGACY_SYMBOLS.has(`${chainId}:${symbol.toLowerCase()}`),
+							url: blob.url,
 							snapshot: data
 						};
 					} catch {
@@ -232,6 +275,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		return json({
 			success: true,
+			chainId,
 			blockNumber: parseInt(blockNumber),
 			tokensFound: snapshots.length,
 			snapshots

--- a/src/routes/api/snapshots/preview-stream/+server.ts
+++ b/src/routes/api/snapshots/preview-stream/+server.ts
@@ -10,6 +10,7 @@ import {
 import { kvGet, KV_KEYS } from '$lib/server/kv';
 import { applyTieredRateLimit } from '$lib/server/rateLimit';
 import { readSession } from '$lib/server/walletSession';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 export const GET: RequestHandler = async ({ url, request, cookies }) => {
 	// SEC-06 + SEC-03 (Plan 03-08b atomic flip): rate-limit BEFORE constructing
@@ -31,6 +32,7 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 	if (rateLimitResponse) return rateLimitResponse;
 
 	const blockParam = url.searchParams.get('block');
+	const chainParam = url.searchParams.get('chainId');
 
 	const stream = new ReadableStream({
 		async start(controller) {
@@ -41,11 +43,26 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 			};
 
 			try {
+				const { networkCatalog } = await getServerApplicationCatalog();
+				if (!chainParam && networkCatalog.length !== 1) {
+					sendEvent('error', { message: 'Missing chainId parameter' });
+					controller.close();
+					return;
+				}
+				const chainId = chainParam ? Number(chainParam) : networkCatalog[0]?.chainId;
+				const network = networkCatalog.find((candidate) => candidate.chainId === chainId);
+				if (!network) {
+					sendEvent('error', { message: 'Unsupported chainId parameter' });
+					controller.close();
+					return;
+				}
 				const overallStart = Date.now();
 
 				// Step 1: Get block number
 				sendEvent('progress', { step: 1, total: 5, message: 'Getting block number...' });
-				const targetBlock = blockParam ? parseInt(blockParam) : await getCurrentBlockNumber();
+				const targetBlock = blockParam
+					? parseInt(blockParam)
+					: await getCurrentBlockNumber(network);
 
 				if (isNaN(targetBlock) || targetBlock <= 0) {
 					sendEvent('error', { message: 'Invalid block number' });
@@ -66,7 +83,7 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 					total: 5,
 					message: 'Fetching transfers, prices, and vault holdings...'
 				});
-				const snapshots = await generateAllTokenSnapshots(targetBlock);
+				const snapshots = await generateAllTokenSnapshots(network, targetBlock);
 				sendEvent('progress', {
 					step: 2,
 					total: 5,
@@ -76,7 +93,7 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 
 				// Step 3: Get timestamp
 				sendEvent('progress', { step: 3, total: 5, message: 'Getting block timestamp...' });
-				const timestamp = await getBlockTimestamp(targetBlock);
+				const timestamp = await getBlockTimestamp(network, targetBlock);
 				const blockDate = new Date(timestamp * 1000).toISOString();
 				sendEvent('progress', {
 					step: 3,

--- a/src/routes/api/snapshots/preview/+server.ts
+++ b/src/routes/api/snapshots/preview/+server.ts
@@ -11,6 +11,7 @@ import {
 import { kvGet, KV_KEYS } from '$lib/server/kv';
 import { applyTieredRateLimit } from '$lib/server/rateLimit';
 import { readSession } from '$lib/server/walletSession';
+import { getServerApplicationCatalog } from '$lib/server/applicationCatalog';
 
 export const GET: RequestHandler = async ({ url, request, cookies }) => {
 	// SEC-06 + SEC-03 (Plan 03-08b atomic flip): tiered rate-limit using the
@@ -32,11 +33,19 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 
 	try {
 		const blockParam = url.searchParams.get('block');
+		const chainParam = url.searchParams.get('chainId');
+		const { networkCatalog } = await getServerApplicationCatalog();
+		if (!chainParam && networkCatalog.length !== 1) {
+			return json({ error: 'Missing chainId parameter' }, { status: 400 });
+		}
+		const chainId = chainParam ? Number(chainParam) : networkCatalog[0]?.chainId;
+		const network = networkCatalog.find((candidate) => candidate.chainId === chainId);
+		if (!network) return json({ error: 'Unsupported chainId parameter' }, { status: 400 });
 		const overallStart = Date.now();
 
 		console.log(`[Preview] Step 1/5: Getting current block number...`);
 		let stepStart = Date.now();
-		const targetBlock = blockParam ? parseInt(blockParam) : await getCurrentBlockNumber();
+		const targetBlock = blockParam ? parseInt(blockParam) : await getCurrentBlockNumber(network);
 		console.log(`[Preview] Step 1/5: Done (${Date.now() - stepStart}ms)`);
 
 		if (isNaN(targetBlock) || targetBlock <= 0) {
@@ -48,7 +57,7 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 		// Use the same core generator function as the cron job
 		console.log(`[Preview] Step 2/5: Generating token snapshots (transfers, prices, vaults)...`);
 		stepStart = Date.now();
-		const snapshots = await generateAllTokenSnapshots(targetBlock);
+		const snapshots = await generateAllTokenSnapshots(network, targetBlock);
 		console.log(
 			`[Preview] Step 2/5: Done - ${snapshots.length} tokens (${Date.now() - stepStart}ms)`
 		);
@@ -56,7 +65,7 @@ export const GET: RequestHandler = async ({ url, request, cookies }) => {
 		// Get timestamp and excluded wallets for response metadata
 		console.log(`[Preview] Step 3/5: Getting block timestamp...`);
 		stepStart = Date.now();
-		const timestamp = await getBlockTimestamp(targetBlock);
+		const timestamp = await getBlockTimestamp(network, targetBlock);
 		const blockDate = new Date(timestamp * 1000).toISOString();
 		console.log(`[Preview] Step 3/5: Done - ${blockDate} (${Date.now() - stepStart}ms)`);
 

--- a/src/routes/api/st0x/[...path]/+server.ts
+++ b/src/routes/api/st0x/[...path]/+server.ts
@@ -11,8 +11,8 @@ import { getLogger, getRequestContext, requestIdOrUuid } from '$lib/server/logge
 import { logSt0xRequestBudget } from '$lib/server/st0xBudgetTelemetry';
 import type { RequestEvent, RequestHandler } from './$types';
 
-const TOKEN_DETAILS_LIST_PATH = 'v1/tokens/details';
-const TOKEN_LIST_PATH = 'v1/tokens';
+const TOKEN_DETAILS_LIST_PATH = 'v2/tokens/details';
+const TOKEN_LIST_PATH = 'v2/tokens';
 
 function errorResponse(requestId: string, status: number, code: string, message: string): Response {
 	return new Response(
@@ -53,59 +53,57 @@ const ALLOWED_PROXY_ROUTES: Array<{ method: string; pattern: RegExp; cache?: str
 	{ method: 'GET', pattern: /^health$/ },
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens$/,
+		pattern: /^v2\/tokens$/,
 		cache: 'public, s-maxage=300, stale-while-revalidate=3600'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/details$/,
+		pattern: /^v2\/tokens\/details$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/[^/]+\/details$/,
+		pattern: /^v2\/tokens\/[^/]+\/details$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/wrap-ratio$/,
+		pattern: /^v2\/tokens\/wrap-ratio$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/wrap-ratio\/[^/]+$/,
+		pattern: /^v2\/tokens\/wrap-ratio\/[^/]+$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/wrap-ratio\/[^/]+\/history$/,
+		pattern: /^v2\/tokens\/wrap-ratio\/[^/]+\/history$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	{
 		method: 'GET',
-		pattern: /^v1\/tokens\/[^/]+\/proofs$/,
+		pattern: /^v2\/tokens\/[^/]+\/proofs$/,
 		cache: 'public, s-maxage=60, stale-while-revalidate=300'
 	},
 	// Shared endpoints — same response for all users, cache at Vercel edge
 	{
 		method: 'GET',
-		pattern: /^v1\/orders\/token\/[^/]+$/,
+		pattern: /^v2\/orders\/token\/[^/]+$/,
 		cache: 'public, s-maxage=5, stale-while-revalidate=120'
 	},
-	{ method: 'POST', pattern: /^v1\/orders\/query$/ },
+	{ method: 'POST', pattern: /^v2\/orders\/query$/ },
 	{
 		method: 'GET',
-		pattern: /^v1\/trades\/token\/[^/]+$/,
+		pattern: /^v2\/trades\/token\/[^/]+$/,
 		cache: 'public, s-maxage=5, stale-while-revalidate=120'
 	},
 	// Per-user endpoints — no shared caching
-	{ method: 'GET', pattern: /^v1\/orders\/owner\/[^/]+$/ },
-	{ method: 'GET', pattern: /^v1\/trades\/tx\/[^/]+$/ },
-	{ method: 'GET', pattern: /^v1\/trades\/(?!taker\/|query$)[^/]+$/ },
-	{ method: 'GET', pattern: /^v1\/trades\/taker\/[^/]+$/ },
-	{ method: 'POST', pattern: /^v1\/trades\/query$/ },
-	{ method: 'POST', pattern: /^v1\/swap\/quote$/ },
-	{ method: 'POST', pattern: /^v1\/swap\/calldata$/ },
+	{ method: 'GET', pattern: /^v2\/orders\/owner\/[^/]+$/ },
+	{ method: 'GET', pattern: /^v2\/trades\/tx\/[^/]+$/ },
+	{ method: 'GET', pattern: /^v2\/trades\/(?!taker\/|query$)[^/]+$/ },
+	{ method: 'GET', pattern: /^v2\/trades\/taker\/[^/]+$/ },
+	{ method: 'POST', pattern: /^v2\/trades\/query$/ },
 	{ method: 'POST', pattern: /^v2\/swap\/quote$/ },
 	{ method: 'POST', pattern: /^v2\/swap\/calldata$/ }
 ];

--- a/tests/fixtures/st0xTokenCatalog.ts
+++ b/tests/fixtures/st0xTokenCatalog.ts
@@ -1,0 +1,91 @@
+import type { CategorizedToken } from '../../src/lib/config/tokens';
+
+const assets = [
+	{
+		symbol: 'IAU',
+		address: '0x1E46d7eFef64A833AFB1CD49299a7AD5B439f4d8',
+		unwrappedAddress: '0x9a507314ea2a6c5686c0d07bfecb764dcf324dff',
+		legacyAddress: '0xd0a90b7c9ae5facbe09ca4c576a3795eda53b397',
+		name: 'Wrapped iShares Gold Trust ST0x',
+		market: 'AMEX'
+	},
+	{
+		symbol: 'NVDA',
+		address: '0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7',
+		unwrappedAddress: '0x7271a3c91bb6070ed09333b84a815949d4f16d14',
+		legacyAddress: '0x69fca9f7fad46a7eef3acef5beac9df5b7eca73b',
+		name: 'Wrapped NVIDIA Corporation ST0x',
+		market: 'NASDAQ'
+	},
+	{
+		symbol: 'AMZN',
+		address: '0x997baE3EC193a249596d3708C3fAB7C501Bb8a53',
+		unwrappedAddress: '0x466cb2e46fa1afc0ab5e22274b34d0391db18efd',
+		legacyAddress: '0x8d8c315db61f60dcc3c66cdb48ca87fc643e35ea',
+		name: 'Wrapped Amazon.com Inc ST0x',
+		market: 'NASDAQ'
+	},
+	{
+		symbol: 'TSLA',
+		address: '0x219A8d384a10BF19b9f24cB5cC53F79Dd0e5A03D',
+		unwrappedAddress: '0x4e169cd2ab4f82640a8c65c68fed55863866fdb0',
+		legacyAddress: '0x470b06815a2e286df8c38c9c73280e0760088623',
+		name: 'Wrapped Tesla Inc ST0x',
+		market: 'NASDAQ'
+	},
+	{
+		symbol: 'MSTR',
+		address: '0xFF05E1bD696900dc6A52CA35Ca61Bb1024eDa8e2',
+		unwrappedAddress: '0x013b782f402d61aa1004cca95b9f5bb402c9d5fe',
+		legacyAddress: '0xff647ad8c4b065bd746911bb9ea1a33c38c63604',
+		name: 'Wrapped MicroStrategy Incorporated ST0x',
+		market: 'NASDAQ'
+	},
+	{
+		symbol: 'COIN',
+		address: '0x5cDa0E1CA4ce2af96315f7F8963C85399c172204',
+		unwrappedAddress: '0x626757e6f50675d17fcad312e82f989ae7a23d38',
+		legacyAddress: '0xb616f8b391d1adc118fd7e4063526d5530d49b10',
+		name: 'Wrapped Coinbase Global Inc ST0x',
+		market: 'NASDAQ'
+	},
+	{
+		symbol: 'SPYM',
+		address: '0x31C2C14134e6E3B7ef9478297F199331133Fc2d8',
+		unwrappedAddress: '0x8fdf41116f755771bfe0747d5f8c3711d5debfbb',
+		legacyAddress: '0x2289249984f1fa2ce86c4e8867e7eb819ea7df95',
+		name: 'Wrapped SPDR Portfolio S&P 500 ETF ST0x',
+		market: 'AMEX',
+		legacySymbol: 'tSPYM',
+		previousSymbols: ['wtSPLG', 'tSPLG']
+	}
+] as const;
+
+export const TEST_ST0X_TOKENS: CategorizedToken[] = assets.map((asset, index) => ({
+	chainId: 8453,
+	address: asset.address,
+	unwrappedAddress: asset.unwrappedAddress,
+	legacyAddress: asset.legacyAddress,
+	symbol: `wt${asset.symbol}`,
+	legacySymbol: 'legacySymbol' in asset ? asset.legacySymbol : undefined,
+	previousSymbols: 'previousSymbols' in asset ? [...asset.previousSymbols] : undefined,
+	decimals: 18,
+	name: asset.name,
+	logoUrl: `https://example.com/${asset.symbol}.png`,
+	priceFeedId: `0x${String(index + 1).padStart(64, '0')}`,
+	category: 'ST0x',
+	tradingViewSymbol: `${asset.market}:${asset.symbol}`,
+	tradingViewMarket: 'america'
+}));
+
+export const TEST_CRYPTO_TOKENS: CategorizedToken[] = [
+	{
+		chainId: 8453,
+		address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+		symbol: 'USDC',
+		decimals: 6,
+		name: 'USD Coin',
+		category: 'CRYPTO',
+		paymentToken: true
+	}
+];

--- a/tests/fixtures/st0xTokenCatalog.ts
+++ b/tests/fixtures/st0xTokenCatalog.ts
@@ -66,6 +66,7 @@ export const TEST_ST0X_TOKENS: CategorizedToken[] = assets.map((asset, index) =>
 	address: asset.address,
 	unwrappedAddress: asset.unwrappedAddress,
 	legacyAddress: asset.legacyAddress,
+	migrationOrderHash: `0x${String(index + 1).padStart(64, '0')}`,
 	symbol: `wt${asset.symbol}`,
 	legacySymbol: 'legacySymbol' in asset ? asset.legacySymbol : undefined,
 	previousSymbols: 'previousSymbols' in asset ? [...asset.previousSymbols] : undefined,

--- a/tests/integration/ui/fixtures.ts
+++ b/tests/integration/ui/fixtures.ts
@@ -363,7 +363,7 @@ export const test = base.extend<UiFixtures>({
 				headers: { 'access-control-allow-origin': '*' }
 			});
 		});
-		await page.route('**/api/st0x/v1/orders/token/**', async (route) => {
+		await page.route('**/api/st0x/v2/orders/token/**', async (route) => {
 			// When maker orders are registered, serve a fully-synthetic
 			// response built from the maker registry. Specs that don't
 			// register any maker (e.g. limitDeploy, which only deploys and
@@ -417,7 +417,7 @@ export const test = base.extend<UiFixtures>({
 		);
 		await use(page);
 		// Drain in-flight route handlers BEFORE Playwright tears down the
-		// page/context. The trade page polls /api/st0x/v1/orders/token/* every
+		// page/context. The trade page polls /api/st0x/v2/orders/token/* every
 		// 15s, and a `route.fetch` mid-flight at teardown throws "Target page
 		// closed" — Playwright then reports that as a test failure even though
 		// the assertions all passed. `ignoreErrors` swallows still-pending

--- a/tests/integration/ui/syntheticOrdersStub.ts
+++ b/tests/integration/ui/syntheticOrdersStub.ts
@@ -5,7 +5,7 @@
 // anvil. The subgraph never sees these orders (it indexes LIVE Base mainnet).
 // To make the UI see them, we synthesize:
 //   1. `SgOrdersListQuery` Goldsky GraphQL responses
-//   2. `/api/st0x/v1/orders/token/<addr>` REST API responses
+//   2. `/api/st0x/v2/orders/token/<addr>` REST API responses
 //
 // The shape of the Goldsky response is captured in
 // `tests/integration/ui/__fixtures__/sample-sgorder-response.json` from a
@@ -258,7 +258,7 @@ export function handleGoldskyRequest(body: string | null): string | null {
 
 /**
  * Convert a DeployedMakerOrder to the ApiOrderSummary shape the production
- * /api/st0x/v1/orders/token proxy returns. `ioRatio`, `maxOutput`, and
+ * /api/st0x/v2/orders/token proxy returns. `ioRatio`, `maxOutput`, and
  * `outputVaultBalance` are decimal strings (NOT hex) — `convertApiOrderToProcessedQuote`
  * in src/lib/api/orders.ts:61 runs `Float.parse()` on `ioRatio`/`maxOutput`
  * and `parseFloat()` on `outputVaultBalance` (it drops the order if
@@ -292,7 +292,7 @@ function makerOrderToApiSummary(o: DeployedMakerOrder): ApiOrderSummary {
 }
 
 /**
- * Build a fully-synthetic /api/st0x/v1/orders/token response from the maker
+ * Build a fully-synthetic /api/st0x/v2/orders/token response from the maker
  * registry, filtered to orders involving `tokenAddress` on the given `side`.
  *   side='output' → orders that GIVE this token (sells of this asset)
  *   side='input'  → orders that RECEIVE this token (buys of this asset)

--- a/tests/integration/ui/wrapRatio.spec.ts
+++ b/tests/integration/ui/wrapRatio.spec.ts
@@ -28,7 +28,7 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
 		await page.route(/\/api\/st0x\/v1\/tokens/, async (route) => {
 			const url = new URL(route.request().url());
 			const pathname = url.pathname.toLowerCase();
-			if (url.pathname === '/api/st0x/v1/tokens') {
+			if (url.pathname === '/api/st0x/v2/tokens') {
 				await route.fulfill({
 					status: 200,
 					contentType: 'application/json',
@@ -48,7 +48,7 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
 				});
 				return;
 			}
-			if (url.pathname === '/api/st0x/v1/tokens/details') {
+			if (url.pathname === '/api/st0x/v2/tokens/details') {
 				await route.fulfill({
 					status: 200,
 					contentType: 'application/json',
@@ -74,7 +74,7 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
 				});
 				return;
 			}
-			if (pathname === `/api/st0x/v1/tokens/${WT_SGOV_ADDRESS.toLowerCase()}/details`) {
+			if (pathname === `/api/st0x/v2/tokens/${WT_SGOV_ADDRESS.toLowerCase()}/details`) {
 				await route.fulfill({
 					status: 200,
 					contentType: 'application/json',
@@ -103,7 +103,7 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
 				});
 				return;
 			}
-			if (pathname === `/api/st0x/v1/tokens/wrap-ratio/${WT_SGOV_ADDRESS.toLowerCase()}/history`) {
+			if (pathname === `/api/st0x/v2/tokens/wrap-ratio/${WT_SGOV_ADDRESS.toLowerCase()}/history`) {
 				await route.fulfill({
 					status: 200,
 					contentType: 'application/json',
@@ -137,7 +137,7 @@ test.describe('Wrap ratio UX — non-1:1 wtSGOV (REST API)', () => {
 				});
 				return;
 			}
-			if (url.pathname === '/api/st0x/v1/tokens/wrap-ratio') {
+			if (url.pathname === '/api/st0x/v2/tokens/wrap-ratio') {
 				await route.fulfill({
 					status: 200,
 					contentType: 'application/json',

--- a/tests/lib/api/st0x-proxy.test.ts
+++ b/tests/lib/api/st0x-proxy.test.ts
@@ -35,7 +35,7 @@ describe('/api/st0x proxy', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('edge-caches the stable GET /v1/tokens metadata response', async () => {
+	it('edge-caches the stable GET /v2/tokens metadata response', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify([{ address: '0xToken', symbol: 'TOK', decimals: 18 }]), {
 				status: 200,
@@ -44,14 +44,14 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe(
 			'public, s-maxage=300, stale-while-revalidate=3600'
 		);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/tokens?page=1',
+			'https://api.example.test/v2/tokens?page=1',
 			expect.objectContaining({
 				method: 'GET',
 				headers: expect.any(Headers)
@@ -72,13 +72,13 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 	});
 
-	it('allows POST /v1/swap/quote and forwards the JSON body without caching', async () => {
+	it('allows POST /v2/swap/quote and forwards the JSON body without caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ estimatedInput: '100' }), {
 				status: 200,
@@ -92,19 +92,19 @@ describe('/api/st0x proxy', () => {
 			outputAmount: '1'
 		});
 
-		const response = await POST(proxyEvent('POST', 'v1/swap/quote', body));
+		const response = await POST(proxyEvent('POST', 'v2/swap/quote', body));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/swap/quote?page=1',
+			'https://api.example.test/v2/swap/quote?page=1',
 			expect.objectContaining({ method: 'POST' })
 		);
 		const init = fetchMock.mock.calls[0][1] as RequestInit;
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
-	it('allows POST /v1/orders/query without unsafe URI-only shared caching', async () => {
+	it('allows POST /v2/orders/query without unsafe URI-only shared caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(
 				JSON.stringify({
@@ -131,19 +131,19 @@ describe('/api/st0x proxy', () => {
 			pageSize: 50
 		});
 
-		const response = await POST(proxyEvent('POST', 'v1/orders/query', body));
+		const response = await POST(proxyEvent('POST', 'v2/orders/query', body));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/orders/query?page=1',
+			'https://api.example.test/v2/orders/query?page=1',
 			expect.objectContaining({ method: 'POST' })
 		);
 		const init = fetchMock.mock.calls[0][1] as RequestInit;
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
-	it('allows POST /v1/trades/query without unsafe URI-only shared caching', async () => {
+	it('allows POST /v2/trades/query without unsafe URI-only shared caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(
 				JSON.stringify({
@@ -172,19 +172,19 @@ describe('/api/st0x proxy', () => {
 			pageSize: 50
 		});
 
-		const response = await POST(proxyEvent('POST', 'v1/trades/query', body));
+		const response = await POST(proxyEvent('POST', 'v2/trades/query', body));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/trades/query?page=1',
+			'https://api.example.test/v2/trades/query?page=1',
 			expect.objectContaining({ method: 'POST' })
 		);
 		const init = fetchMock.mock.calls[0][1] as RequestInit;
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
-	it('allows POST /v1/swap/calldata without caching', async () => {
+	it('allows POST /v2/swap/calldata without caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ to: '0xOrderbook', data: '0x', value: '0', approvals: [] }), {
 				status: 200,
@@ -193,12 +193,12 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await POST(proxyEvent('POST', 'v1/swap/calldata', '{}'));
+		const response = await POST(proxyEvent('POST', 'v2/swap/calldata', '{}'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/swap/calldata?page=1',
+			'https://api.example.test/v2/swap/calldata?page=1',
 			expect.objectContaining({ method: 'POST' })
 		);
 	});
@@ -280,7 +280,7 @@ describe('/api/st0x proxy', () => {
 		expect(await new Response(init.body).text()).toBe(body);
 	});
 
-	it('allows GET /v1/trades/tx/:hash without caching', async () => {
+	it('allows GET /v2/trades/tx/:hash without caching', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ txHash: '0x1234', trades: [], totals: {} }), {
 				status: 200,
@@ -289,12 +289,12 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/trades/tx/0x1234'));
+		const response = await GET(proxyEvent('GET', 'v2/trades/tx/0x1234'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/trades/tx/0x1234?page=1',
+			'https://api.example.test/v2/trades/tx/0x1234?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
 	});
@@ -308,14 +308,14 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/wrap-ratio'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/wrap-ratio'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe(
 			'public, s-maxage=60, stale-while-revalidate=300'
 		);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/tokens/wrap-ratio?page=1',
+			'https://api.example.test/v2/tokens/wrap-ratio?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
 	});
@@ -343,14 +343,14 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/wrap-ratio/0xShare/history'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/wrap-ratio/0xShare/history'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe(
 			'public, s-maxage=60, stale-while-revalidate=300'
 		);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/tokens/wrap-ratio/0xShare/history?page=1',
+			'https://api.example.test/v2/tokens/wrap-ratio/0xShare/history?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
 	});
@@ -364,14 +364,14 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/details'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/details'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe(
 			'public, s-maxage=60, stale-while-revalidate=300'
 		);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/tokens/details?page=1',
+			'https://api.example.test/v2/tokens/details?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
 	});
@@ -391,7 +391,7 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/details'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/details'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
@@ -411,7 +411,7 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/details'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/details'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBeNull();
@@ -434,14 +434,14 @@ describe('/api/st0x proxy', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		const response = await GET(proxyEvent('GET', 'v1/tokens/0xToken/details'));
+		const response = await GET(proxyEvent('GET', 'v2/tokens/0xToken/details'));
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe(
 			'public, s-maxage=60, stale-while-revalidate=300'
 		);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://api.example.test/v1/tokens/0xToken/details?page=1',
+			'https://api.example.test/v2/tokens/0xToken/details?page=1',
 			expect.objectContaining({ method: 'GET' })
 		);
 	});
@@ -466,7 +466,7 @@ describe('/api/st0x proxy', () => {
 		vi.stubGlobal('fetch', fetchMock);
 
 		const response = await GET(
-			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+			proxyEvent('GET', 'v2/orders/token/0xToken', undefined, {
 				'X-Request-Id': 'web-request-123'
 			})
 		);
@@ -501,7 +501,7 @@ describe('/api/st0x proxy', () => {
 		vi.stubGlobal('fetch', fetchMock);
 
 		const response = await GET(
-			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+			proxyEvent('GET', 'v2/orders/token/0xToken', undefined, {
 				'X-Request-Id': incomingId
 			})
 		);
@@ -518,7 +518,7 @@ describe('/api/st0x proxy', () => {
 		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('private DNS detail')));
 
 		const response = await GET(
-			proxyEvent('GET', 'v1/orders/token/0xToken', undefined, {
+			proxyEvent('GET', 'v2/orders/token/0xToken', undefined, {
 				'X-Request-Id': 'web-request-503'
 			})
 		);

--- a/tests/lib/api/st0xApi.test.ts
+++ b/tests/lib/api/st0xApi.test.ts
@@ -31,6 +31,7 @@ describe('st0x API client', () => {
 		vi.stubGlobal('fetch', fetchMock);
 
 		const result = await apiGetSwapCalldataV2({
+			chainId: 8453,
 			taker: '0x0000000000000000000000000000000000000002',
 			inputToken: '0x0000000000000000000000000000000000000003',
 			outputToken: '0x0000000000000000000000000000000000000004',
@@ -45,6 +46,7 @@ describe('st0x API client', () => {
 			expect.objectContaining({
 				method: 'POST',
 				body: JSON.stringify({
+					chainId: 8453,
 					taker: '0x0000000000000000000000000000000000000002',
 					inputToken: '0x0000000000000000000000000000000000000003',
 					outputToken: '0x0000000000000000000000000000000000000004',
@@ -78,6 +80,7 @@ describe('st0x API client', () => {
 		vi.stubGlobal('fetch', fetchMock);
 
 		const request = {
+			chainId: 8453,
 			taker: '0x0000000000000000000000000000000000000002',
 			inputToken: responseBody.inputToken,
 			outputToken: responseBody.outputToken,
@@ -128,7 +131,7 @@ describe('st0x API client', () => {
 
 		await expect(apiQueryOrders(request, signal)).resolves.toEqual(response);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'/api/st0x/v1/orders/query',
+			'/api/st0x/v2/orders/query',
 			expect.objectContaining({
 				method: 'POST',
 				body: JSON.stringify(request),
@@ -168,7 +171,7 @@ describe('st0x API client', () => {
 
 		await expect(apiQueryTrades(request, signal)).resolves.toEqual(response);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'/api/st0x/v1/trades/query',
+			'/api/st0x/v2/trades/query',
 			expect.objectContaining({
 				method: 'POST',
 				body: JSON.stringify(request),
@@ -190,12 +193,12 @@ describe('st0x API client', () => {
 		);
 		vi.stubGlobal('fetch', fetchMock);
 
-		await expect(apiGetTradesBatch(['0xhash'])).resolves.toEqual(response);
+		await expect(apiGetTradesBatch(['0xhash'], 8453)).resolves.toEqual(response);
 		expect(fetchMock).toHaveBeenCalledWith(
-			'/api/st0x/v1/trades/query',
+			'/api/st0x/v2/trades/query',
 			expect.objectContaining({
 				method: 'POST',
-				body: JSON.stringify({ orderHashes: ['0xhash'] })
+				body: JSON.stringify({ orderHashes: ['0xhash'], chainId: 8453 })
 			})
 		);
 	});

--- a/tests/lib/config/tokenCatalog.test.ts
+++ b/tests/lib/config/tokenCatalog.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	PREVIOUS_SYMBOLS_BY_TOKEN,
+	TOKEN_SYMBOLS,
+	TOKENS,
+	getTokenByAnyAddress,
+	replaceTokenCatalog,
+	type CategorizedToken
+} from '../../../src/lib/config/tokens';
+import { TOKEN_MIGRATION_MAPPINGS } from '../../../src/lib/config/tokenMigration';
+import { TOKEN_WRAPPING_MAPPINGS } from '../../../src/lib/config/tokenWrapping';
+
+function token(overrides: Partial<CategorizedToken> = {}): CategorizedToken {
+	return {
+		chainId: 8453,
+		address: '0x0000000000000000000000000000000000000001',
+		unwrappedAddress: '0x0000000000000000000000000000000000000002',
+		legacyAddress: '0x0000000000000000000000000000000000000003',
+		symbol: 'wtTEST',
+		legacySymbol: 'tTEST',
+		previousSymbols: ['wtOLD'],
+		decimals: 18,
+		name: 'Wrapped Test ST0x',
+		priceFeedId: '0xfeed',
+		migrationOrderHash: `0x${'1'.repeat(64)}`,
+		category: 'ST0x',
+		...overrides
+	};
+}
+
+describe('runtime token catalog', () => {
+	afterEach(() => replaceTokenCatalog([]));
+
+	it('rebuilds lookups, wrapping mappings, and migration mappings in place', () => {
+		replaceTokenCatalog([token()]);
+
+		expect(TOKENS.map((item) => item.symbol)).toEqual(['wtTEST']);
+		expect(TOKEN_SYMBOLS).toEqual(['wtTEST']);
+		expect(PREVIOUS_SYMBOLS_BY_TOKEN.get('wtTEST')).toEqual(['wtOLD']);
+		expect(getTokenByAnyAddress('0x0000000000000000000000000000000000000002')?.symbol).toBe(
+			'wtTEST'
+		);
+		expect(TOKEN_WRAPPING_MAPPINGS).toHaveLength(1);
+		expect(TOKEN_MIGRATION_MAPPINGS).toHaveLength(1);
+
+		replaceTokenCatalog([
+			token({
+				address: '0x0000000000000000000000000000000000000004',
+				unwrappedAddress: '0x0000000000000000000000000000000000000005',
+				legacyAddress: undefined,
+				symbol: 'wtNEXT',
+				previousSymbols: undefined
+			})
+		]);
+
+		expect(getTokenByAnyAddress('0x0000000000000000000000000000000000000001')).toBeNull();
+		expect(TOKEN_WRAPPING_MAPPINGS[0]?.wrappedToken.symbol).toBe('wtNEXT');
+		expect(TOKEN_MIGRATION_MAPPINGS).toHaveLength(0);
+	});
+});

--- a/tests/lib/network.test.ts
+++ b/tests/lib/network.test.ts
@@ -1,252 +1,115 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
-	getNetworkById,
+	buildNetworkCatalog,
 	getNetworkByChainId,
+	getNetworkById,
 	getNetworkByName,
-	getDefaultPaymentTokenForNetwork,
-	getAllTokens,
-	getTokensByNetwork,
-	getCryptoTokensByNetwork,
-	getAllTokensByNetwork,
 	networks,
-	DEFAULT_PAYMENT_TOKENS,
-	TOKENS,
-	CRYPTO_TOKENS
-} from '$lib/config/network';
+	replaceNetworkCatalog,
+	type Network
+} from '$lib/config/networks';
+import {
+	getAllTokensByNetwork,
+	getDefaultPaymentTokenForNetwork,
+	getTokenByAnyAddress,
+	replaceTokenCatalog,
+	type CategorizedToken
+} from '$lib/config/tokens';
 
-describe('network', () => {
-	describe('getNetworkById', () => {
-		it('should find network by id', () => {
-			const network = getNetworkById(8453);
-			expect(network).toBeDefined();
-			expect(network?.id).toBe(8453);
-			expect(network?.name).toBe('base');
-		});
+const SETTINGS = `
+version: 6
+networks:
+  alpha:
+    rpcs:
+      - https://alpha.example/rpc
+      - https://alpha-fallback.example/rpc
+    chain-id: 111
+    currency: ETH
+  beta:
+    rpcs:
+      - https://beta.example/rpc
+    chain-id: 222
+    currency: BETA
+subgraphs:
+  alpha: https://alpha.example/orders
+  sft-alpha: https://alpha.example/sft
+  beta: https://beta.example/orders
+  sft-beta: https://beta.example/sft
+metaboards:
+  alpha: https://alpha.example/meta
+  beta: https://beta.example/meta
+raindexes:
+  alpha:
+    address: 0x0000000000000000000000000000000000000111
+    network: alpha
+    subgraph: alpha
+    deployment-block: 1
+  beta:
+    address: 0x0000000000000000000000000000000000000222
+    network: beta
+    subgraph: beta
+    deployment-block: 2
+`;
 
-		it.each([[9999], [-1], [0]])('should return undefined for invalid network id: %s', (id) => {
-			expect(getNetworkById(id)).toBeUndefined();
-		});
+function token(
+	chainId: number,
+	address: string,
+	symbol: string,
+	category: 'ST0x' | 'CRYPTO'
+): CategorizedToken {
+	return {
+		chainId,
+		address,
+		symbol,
+		decimals: category === 'CRYPTO' ? 6 : 18,
+		name: symbol,
+		category,
+		paymentToken: category === 'CRYPTO'
+	};
+}
+
+const TOKENS = [
+	token(111, '0x0000000000000000000000000000000000000001', 'wtONE', 'ST0x'),
+	token(111, '0x0000000000000000000000000000000000000011', 'USDC', 'CRYPTO'),
+	token(222, '0x0000000000000000000000000000000000000001', 'wtTWO', 'ST0x'),
+	token(222, '0x0000000000000000000000000000000000000022', 'USDB', 'CRYPTO')
+];
+
+describe('registry-backed network catalog', () => {
+	afterEach(() => {
+		replaceTokenCatalog([]);
+		replaceNetworkCatalog([]);
 	});
 
-	describe('getNetworkByChainId', () => {
-		it('should find network by chainId', () => {
-			const network = getNetworkByChainId(8453);
-			expect(network).toBeDefined();
-			expect(network?.chainId).toBe(8453);
-		});
+	it('uses the Raindex SDK settings model to build every configured network', async () => {
+		replaceTokenCatalog(TOKENS);
+		const catalog = await buildNetworkCatalog(SETTINGS, TOKENS);
+		replaceNetworkCatalog(catalog);
 
-		it.each([[9999], [-1]])('should return undefined for invalid chainId: %s', (chainId) => {
-			expect(getNetworkByChainId(chainId)).toBeUndefined();
-		});
+		expect(networks.map((network) => network.chainId)).toEqual([111, 222]);
+		expect(getNetworkById(111)?.rpcUrl).toBe('https://alpha.example/rpc');
+		expect(getNetworkByChainId(222)?.defaultPaymentToken.symbol).toBe('USDB');
+		expect(getNetworkByName('beta')?.trustedOrderbooks).toEqual([
+			'0x0000000000000000000000000000000000000222'
+		]);
+		expect(catalog[0]?.fallbackRpcUrls).toEqual(['https://alpha-fallback.example/rpc']);
 	});
 
-	describe('getNetworkByName', () => {
-		it('should find network by name', () => {
-			const network = getNetworkByName('base');
-			expect(network).toBeDefined();
-			expect(network?.name).toBe('base');
-			expect(network?.displayName).toBe('Base Mainnet');
-		});
-
-		it.each([
-			['Base'], // case-sensitive
-			['unknown'],
-			['']
-		])('should return undefined for invalid name: %s', (name) => {
-			expect(getNetworkByName(name)).toBeUndefined();
-		});
+	it('keeps same-address tokens isolated by chain', () => {
+		replaceTokenCatalog(TOKENS);
+		expect(getTokenByAnyAddress(TOKENS[0].address)).toBeNull();
+		expect(getTokenByAnyAddress(TOKENS[0].address, 111)?.symbol).toBe('wtONE');
+		expect(getTokenByAnyAddress(TOKENS[0].address, 222)?.symbol).toBe('wtTWO');
+		expect(getAllTokensByNetwork(222).map((item) => item.symbol)).toEqual(['wtTWO', 'USDB']);
+		expect(getDefaultPaymentTokenForNetwork(111)?.symbol).toBe('USDC');
 	});
 
-	describe('getDefaultPaymentTokenForNetwork', () => {
-		it('should get payment token for Base', () => {
-			const token = getDefaultPaymentTokenForNetwork(8453);
-			expect(token).toBeDefined();
-			expect(token?.symbol).toBe('USDC');
-			expect(token?.decimals).toBe(6);
-			expect(token?.chainId).toBe(8453);
-		});
-
-		it('should return undefined for network without configured payment token', () => {
-			expect(getDefaultPaymentTokenForNetwork(9999)).toBeUndefined();
-		});
-
-		it('should have valid token properties', () => {
-			const token = getDefaultPaymentTokenForNetwork(8453);
-			expect(token?.address).toBeDefined();
-			expect(token?.name).toBeDefined();
-		});
-	});
-
-	describe('getAllTokens', () => {
-		it('should return all tokens from TOKENS array', () => {
-			const tokens = getAllTokens();
-			expect(tokens).toEqual(TOKENS);
-		});
-
-		it('should include ST0x tokens', () => {
-			const tokens = getAllTokens();
-			const st0xTokens = tokens.filter((t) => t.category === 'ST0x');
-			expect(st0xTokens.length).toBeGreaterThan(0);
-		});
-
-		it('should not include CRYPTO tokens from CRYPTO_TOKENS', () => {
-			const allTokens = getAllTokens();
-			const cryptoTokensSet = new Set(CRYPTO_TOKENS.map((t) => t.address.toLowerCase()));
-			const hasCrypto = allTokens.some((t) => cryptoTokensSet.has(t.address.toLowerCase()));
-			expect(hasCrypto).toBe(false);
-		});
-	});
-
-	describe('getTokensByNetwork', () => {
-		it('should get tokens for Base network', () => {
-			const tokens = getTokensByNetwork(8453);
-			expect(tokens.length).toBeGreaterThan(0);
-			expect(tokens.every((t) => t.chainId === 8453)).toBe(true);
-		});
-
-		it('should include wtIAU for Base', () => {
-			const tokens = getTokensByNetwork(8453);
-			const wtIAU = tokens.find((t) => t.symbol === 'wtIAU');
-			expect(wtIAU).toBeDefined();
-		});
-
-		it('should return empty array for unknown network', () => {
-			expect(getTokensByNetwork(9999)).toEqual([]);
-		});
-	});
-
-	describe('getCryptoTokensByNetwork', () => {
-		it.each([
-			[8453], // Base
-			[42161] // Arbitrum
-		])('should get crypto tokens for network %s', (chainId) => {
-			const tokens = getCryptoTokensByNetwork(chainId);
-			expect(tokens.length).toBeGreaterThan(0);
-			expect(tokens.every((t) => t.chainId === chainId)).toBe(true);
-		});
-
-		it('should include USDC for both Base and Arbitrum', () => {
-			const baseTokens = getCryptoTokensByNetwork(8453);
-			const arbTokens = getCryptoTokensByNetwork(42161);
-
-			const baseUsdc = baseTokens.find((t) => t.symbol === 'USDC');
-			const arbUsdc = arbTokens.find((t) => t.symbol === 'USDC');
-
-			expect(baseUsdc).toBeDefined();
-			expect(arbUsdc).toBeDefined();
-		});
-
-		it('should return empty array for unknown network', () => {
-			expect(getCryptoTokensByNetwork(9999)).toEqual([]);
-		});
-	});
-
-	describe('getAllTokensByNetwork', () => {
-		it('should combine regular and crypto tokens for Base', () => {
-			const allTokens = getAllTokensByNetwork(8453);
-			const regularTokens = getTokensByNetwork(8453);
-			const cryptoTokens = getCryptoTokensByNetwork(8453);
-
-			// Verify that all tokens are actually present in the combined result
-			regularTokens.forEach((token) => {
-				expect(allTokens).toContainEqual(token);
-			});
-			cryptoTokens.forEach((token) => {
-				expect(allTokens).toContainEqual(token);
-			});
-		});
-
-		it('should include both ST0x and CRYPTO tokens', () => {
-			const allTokens = getAllTokensByNetwork(8453);
-			const hasST0x = allTokens.some((t) => t.category === 'ST0x');
-			const hasCrypto = allTokens.some((t) => t.category === 'CRYPTO');
-
-			expect(hasST0x).toBe(true);
-			expect(hasCrypto).toBe(true);
-		});
-
-		it('should not have duplicate tokens by address', () => {
-			const allTokens = getAllTokensByNetwork(8453);
-			const addresses = allTokens.map((t) => t.address.toLowerCase());
-			const uniqueAddresses = new Set(addresses);
-
-			expect(addresses.length).toBe(uniqueAddresses.size);
-		});
-
-		it('should return empty array for unknown network', () => {
-			expect(getAllTokensByNetwork(9999)).toEqual([]);
-		});
-	});
-
-	describe('token properties validation', () => {
-		it('should have all required properties for ST0x tokens', () => {
-			const tokens = TOKENS.filter((t) => t.category === 'ST0x');
-			tokens.forEach((token) => {
-				expect(token.address).toBeDefined();
-				expect(token.symbol).toBeDefined();
-				expect(token.decimals).toBeDefined();
-				expect(token.chainId).toBeDefined();
-				expect(token.category).toBe('ST0x');
-			});
-		});
-
-		it('should have valid addresses (starting with 0x)', () => {
-			const allTokens = [...TOKENS, ...CRYPTO_TOKENS];
-			allTokens.forEach((token) => {
-				expect(token.address).toMatch(/^0x[a-fA-F0-9]{40}$/);
-			});
-		});
-
-		it('should have valid decimal values', () => {
-			const allTokens = [...TOKENS, ...CRYPTO_TOKENS];
-			allTokens.forEach((token) => {
-				expect(token.decimals).toBeGreaterThanOrEqual(0);
-				expect(token.decimals).toBeLessThanOrEqual(30);
-			});
-		});
-	});
-
-	describe('network properties validation', () => {
-		it('should have all required properties', () => {
-			networks.forEach((network) => {
-				expect(network.id).toBeDefined();
-				expect(network.chainId).toBeDefined();
-				expect(network.name).toBeDefined();
-				expect(network.displayName).toBeDefined();
-				expect(network.rpcUrl).toBeDefined();
-				expect(network.blockExplorer).toBeDefined();
-				expect(network.subgraph_url).toBeDefined();
-				expect(network.orderbook_subgraph_url).toBeDefined();
-			});
-		});
-
-		it('should have matching id and chainId for Base', () => {
-			const network = networks.find((n) => n.name === 'base');
-			expect(network).toBeDefined();
-			expect(network?.id).toBe(network?.chainId);
-		});
-
-		it('should have valid URLs', () => {
-			networks.forEach((network) => {
-				expect(network.rpcUrl).toMatch(/^https?:\/\//);
-				expect(network.blockExplorer).toMatch(/^https?:\/\//);
-				expect(network.subgraph_url).toMatch(/^https?:\/\//);
-			});
-		});
-	});
-
-	describe('payment token configuration', () => {
-		it('should have default payment token for Base', () => {
-			expect(DEFAULT_PAYMENT_TOKENS[8453]).toBeDefined();
-			expect(DEFAULT_PAYMENT_TOKENS[8453].symbol).toBe('USDC');
-		});
-
-		it('should match network default payment token', () => {
-			const network = getNetworkById(8453);
-			const token = getDefaultPaymentTokenForNetwork(8453);
-			expect(network?.defaultPaymentToken).toEqual(token);
-		});
+	it('rejects a registry chain without a REST payment token', async () => {
+		await expect(
+			buildNetworkCatalog(
+				SETTINGS,
+				TOKENS.filter((item) => item.chainId === 111)
+			)
+		).rejects.toThrow('no payment token for chain 222');
 	});
 });

--- a/tests/lib/queries/exchangeRates.test.ts
+++ b/tests/lib/queries/exchangeRates.test.ts
@@ -24,6 +24,7 @@ describe('exchangeRates REST adapters', () => {
 	it('composes token refs from token metadata and resolves by share or asset address', () => {
 		const rate = mapApiWrapRatio(
 			{
+				chainId: 8453,
 				shareAddress: '0xShare',
 				assetAddress: '0xAsset',
 				assetsPerShare: '1.0027',
@@ -45,6 +46,7 @@ describe('exchangeRates REST adapters', () => {
 	it('maps snapshot history events', () => {
 		const history = mapApiWrapRatioHistory(
 			{
+				chainId: 8453,
 				shareAddress: '0xShare',
 				assetAddress: '0xAsset',
 				events: [

--- a/tests/lib/queries/tokens.test.ts
+++ b/tests/lib/queries/tokens.test.ts
@@ -75,6 +75,33 @@ describe('normalizeApiTokensForNetwork', () => {
 		expect(tokens[0].legacyAddress).toBeUndefined();
 	});
 
+	it('normalizes remote pricing and historical metadata', () => {
+		const tokens = normalizeApiTokensForNetwork(
+			[
+				apiToken({
+					symbol: 'wtSPYM',
+					isin: 'US78464A8541',
+					extensions: {
+						category: 'ST0x',
+						priceFeedId: '0xfeed',
+						fallbackPrice: 82.5,
+						previousSymbols: ['wtSPLG', 'tSPLG'],
+						receiptAddress: '0x0000000000000000000000000000000000000002'
+					}
+				})
+			],
+			8453
+		);
+
+		expect(tokens[0]).toMatchObject({
+			priceFeedId: '0xfeed',
+			fallbackPrice: 82.5,
+			previousSymbols: ['wtSPLG', 'tSPLG'],
+			receiptAddress: '0x0000000000000000000000000000000000000002',
+			isin: 'US78464A8541'
+		});
+	});
+
 	it('deduplicates API tokens by address', () => {
 		const tokens = normalizeApiTokensForNetwork(
 			[

--- a/tests/lib/seo/trade.test.ts
+++ b/tests/lib/seo/trade.test.ts
@@ -17,7 +17,7 @@ describe('trade SEO metadata', () => {
 		expect(metadata).toEqual({
 			title: 'Trade Wrapped NVIDIA Corporation ST0x | ST0x',
 			description:
-				'Trade Wrapped NVIDIA Corporation ST0x 24/7 on ST0x with on-chain execution and non-custodial settlement on Base.',
+				'Trade Wrapped NVIDIA Corporation ST0x 24/7 on ST0x with on-chain execution and non-custodial settlement on supported networks.',
 			canonicalUrl: `https://www.st0x.io/trade/${NVDA_WRAPPED}`
 		});
 	});

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
 	update: vi.fn(),
 	invalidateDashboardBalances: vi.fn(),
 	trackTradeEvent: vi.fn(),
-	captureTradeFlowError: vi.fn()
+	captureTradeFlowError: vi.fn(),
+	isOutsideMarketHours: vi.fn()
 }));
 
 vi.mock('$lib/api/st0xApi', () => ({
@@ -30,7 +31,10 @@ vi.mock('$lib/services/walletService', () => ({
 	waitForTransaction: mocks.waitForTransaction
 }));
 vi.mock('$lib/queries/balances', () => ({
-	invalidateDashboardBalances: mocks.invalidateDashboardBalances
+	invalidateExecutedTradeQueries: mocks.invalidateDashboardBalances
+}));
+vi.mock('$lib/utils/marketHours', () => ({
+	isOutsideMarketHours: mocks.isOutsideMarketHours
 }));
 vi.mock('$lib/stores/transactionShared', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
@@ -256,6 +260,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.getSignerAddress.mockReturnValue(TAKER);
+		mocks.isOutsideMarketHours.mockReturnValue(false);
 		mocks.apiGetSwapCalldataV2.mockImplementation(async (request) => readyResponse(request));
 		mocks.apiGetTradesByTx.mockImplementation(async () => {
 			const request = mocks.apiGetSwapCalldataV2.mock.calls.at(-1)?.[0];
@@ -293,7 +298,8 @@ describe('executeMarketOrder REST calldata execution', () => {
 		expect(mocks.sendTransaction).toHaveBeenCalledWith({
 			to: ORDERBOOK,
 			data: expect.stringMatching(/^0x69c72856/),
-			value: 0n
+			value: 0n,
+			chainId: 8453
 		});
 		expect(mocks.apiGetTradesByTx).toHaveBeenCalledWith(TRADE_HASH, 8453);
 		expect(mocks.transactionSuccess).toHaveBeenCalledWith(TRADE_HASH, 'Market order confirmed', {
@@ -502,9 +508,10 @@ describe('executeMarketOrder REST calldata execution', () => {
 		expect(result.success).toBe(true);
 		expect(mocks.sendTransaction).toHaveBeenNthCalledWith(1, {
 			to: PAYMENT,
-			data: approvalData
+			data: approvalData,
+			chainId: 8453
 		});
-		expect(mocks.waitForTransaction).toHaveBeenNthCalledWith(1, APPROVAL_HASH, {
+		expect(mocks.waitForTransaction).toHaveBeenNthCalledWith(1, APPROVAL_HASH, 8453, {
 			confirmations: 2
 		});
 		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(2, {
@@ -626,5 +633,24 @@ describe('executeMarketOrder REST calldata execution', () => {
 				stage: 'signing'
 			}
 		});
+	});
+
+	it('blocks execution before API or wallet work while the market is closed', async () => {
+		mocks.isOutsideMarketHours.mockReturnValue(true);
+
+		const result = await executeMarketOrder({
+			orderSide: 'Buy',
+			amount: 1_000_000_000_000_000_000n,
+			...tokens,
+			network
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errorClass: 'market_closed',
+			tradeError: { code: 'TRADE_MARKET_CLOSED' }
+		});
+		expect(mocks.apiGetSwapCalldataV2).not.toHaveBeenCalled();
+		expect(mocks.sendTransaction).not.toHaveBeenCalled();
 	});
 });

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -16,8 +16,7 @@ const mocks = vi.hoisted(() => ({
 	update: vi.fn(),
 	invalidateDashboardBalances: vi.fn(),
 	trackTradeEvent: vi.fn(),
-	captureTradeFlowError: vi.fn(),
-	isOutsideMarketHours: vi.fn()
+	captureTradeFlowError: vi.fn()
 }));
 
 vi.mock('$lib/api/st0xApi', () => ({
@@ -32,9 +31,6 @@ vi.mock('$lib/services/walletService', () => ({
 }));
 vi.mock('$lib/queries/balances', () => ({
 	invalidateExecutedTradeQueries: mocks.invalidateDashboardBalances
-}));
-vi.mock('$lib/utils/marketHours', () => ({
-	isOutsideMarketHours: mocks.isOutsideMarketHours
 }));
 vi.mock('$lib/stores/transactionShared', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
@@ -260,7 +256,6 @@ describe('executeMarketOrder REST calldata execution', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.getSignerAddress.mockReturnValue(TAKER);
-		mocks.isOutsideMarketHours.mockReturnValue(false);
 		mocks.apiGetSwapCalldataV2.mockImplementation(async (request) => readyResponse(request));
 		mocks.apiGetTradesByTx.mockImplementation(async () => {
 			const request = mocks.apiGetSwapCalldataV2.mock.calls.at(-1)?.[0];
@@ -633,24 +628,5 @@ describe('executeMarketOrder REST calldata execution', () => {
 				stage: 'signing'
 			}
 		});
-	});
-
-	it('blocks execution before API or wallet work while the market is closed', async () => {
-		mocks.isOutsideMarketHours.mockReturnValue(true);
-
-		const result = await executeMarketOrder({
-			orderSide: 'Buy',
-			amount: 1_000_000_000_000_000_000n,
-			...tokens,
-			network
-		});
-
-		expect(result).toMatchObject({
-			success: false,
-			errorClass: 'market_closed',
-			tradeError: { code: 'TRADE_MARKET_CLOSED' }
-		});
-		expect(mocks.apiGetSwapCalldataV2).not.toHaveBeenCalled();
-		expect(mocks.sendTransaction).not.toHaveBeenCalled();
 	});
 });

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -73,6 +73,7 @@ const APPROVAL_HASH = `0x${'a'.repeat(64)}` as const;
 const TRADE_HASH = `0x${'b'.repeat(64)}` as const;
 const network = {
 	id: 8453,
+	chainId: 8453,
 	trustedOrderbooks: [ORDERBOOK]
 } as unknown as Parameters<typeof executeMarketOrder>[0]['network'];
 const tokens = {
@@ -114,6 +115,7 @@ function takeOrdersData(request: ApiSwapCalldataV2Request) {
 
 function readyResponse(
 	request: ApiSwapCalldataV2Request = {
+		chainId: 8453,
 		taker: TAKER,
 		inputToken: PAYMENT,
 		outputToken: ASSET,
@@ -141,12 +143,14 @@ function indexedTradeResponse(request: ApiSwapCalldataV2Request) {
 	const totalOutputAmount =
 		request.mode === 'buyUpTo' ? request.amount : inputIsPayment ? '1' : '100';
 	return {
+		chainId: request.chainId,
 		txHash: TRADE_HASH,
 		blockNumber: 123,
 		timestamp: 1_700_000_000,
 		sender: TAKER,
 		trades: [
 			{
+				chainId: request.chainId,
 				orderHash: ZERO_BYTES32,
 				orderOwner: TAKER,
 				request: {
@@ -241,6 +245,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 				})
 			).toEqual({
 				...expected,
+				chainId: 8453,
 				slippageBps: 75,
 				referenceIoRatio: '2.5',
 				denomination: 'wrapped'
@@ -275,6 +280,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 
 		expect(result).toEqual({ success: true });
 		expect(mocks.apiGetSwapCalldataV2).toHaveBeenCalledWith({
+			chainId: 8453,
 			taker: TAKER,
 			inputToken: PAYMENT,
 			outputToken: ASSET,
@@ -289,7 +295,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 			data: expect.stringMatching(/^0x69c72856/),
 			value: 0n
 		});
-		expect(mocks.apiGetTradesByTx).toHaveBeenCalledWith(TRADE_HASH);
+		expect(mocks.apiGetTradesByTx).toHaveBeenCalledWith(TRADE_HASH, 8453);
 		expect(mocks.transactionSuccess).toHaveBeenCalledWith(TRADE_HASH, 'Market order confirmed', {
 			marketOrderSummary: expect.objectContaining({
 				inputAmount: 2_000_000_000_000_000_000n,
@@ -303,6 +309,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 	it('reports a spend-anchored partial fill from indexed REST trade totals', async () => {
 		mocks.apiGetTradesByTx.mockResolvedValue({
 			...indexedTradeResponse({
+				chainId: 8453,
 				taker: TAKER,
 				inputToken: ASSET,
 				outputToken: PAYMENT,
@@ -344,6 +351,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 	it('keeps a confirmed transaction successful when indexed summary data is malformed', async () => {
 		mocks.apiGetTradesByTx.mockResolvedValue({
 			...indexedTradeResponse({
+				chainId: 8453,
 				taker: TAKER,
 				inputToken: PAYMENT,
 				outputToken: ASSET,
@@ -456,6 +464,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 			args: [ORDERBOOK, 100_000_000n]
 		});
 		const retryRequest = {
+			chainId: 8453,
 			taker: TAKER,
 			inputToken: PAYMENT,
 			outputToken: ASSET,

--- a/tests/lib/services/walletService.test.ts
+++ b/tests/lib/services/walletService.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+	method: 'dynamic' as 'dynamic' | 'wallet' | 'none',
+	dynamicAddress: '0x1111111111111111111111111111111111111111',
+	wagmiConfig: { id: 'config' }
+}));
+const mocks = vi.hoisted(() => ({
+	wagmiSendTransaction: vi.fn(),
+	wagmiWaitForTransactionReceipt: vi.fn(),
+	wagmiSignMessage: vi.fn()
+}));
+
+vi.mock('$lib/stores/authStore', () => ({
+	authMethod: {
+		subscribe: (run: (value: typeof state.method) => void) => (run(state.method), () => undefined)
+	}
+}));
+vi.mock('$lib/stores/dynamicStore', () => ({
+	dynamicWalletAddress: {
+		subscribe: (run: (value: string) => void) => (run(state.dynamicAddress), () => undefined)
+	}
+}));
+vi.mock('svelte-wagmi', () => ({
+	wagmiConfig: {
+		subscribe: (run: (value: typeof state.wagmiConfig) => void) => (
+			run(state.wagmiConfig), () => undefined
+		)
+	},
+	signerAddress: { subscribe: (run: (value: null) => void) => (run(null), () => undefined) }
+}));
+vi.mock('@wagmi/core', () => ({
+	sendTransaction: mocks.wagmiSendTransaction,
+	waitForTransactionReceipt: mocks.wagmiWaitForTransactionReceipt,
+	signMessage: mocks.wagmiSignMessage
+}));
+
+import {
+	sendTransaction,
+	setDynamicWalletProvider,
+	waitForTransaction
+} from '$lib/services/walletService';
+
+const HASH = `0x${'a'.repeat(64)}` as const;
+
+describe('walletService chain binding', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		state.method = 'dynamic';
+		mocks.wagmiSendTransaction.mockResolvedValue(HASH);
+		mocks.wagmiWaitForTransactionReceipt.mockResolvedValue({ status: 'success' });
+		setDynamicWalletProvider(null);
+	});
+
+	it('switches and verifies the requested Dynamic chain before submission', async () => {
+		const request = vi.fn(async ({ method }: { method: string }) => {
+			if (method === 'eth_chainId') return '0x2105';
+			if (method === 'eth_sendTransaction') return HASH;
+			return null;
+		});
+		setDynamicWalletProvider({ request });
+
+		await expect(
+			sendTransaction({
+				to: '0x2222222222222222222222222222222222222222',
+				chainId: 8453
+			})
+		).resolves.toBe(HASH);
+		expect(request).toHaveBeenNthCalledWith(1, {
+			method: 'wallet_switchEthereumChain',
+			params: [{ chainId: '0x2105' }]
+		});
+		expect(request).toHaveBeenCalledWith({ method: 'eth_chainId' });
+	});
+
+	it('does not submit when Dynamic remains on a different chain', async () => {
+		const request = vi.fn(async ({ method }: { method: string }) =>
+			method === 'eth_chainId' ? '0xa' : null
+		);
+		setDynamicWalletProvider({ request });
+
+		await expect(
+			sendTransaction({
+				to: '0x2222222222222222222222222222222222222222',
+				chainId: 8453
+			})
+		).rejects.toThrow('Wallet did not switch to chain 8453');
+		expect(request).not.toHaveBeenCalledWith(
+			expect.objectContaining({ method: 'eth_sendTransaction' })
+		);
+	});
+
+	it('pins wagmi submission and receipt polling to the caller chain', async () => {
+		state.method = 'wallet';
+
+		await sendTransaction({
+			to: '0x2222222222222222222222222222222222222222',
+			chainId: 10
+		});
+		await waitForTransaction(HASH, 10, { confirmations: 2 });
+
+		expect(mocks.wagmiSendTransaction).toHaveBeenCalledWith(
+			state.wagmiConfig,
+			expect.objectContaining({ chainId: 10 })
+		);
+		expect(mocks.wagmiWaitForTransactionReceipt).toHaveBeenCalledWith(
+			state.wagmiConfig,
+			expect.objectContaining({ hash: HASH, chainId: 10, confirmations: 2 })
+		);
+	});
+});

--- a/tests/lib/transactionStore.test.ts
+++ b/tests/lib/transactionStore.test.ts
@@ -5,8 +5,10 @@ import { readContract, sendTransaction, waitForTransactionReceipt, estimateGas }
 import {
 	TOKENS,
 	DEFAULT_PAYMENT_TOKENS,
-	getDefaultPaymentTokenForNetwork
+	getDefaultPaymentTokenForNetwork,
+	replaceTokenCatalog
 } from '$lib/config/network';
+import { TEST_ST0X_TOKENS } from '../fixtures/st0xTokenCatalog';
 import { rainlangConfirmationModal, currentNetwork, reviewStrategyOnDeploy } from '$lib/stores';
 
 const STOXs = TOKENS;
@@ -205,6 +207,7 @@ describe('transactionStore tests', () => {
 	let mockGetAddOrdersForTransaction: ReturnType<typeof vi.fn>;
 
 	beforeEach(async () => {
+		replaceTokenCatalog(TEST_ST0X_TOKENS);
 		vi.clearAllMocks();
 		transactionStore.reset();
 

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,10 +1,18 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
-import {  web3ModalStore } from './tests/mocks/mockStores';
+import { web3ModalStore } from './tests/mocks/mockStores';
 import { mockCurrentNetwork } from './tests/mocks/mockCurrentNetwork';
+import { TEST_CRYPTO_TOKENS, TEST_ST0X_TOKENS } from './tests/fixtures/st0xTokenCatalog';
+import { replaceTokenCatalog } from './src/lib/config/tokens';
+import { replaceNetworkCatalog, type Network } from './src/lib/config/networks';
 
-const { mockWagmiConfigStore, mockSignerAddressStore, mockChainIdStore, mockConnectedStore, mockWrongNetworkStore } =
-	await vi.hoisted(() => import('./tests/mocks/mockStores'));
+const {
+	mockWagmiConfigStore,
+	mockSignerAddressStore,
+	mockChainIdStore,
+	mockConnectedStore,
+	mockWrongNetworkStore
+} = await vi.hoisted(() => import('./tests/mocks/mockStores'));
 
 // SvelteKit's vitest resolver produces a virtual module for `$env/dynamic/public`
 // whose `env` is undefined in the test environment. Provide a default empty `env`;
@@ -22,7 +30,7 @@ vi.mock('svelte-wagmi', async () => {
 });
 
 vi.mock('$lib/stores', async (importOriginal) => {
-	const actual = await importOriginal() as object;
+	const actual = (await importOriginal()) as object;
 	return {
 		...actual,
 		wrongNetwork: mockWrongNetworkStore,
@@ -44,8 +52,10 @@ vi.mock('$lib/stores', async (importOriginal) => {
 // unaffected — Sentry init is gated on !dev && DSN in hooks.{client,server}.ts.
 vi.mock('@sentry/sveltekit', async () => {
 	const noop = () => {};
-	const noopHandler = () => async ({ event, resolve }: { event: unknown; resolve: (e: unknown) => unknown }) =>
-		resolve(event);
+	const noopHandler =
+		() =>
+		async ({ event, resolve }: { event: unknown; resolve: (e: unknown) => unknown }) =>
+			resolve(event);
 	return {
 		init: noop,
 		captureException: noop,
@@ -55,7 +65,8 @@ vi.mock('@sentry/sveltekit', async () => {
 		setTag: noop,
 		setContext: noop,
 		setExtra: noop,
-		withScope: (fn: (scope: unknown) => void) => fn({ setTag: noop, setContext: noop, setExtra: noop }),
+		withScope: (fn: (scope: unknown) => void) =>
+			fn({ setTag: noop, setContext: noop, setExtra: noop }),
 		sentryHandle: noopHandler,
 		handleErrorWithSentry: () => () => undefined,
 		// Vite plugin export is referenced by vite.config.js but tests don't run Vite plugins.
@@ -109,3 +120,8 @@ vi.mock('$app/stores', async () => {
 		updated
 	};
 });
+
+// Runtime catalogs are intentionally empty until the application hydrates them.
+// Unit tests use an explicit registry/API fixture so they exercise the same dynamic path.
+replaceTokenCatalog([...TEST_ST0X_TOKENS, ...TEST_CRYPTO_TOKENS]);
+replaceNetworkCatalog([mockCurrentNetwork as Network]);


### PR DESCRIPTION
## Motivation

The website still treated Base as compile-time configuration even though the REST API and Dotrain registry are the authoritative sources for tokens, networks, RPCs, and orderbooks. That would make a second configured network unsafe: token addresses could collide, requests could omit chain context, and snapshots/TVL could mix data across chains.

This change is designed to ship with [ST0x REST API #151](https://github.com/ST0x-Technology/st0x.rest.api/pull/151).

## Solution

- Hydrate the runtime token catalog from the REST API v2 token response instead of bundled Base token arrays.
- Resolve the API active registry source commit and load its settings through DotrainRegistry and RaindexClient.
- Build the network selector, wagmi chains, RPC fallbacks, payment tokens, and trusted orderbooks from the registry catalog.
- Forward chainId through token, order, trade, swap, price, proof, wrapping, authentication, and wallet flows.
- Make wallet reads/writes and signature verification explicitly use the selected registry network.
- Partition snapshot paths, preview APIs, TVL, trade activity, token lookup, and platform metrics by chain ID.
- Keep legacy snapshot fallback only while exactly one network is configured, preventing old Base snapshots from leaking into future networks.
- Replace Base-specific explorer/native-currency behavior with selected-network metadata.

## Deployment dependency

Deploy this after or together with REST API #151. The website requires the API registry metadata to expose a valid source_commit and uses the v2 chain-aware routes.

The current public registry configures only Base, so the selector currently contains one option and will expand automatically as networks are added. Legacy migration actions also require migrationOrderHash in the REST token extensions; no Base-only order hashes remain in the website.

## Validation

- npm run svelte-lint-format-check
- npm test -- --run (85 files, 856 passed, 1 skipped)
- production build with Node 22 and adapter-vercel
- local REST API PR branch reached ready/healthy sync for chain 8453
- production preview loaded the current API registry source commit and rendered the live asset table
- registry-derived network dropdown opened with Base / ETH metadata
- browser proxy verification: chainId 8453 returned 39 tokens all tagged 8453; unsupported chainId 999999 returned HTTP 400
- synthetic two-network tests cover catalog construction, per-chain payment tokens, and same-address isolation across chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple networks with dynamically loaded network and token catalogs.
  * Network-specific balances, trades, swaps, wrapping, snapshots, explorer links, and wallet transactions are now supported.
  * Payment tokens and native currencies are selected based on the active network.
  * Updated integrations to use v2 endpoints and chain-aware requests.

* **Bug Fixes**
  * Prevented network-mismatched token, order, trade, and balance data.
  * Improved handling when no network or explorer details are available.
  * Improved catalog refresh and legacy snapshot fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->