### PR TITLE
fix: prevent formatUnits crash after failed market trades

### DIFF
--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -3,6 +3,7 @@
 	import { currentNetwork } from '$lib/stores';
 	import TradeAmountInput from '$lib/components/TradeAmountInput.svelte';
 	import { formatUnits } from 'viem';
+	import { formatUnitsSafe } from '$lib/utils/format';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import { isAuthenticated, walletAddress } from '$lib/stores/authStore';
@@ -576,18 +577,20 @@
 				assetSymbol: assetToken?.symbol,
 				paymentSymbol: paymentToken?.symbol
 			});
+			// Snapshot before any await. TradeAmountInput can bind selectedAmount
+			// to undefined while the swap request is in flight; formatting the
+			// live binding on trade_failed then throws (ST0-28 / ST0X-DEX-UI-2B).
+			const submittedAmountFormatted = formatUnitsSafe(
+				selectedAmount,
+				inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
+			);
 			try {
 				trackTradeEvent('trade_button_clicked', {
 					order_type: 'market',
 					order_side: orderSide.toLowerCase() as 'buy' | 'sell',
 					asset_symbol: assetToken?.symbol,
 					payment_symbol: paymentToken?.symbol,
-					amount: selectedAmount
-						? formatUnits(
-								selectedAmount,
-								inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
-							)
-						: '0',
+					amount: submittedAmountFormatted,
 					slippage_bps: slippageBps,
 					mode: inputMode === 'spend' ? 'spendUpTo' : 'buyUpTo'
 				});
@@ -656,10 +659,7 @@
 						order_side: orderSide.toLowerCase() as 'buy' | 'sell',
 						asset_symbol: assetToken?.symbol,
 						payment_symbol: paymentToken?.symbol,
-						amount: formatUnits(
-							selectedAmount,
-							inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
-						),
+						amount: submittedAmountFormatted,
 						avg_price: marketPrice,
 						error_class: eventErrorClass,
 						error_message: userFacingError.message,
@@ -673,10 +673,7 @@
 						order_side: orderSide.toLowerCase() as 'buy' | 'sell',
 						asset_symbol: assetToken?.symbol,
 						payment_symbol: paymentToken?.symbol,
-						amount: formatUnits(
-							selectedAmount,
-							inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
-						),
+						amount: submittedAmountFormatted,
 						avg_price: marketPrice
 					});
 				}
@@ -696,10 +693,7 @@
 					order_side: orderSide.toLowerCase() as 'buy' | 'sell',
 					asset_symbol: assetToken?.symbol,
 					payment_symbol: paymentToken?.symbol,
-					amount: formatUnits(
-						selectedAmount,
-						inputMode === 'spend' ? paymentToken?.decimals ?? 6 : assetToken?.decimals ?? 18
-					),
+					amount: submittedAmountFormatted,
 					avg_price: marketPrice,
 					error_class: userFacingError.errorClass,
 					error_message: userFacingError.message,

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -2,7 +2,27 @@
  * Format utilities to replace duplicate code across the app
  */
 
+import { formatUnits } from 'viem';
+
 const ETH_ADDRESS_RE = /^0x[a-f0-9]{40}$/i;
