### PR TITLE
fix: retry calldata after approve until allowance settles

### DIFF
--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -232,9 +232,7 @@ function validateReadyCalldata(
 	network: Network
 ): { to: `0x${string}`; data: Hex; value: bigint } {
 	if (response.approvals.length > 0) {
-		throw new Error(
-			'Approval is still settling on-chain. Please try the trade again in a moment.'
-		);
+		throw new Error('Approval is still settling on-chain. Please try the trade again in a moment.');
 	}
 	if (!isAddress(response.to)) {
 		throw new Error('Calldata API returned an invalid transaction target');

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -207,13 +207,34 @@ async function submitApprovals(
 	}
 }
 
+const APPROVAL_SETTLE_ATTEMPTS = 4;
+const APPROVAL_SETTLE_DELAY_MS = 400;
+
+async function fetchSwapCalldataUntilApproved(
+	request: ApiSwapCalldataV2Request
+): Promise<ApiSwapCalldataV2Response> {
+	let last: ApiSwapCalldataV2Response | undefined;
+	for (let attempt = 0; attempt < APPROVAL_SETTLE_ATTEMPTS; attempt++) {
+		if (attempt > 0) {
+			await new Promise((resolve) =>
+				setTimeout(resolve, APPROVAL_SETTLE_DELAY_MS * 2 ** (attempt - 1))
+			);
+		}
+		last = await apiGetSwapCalldataV2(request);
+		if (last.approvals.length === 0) return last;
+	}
+	throw new Error('Approval is still settling on-chain. Please try the trade again in a moment.');
+}
+
 function validateReadyCalldata(
 	response: ApiSwapCalldataV2Response,
 	request: ApiSwapCalldataV2Request,
 	network: Network
 ): { to: `0x${string}`; data: Hex; value: bigint } {
 	if (response.approvals.length > 0) {
-		throw new Error('Calldata API still requires approval after approval confirmation');
+		throw new Error(
+			'Approval is still settling on-chain. Please try the trade again in a moment.'
+		);
 	}
 	if (!isAddress(response.to)) {
 		throw new Error('Calldata API returned an invalid transaction target');
@@ -440,22 +461,24 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			activeTradeErrorStage = 'approval';
 			const inputTokenDecimals = orderSide === 'Buy' ? paymentToken.decimals : assetToken.decimals;
 			await submitApprovals(response.approvals, request, network, inputTokenDecimals);
+			const retryRequest = buildApprovalRetryRequest(request, response.resolvedPriceCap);
+			// Poll until the API's RPC sees the new allowance. The last clean
+			// payload is also the fresh oracle-signed takeOrders frame.
+			addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'started');
+			response = await fetchSwapCalldataUntilApproved(retryRequest);
+			addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'completed');
+		} else {
+			// Oracle-backed orders embed a short-lived signed quote in takeOrders
+			// calldata. Wallet confirmation can outlive that quote, so fetch a
+			// fresh frame with the already-resolved price cap immediately before
+			// asking the wallet to broadcast.
 			activeTradeErrorStage = 'calldata';
+			addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'started');
 			response = await apiGetSwapCalldataV2(
 				buildApprovalRetryRequest(request, response.resolvedPriceCap)
 			);
+			addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'completed');
 		}
-
-		// Oracle-backed orders embed a short-lived signed quote in takeOrders
-		// calldata. Approvals and wallet confirmation can outlive that quote, so
-		// fetch a fresh frame with the already-resolved price cap immediately
-		// before asking the wallet to broadcast.
-		activeTradeErrorStage = 'calldata';
-		addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'started');
-		response = await apiGetSwapCalldataV2(
-			buildApprovalRetryRequest(request, response.resolvedPriceCap)
-		);
-		addTradeFlowBreadcrumb(flowContext('calldata', 'refresh_api_calldata'), 'completed');
 
 		const transaction = validateReadyCalldata(response, request, network);
 		activeStage = 'submission';

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -204,6 +204,14 @@ const ERROR_CATALOG: Record<string, CatalogEntry> = {
 		action: 'retry',
 		errorClass: 'unknown'
 	},
