### PR TITLE
fix: refresh market calldata before wallet broadcast

### DIFF
--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -4,8 +4,9 @@
  * The browser deliberately does not walk orders, hydrate SDK objects, simulate
  * candidates, derive price caps, or build takeOrders calldata. Those decisions
  * live in the REST API and the Raindex SDK it calls. This module validates the
- * returned transactions, handles approvals, submits them, and reports indexed
- * fill totals after confirmation.
+ * returned transactions, handles approvals, refreshes executable calldata
+ * immediately before broadcast (so short-lived oracle signed context stays
+ * fresh), submits them, and reports indexed fill totals after confirmation.
  */
 
 import {
@@ -444,6 +445,17 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 				buildApprovalRetryRequest(request, response.resolvedPriceCap)
 			);
 		}
+
+		// Oracle-backed orders embed a short-lived signed quote in takeOrders
+		// calldata. Approvals and wallet confirmation can outlive that quote, so
+		// fetch a fresh frame with the already-resolved price cap immediately
+		// before asking the wallet to broadcast.
+		activeTradeErrorStage = 'calldata';
+		addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'started');
+		response = await apiGetSwapCalldataV2(
+			buildApprovalRetryRequest(request, response.resolvedPriceCap)
+		);
+		addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'completed');
 
 		const transaction = validateReadyCalldata(response, request, network);
 		activeStage = 'submission';

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -82,7 +82,10 @@ const tokens = {
 
 const ZERO_BYTES32 = `0x${'0'.repeat(64)}` as const;
 
-function takeOrdersData(request: ApiSwapCalldataV2Request) {
+function takeOrdersData(
+	request: ApiSwapCalldataV2Request,
+	options: { nonce?: `0x${string}` } = {}
+) {
 	return encodeFunctionData({
 		abi: TAKE_ORDERS_4_ABI,
 		functionName: 'takeOrders4',
@@ -99,7 +102,7 @@ function takeOrdersData(request: ApiSwapCalldataV2Request) {
 							evaluable: { interpreter: TAKER, store: TAKER, bytecode: '0x' },
 							validInputs: [{ token: request.inputToken, vaultId: ZERO_BYTES32 }],
 							validOutputs: [{ token: request.outputToken, vaultId: ZERO_BYTES32 }],
-							nonce: ZERO_BYTES32
+							nonce: options.nonce ?? ZERO_BYTES32
 						},
 						inputIOIndex: 0n,
 						outputIOIndex: 0n,
@@ -449,7 +452,61 @@ describe('executeMarketOrder REST calldata execution', () => {
 		);
 	});
 
-	it('submits API approvals then retries with the fixed resolved price cap', async () => {
+	it('refreshes ready calldata immediately before wallet broadcast', async () => {
+		const initialRequest = {
+			taker: TAKER,
+			inputToken: PAYMENT,
+			outputToken: ASSET,
+			mode: 'buyUpTo' as const,
+			amount: '1',
+			slippageBps: 100,
+			denomination: 'wrapped' as const
+		};
+		const refreshRequest = {
+			taker: TAKER,
+			inputToken: PAYMENT,
+			outputToken: ASSET,
+			mode: 'buyUpTo' as const,
+			amount: '1',
+			priceCap: '2.02',
+			denomination: 'wrapped' as const
+		};
+		const staleData = takeOrdersData(initialRequest, { nonce: `0x${'1'.repeat(64)}` });
+		const freshData = takeOrdersData(refreshRequest, { nonce: `0x${'2'.repeat(64)}` });
+		mocks.apiGetSwapCalldataV2
+			.mockResolvedValueOnce({
+				...readyResponse(initialRequest),
+				data: staleData,
+				resolvedPriceCap: '2.02'
+			})
+			.mockResolvedValueOnce({
+				...readyResponse(refreshRequest),
+				data: freshData,
+				resolvedPriceCap: '2.02'
+			});
+
+		const result = await executeMarketOrder({
+			orderSide: 'Buy',
+			amount: 1_000_000_000_000_000_000n,
+			slippageBps: 100,
+			...tokens,
+			network
+		});
+
+		expect(result.success).toBe(true);
+		expect(mocks.apiGetSwapCalldataV2).toHaveBeenCalledTimes(2);
+		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(2, refreshRequest);
+		expect(mocks.sendTransaction).toHaveBeenCalledWith({
+			to: ORDERBOOK,
+			data: freshData,
+			value: 0n
+		});
+		expect(mocks.sendTransaction).not.toHaveBeenCalledWith(
+			expect.objectContaining({ data: staleData })
+		);
+	});
+
+	it('submits API approvals then retries and refreshes with the fixed resolved price cap', async () => {
 		const approvalData = encodeFunctionData({
 			abi: erc20Abi,
 			functionName: 'approve',
@@ -479,6 +536,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 					}
 				]
 			})
+			.mockResolvedValueOnce(readyResponse(retryRequest))
 			.mockResolvedValueOnce(readyResponse(retryRequest));
 		mocks.sendTransaction.mockResolvedValueOnce(APPROVAL_HASH).mockResolvedValueOnce(TRADE_HASH);
 
@@ -501,6 +559,10 @@ describe('executeMarketOrder REST calldata execution', () => {
 		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(2, {
 			...retryRequest
 		});
+		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(3, {
+			...retryRequest
+		});
+		expect(mocks.apiGetSwapCalldataV2).toHaveBeenCalledTimes(3);
 	});
 
 	it.each([


### PR DESCRIPTION
## Summary
- Market orders now refetch `/v2/swap/calldata` with the already-resolved price cap immediately before wallet confirmation.
- This keeps short-lived oracle signed context fresher across approval and wallet delay, reducing `Past oracle expiry` reverts (seen on Base when quote expiry landed ~9s before inclusion).
- Approval path still retries once after approvals, then performs the same pre-broadcast refresh.

## Test plan
- [x] `npx vitest run tests/lib/services/marketOrderExecution.test.ts tests/lib/services/marketOrderExecution.events.test.ts`
- [x] Manually: market buy/sell with no approval needed — confirm two calldata requests, second uses `priceCap`
- [x] Manually: market order that needs ERC20 approval — confirm approval, post-approval retry, then pre-broadcast refresh before takeOrders
- [x] Manually: slow wallet confirmation still succeeds more often on oracle-backed pairs during premarket/rth


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshed market-order transaction data immediately before wallet submission to help prevent stale pricing or oracle information from being used.
  * Preserved the resolved price limit after approval steps and retries.
  * Improved reliability when approvals require another attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->