+
+/**
+ * Format a token amount for display or analytics without throwing.
+ * viem's formatUnits calls value.toString(); an undefined amount after a
+ * failed trade (cleared bound input) otherwise crashes the failure path.
+ */
+export function formatUnitsSafe(
+	amount: bigint | null | undefined,
+	decimals: number | null | undefined
+): string {
+	if (amount === undefined || amount === null) return '0';
+	if (typeof decimals !== 'number' || !Number.isFinite(decimals) || decimals < 0) return '0';
+	try {
+		return formatUnits(amount, decimals);
+	} catch {
+		return '0';
+	}
+}
 
 /**
  * Validate an Ethereum address (0x + 40 hex chars, case-insensitive)

--- a/tests/lib/components/orders/MarketOrder.events.test.ts
+++ b/tests/lib/components/orders/MarketOrder.events.test.ts
@@ -136,6 +136,21 @@ describe('MarketOrder.svelte event instrumentation (Plan 02-03 Task 1a)', () => 
 		);
 	});
 
+	it('Test 11: snapshots the submitted amount before executeMarketOrder so a cleared input cannot crash trade_failed', () => {
+		const handlerStart = componentSource.indexOf('const handleMarketOrder');
+		const handlerEnd = componentSource.indexOf('};', handlerStart) + 2;
+		const handlerBlock = componentSource.slice(handlerStart, handlerEnd);
+		const executeIdx = handlerBlock.indexOf('await executeMarketOrder(');
+		expect(executeIdx).toBeGreaterThan(-1);
+
+		const beforeExecute = handlerBlock.slice(0, executeIdx);
+		const afterExecute = handlerBlock.slice(executeIdx);
+
+		expect(beforeExecute).toMatch(/formatUnitsSafe\s*\(/);
+		expect(afterExecute).not.toMatch(/formatUnits\s*\(\s*selectedAmount/);
+		expect(handlerBlock).toMatch(/trackTradeEvent\(\s*['"]trade_failed['"]/);
+	});
+
 	it('Test 10: remaps unexpected post-preparation failures at the wallet boundary', () => {
 		expect(componentSource).toMatch(/inferWalletFailureStage/);
 		expect(componentSource).toMatch(

--- a/tests/lib/utils/format.test.ts
+++ b/tests/lib/utils/format.test.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect } from 'vitest';
-import { truncateAddress, formatUsd, formatPoints, formatApy } from '$lib/utils/format';
+import { formatUnits } from 'viem';
+import {
+	truncateAddress,
+	formatUsd,
+	formatPoints,
+	formatApy,
+	formatUnitsSafe
+} from '$lib/utils/format';
 
 describe('format utilities', () => {
 	describe('truncateAddress', () => {
@@ -54,6 +61,27 @@ describe('format utilities', () => {
 			[0, Math.round(0).toLocaleString('en-US')]
 		])('should format %s as %s', (value, expected) => {
 			expect(formatPoints(value)).toBe(expected);
+		});
+	});
+
+	describe('formatUnitsSafe', () => {
+		it('does not throw when amount is undefined (ST0-28 / ST0X-DEX-UI-2B)', () => {
+			expect(() => formatUnits(undefined as unknown as bigint, 18)).toThrow(
+				/Cannot read properties of undefined/
+			);
+			expect(() => formatUnitsSafe(undefined, 18)).not.toThrow();
+			expect(formatUnitsSafe(undefined, 18)).toBe('0');
+		});
+
+		it('does not throw when amount is null or decimals are missing', () => {
+			expect(formatUnitsSafe(null, 6)).toBe('0');
+			expect(formatUnitsSafe(1_000_000n, undefined)).toBe('0');
+			expect(formatUnitsSafe(1_000_000n, null)).toBe('0');
+		});
+
+		it('formats a valid amount the same as viem formatUnits', () => {
+			expect(formatUnitsSafe(1_000_000n, 6)).toBe(formatUnits(1_000_000n, 6));
+			expect(formatUnitsSafe(0n, 18)).toBe('0');
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Fixes [ST0-28](https://linear.app/makeitrain/issue/ST0-28/st0x-ui-formatunits-crash-on-undefined-amount-after-failed-trade-st0x) / Sentry [ST0X-DEX-UI-2B](https://st0x.sentry.io/issues/ST0X-DEX-UI-2B): after a failed market trade, analytics called viem `formatUnits` on a bound `selectedAmount` that `TradeAmountInput` can set to `undefined` during the request, throwing `Cannot read properties of undefined (reading 'toString')` on top of the real trade error.
- Snapshot the submitted amount with `formatUnitsSafe` before any await and reuse it for `trade_button_clicked`, `trade_failed`, and `trade_initiated` so the primary trade error still surfaces cleanly.

## Test plan
- [x] `npx vitest run tests/lib/utils/format.test.ts tests/lib/components/orders/MarketOrder.events.test.ts tests/lib/components/orders/MarketOrder.test.ts` (64 passed)
- [ ] On `/trade/[id]`, submit a market order that fails (quote/calldata/wallet reject) and confirm the original error shows with no unhandled `formatUnits` TypeError
- [ ] Confirm Sentry no longer records `undefined.toString` from the market `trade_failed` path after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market-order analytics so submitted amounts remain accurate when order inputs are cleared or changed during processing.
  * Added safe handling for missing, invalid, or zero token amounts and decimal values.
* **Tests**
  * Added coverage for reliable trade event reporting and safe amount formatting across valid and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->