+	TRADE_APPROVAL_SETTLING: {
+		title: 'Approval is still confirming',
+		message:
+			'The approval went through, but the network has not picked it up yet. Try the trade again in a moment.',
+		retryable: true,
+		action: 'try_later',
+		errorClass: 'unknown'
+	},
 	TRADE_SIGNING_FAILED: {
 		title: 'Signature failed',
 		message: 'The wallet signature did not complete. Check your wallet and try again.',
@@ -295,6 +303,9 @@ export function toUserFacingTradeError(
 	}
 	if (/wallet.*(not connected|disconnected)/.test(message)) {
 		return createTradeError('TRADE_WALLET_NOT_CONNECTED', { stage });
+	}
+	if (message.includes('still settling') || message.includes('still requires approval')) {
+		return createTradeError('TRADE_APPROVAL_SETTLING', { stage: 'approval' });
 	}
 	if (message.includes('slippage')) {
 		return createTradeError('TRADE_SLIPPAGE_EXCEEDED', { stage });

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -253,6 +253,10 @@ describe('executeMarketOrder REST calldata execution', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mocks.apiGetSwapCalldataV2.mockReset();
+		mocks.sendTransaction.mockReset();
+		mocks.waitForTransaction.mockReset();
+		mocks.apiGetTradesByTx.mockReset();
 		mocks.getSignerAddress.mockReturnValue(TAKER);
 		mocks.apiGetSwapCalldataV2.mockImplementation(async (request) => readyResponse(request));
 		mocks.apiGetTradesByTx.mockImplementation(async () => {
@@ -536,7 +540,6 @@ describe('executeMarketOrder REST calldata execution', () => {
 					}
 				]
 			})
-			.mockResolvedValueOnce(readyResponse(retryRequest))
 			.mockResolvedValueOnce(readyResponse(retryRequest));
 		mocks.sendTransaction.mockResolvedValueOnce(APPROVAL_HASH).mockResolvedValueOnce(TRADE_HASH);
 
@@ -559,10 +562,115 @@ describe('executeMarketOrder REST calldata execution', () => {
 		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(2, {
 			...retryRequest
 		});
-		expect(mocks.apiGetSwapCalldataV2).toHaveBeenNthCalledWith(3, {
-			...retryRequest
+		expect(mocks.apiGetSwapCalldataV2).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries calldata after approve when the next responses still list approvals (ST0-27)', async () => {
+		const approvalData = encodeFunctionData({
+			abi: erc20Abi,
+			functionName: 'approve',
+			args: [ORDERBOOK, 100_000_000n]
 		});
-		expect(mocks.apiGetSwapCalldataV2).toHaveBeenCalledTimes(3);
+		const retryRequest = {
+			taker: TAKER,
+			inputToken: PAYMENT,
+			outputToken: ASSET,
+			mode: 'buyUpTo' as const,
+			amount: '1',
+			priceCap: '2.02',
+			denomination: 'wrapped' as const
+		};
+		const pending = {
+			...readyResponse(),
+			data: '0x',
+			resolvedPriceCap: '2.02',
+			approvals: [
+				{
+					token: PAYMENT,
+					spender: ORDERBOOK,
+					amount: '100',
+					symbol: 'USDC',
+					approvalData
+				}
+			]
+		};
+		const timeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb) => {
+			if (typeof cb === 'function') cb();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		});
+		try {
+			mocks.apiGetSwapCalldataV2
+				.mockResolvedValueOnce(pending)
+				.mockResolvedValueOnce(pending)
+				.mockResolvedValueOnce(pending)
+				.mockResolvedValueOnce(readyResponse(retryRequest));
+			mocks.sendTransaction.mockResolvedValueOnce(APPROVAL_HASH).mockResolvedValueOnce(TRADE_HASH);
+
+			const result = await executeMarketOrder({
+				orderSide: 'Buy',
+				amount: 1_000_000_000_000_000_000n,
+				slippageBps: 100,
+				...tokens,
+				network
+			});
+
+			expect(result.success).toBe(true);
+			expect(mocks.sendTransaction).toHaveBeenNthCalledWith(1, {
+				to: PAYMENT,
+				data: approvalData
+			});
+			expect(mocks.apiGetSwapCalldataV2.mock.calls.length).toBeGreaterThanOrEqual(4);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it('surfaces a settling error after approve if calldata keeps requiring approval (ST0-27)', async () => {
+		const approvalData = encodeFunctionData({
+			abi: erc20Abi,
+			functionName: 'approve',
+			args: [ORDERBOOK, 100_000_000n]
+		});
+		const pending = {
+			...readyResponse(),
+			data: '0x',
+			resolvedPriceCap: '2.02',
+			approvals: [
+				{
+					token: PAYMENT,
+					spender: ORDERBOOK,
+					amount: '100',
+					symbol: 'USDC',
+					approvalData
+				}
+			]
+		};
+		const timeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb) => {
+			if (typeof cb === 'function') cb();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		});
+		try {
+			mocks.apiGetSwapCalldataV2.mockResolvedValue(pending);
+			mocks.sendTransaction.mockResolvedValueOnce(APPROVAL_HASH);
+
+			const result = await executeMarketOrder({
+				orderSide: 'Buy',
+				amount: 1_000_000_000_000_000_000n,
+				slippageBps: 100,
+				...tokens,
+				network
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/still settling/i);
+			expect(result.tradeError).toMatchObject({
+				code: 'TRADE_APPROVAL_SETTLING',
+				stage: 'approval'
+			});
+			expect(mocks.sendTransaction).toHaveBeenCalledTimes(1);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
 	});
 
 	it.each([

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -50,6 +50,20 @@ describe('tradeError', () => {
 		});
 	});
 
+	it('maps post-approve calldata lag to TRADE_APPROVAL_SETTLING (ST0-27)', () => {
+		expect(
+			toUserFacingTradeError(
+				new Error('Approval is still settling on-chain. Please try the trade again in a moment.'),
+				'approval'
+			)
+		).toMatchObject({
+			code: 'TRADE_APPROVAL_SETTLING',
+			stage: 'approval',
+			retryable: true,
+			action: 'try_later'
+		});
+	});
+
 	it('maps RPC rate-limit failures to UPSTREAM_UNAVAILABLE instead of stage fallback', () => {
 		expect(toUserFacingTradeError(new Error('over rate limit'), 'approval')).toMatchObject({
 			code: 'UPSTREAM_UNAVAILABLE',


### PR DESCRIPTION
## Summary
- Fixes [ST0-27](https://linear.app/makeitrain/issue/ST0-27/st0x-ui-calldata-still-requires-approval-after-approve-confirms-st0x) / Sentry [ST0X-DEX-UI-2V](https://st0x.sentry.io/issues/ST0X-DEX-UI-2V): after a confirmed ERC-20 approve, `/v2/swap/calldata` can still return `approvals.length > 0` because the API's RPC has not seen the new allowance yet. The UI then threw `Calldata API still requires approval after approval confirmation`.
- After a successful approve, poll calldata up to 4 times with exponential backoff. If it never clears, surface `TRADE_APPROVAL_SETTLING` ("approval still confirming") instead of a generic `SWAP_CALLDATA_FAILED`.

## Test plan
- [x] `npx vitest run tests/lib/services/marketOrderExecution.test.ts tests/lib/services/tradeError.test.ts` (31 passed)
- [x] On `/trade/[id]`, first-time USDC market buy: confirm approve in wallet, then the take-order prompt should follow without a hard calldata error
- [ ] If allowance is still lagging after retries, the UI should say the approval is still confirming and invite a retry, not "trade preparation failed"


Made with [Cursor](https://cursor.com)