### PR TITLE
fix: handle unavailable swap oracle

### DIFF
--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -32,6 +32,7 @@
 	} from '$lib/services/marketOrderExecution';
 	import {
 		createTradeError,
+		shouldRetryTradeQuery,
 		toUserFacingTradeError,
 		type UserFacingTradeError
 	} from '$lib/services/tradeError';
@@ -198,7 +199,7 @@
 		queryKey: ['swapQuoteV2', $currentNetwork?.id, marketQuoteRequest],
 		enabled: browser && Boolean(marketQuoteRequest),
 		staleTime: 5_000,
-		retry: 1,
+		retry: shouldRetryTradeQuery,
 		queryFn: () => {
 			if (!marketQuoteRequest) throw new Error('Missing swap quote request');
 			return apiGetSwapQuoteV2(marketQuoteRequest);

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -29,6 +29,7 @@
 	import { withTradeId } from '$lib/services/observability/tradeId';
 	import {
 		createTradeError,
+		shouldRetryTradeQuery,
 		toUserFacingTradeError,
 		type UserFacingTradeError
 	} from '$lib/services/tradeError';
@@ -332,6 +333,7 @@
 	$: errorClass = (() => {
 		if (insufficientBalanceError) return 'insufficient_balance';
 		if (serviceErrorClass) return serviceErrorClass;
+		if (marketQuoteTradeError) return marketQuoteTradeError.errorClass;
 		if (isOutsideMarketHours() && orderPreparationError) return 'market_closed';
 		if (priceError && (priceErrorReason === 'no_quotes' || priceErrorReason === 'no_fill'))
 			return 'no_liquidity';
@@ -392,7 +394,7 @@
 		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, marketQuoteRequest],
 		enabled: Boolean(marketQuoteRequest),
 		staleTime: 5_000,
-		retry: 1,
+		retry: shouldRetryTradeQuery,
 		queryFn: () => {
 			if (!marketQuoteRequest) throw new Error('Missing market quote request');
 			return apiGetSwapQuoteV2(marketQuoteRequest);

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -57,6 +57,13 @@ const ERROR_CATALOG: Record<string, CatalogEntry> = {
 		action: 'adjust_amount',
 		errorClass: 'no_liquidity'
 	},
+	SWAP_ORACLE_UNAVAILABLE: {
+		title: 'Price data unavailable',
+		message: 'Live price data is temporarily unavailable. Try again in a moment.',
+		retryable: true,
+		action: 'try_later',
+		errorClass: 'stale_oracle'
+	},
 	SWAP_QUOTE_FAILED: {
 		title: 'Quote unavailable',
 		message: 'We could not calculate a reliable quote. Refresh the market data and try again.',
@@ -236,6 +243,13 @@ const STAGE_FALLBACK: Record<TradeErrorStage, string> = {
 	submission: 'TRADE_SUBMISSION_FAILED',
 	confirmation: 'TRADE_CONFIRMATION_FAILED'
 };
+
+/** Avoid amplifying explicit REST backoff responses while retaining one retry for other failures. */
+export function shouldRetryTradeQuery(failureCount: number, error: unknown): boolean {
+	return (
+		failureCount < 1 && !(isHttpError(error) && (error.status === 429 || error.status === 503))
+	);
+}
 
 function safeCode(code: string): string {
 	return /^[A-Z][A-Z0-9_]{0,63}$/.test(code) ? code : 'TRADE_UNKNOWN';

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -661,6 +661,36 @@ describe('executeMarketOrder REST calldata execution', () => {
 		});
 	});
 
+	it('surfaces oracle-unavailable calldata failures as temporary price-data errors', async () => {
+		mocks.apiGetSwapCalldataV2.mockRejectedValue(
+			new HttpError({
+				status: 503,
+				code: 'SWAP_ORACLE_UNAVAILABLE',
+				requestId: 'request-oracle',
+				publicMessage: 'Required swap oracle unavailable',
+				retryAfter: null
+			})
+		);
+
+		const result = await executeMarketOrder({
+			orderSide: 'Buy',
+			amount: 1_000_000_000_000_000_000n,
+			...tokens,
+			network
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errorClass: 'stale_oracle',
+			tradeError: {
+				code: 'SWAP_ORACLE_UNAVAILABLE',
+				requestId: 'request-oracle',
+				stage: 'calldata',
+				action: 'try_later'
+			}
+		});
+	});
+
 	it('maps wallet rejection to the signing support code', async () => {
 		mocks.sendTransaction.mockRejectedValue(new Error('User rejected request'));
 

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { HttpError } from '$lib/clients/http';
-import { createTradeError, toUserFacingTradeError } from '$lib/services/tradeError';
+import {
+	createTradeError,
+	shouldRetryTradeQuery,
+	toUserFacingTradeError
+} from '$lib/services/tradeError';
 
 describe('tradeError', () => {
 	it('maps a typed REST failure without exposing its raw public message', () => {
@@ -37,6 +41,43 @@ describe('tradeError', () => {
 		expect(result.code).toBe('FUTURE_API_FAILURE');
 		expect(result.requestId).toBe('request-future');
 		expect(result.message).not.toContain('do not display this');
+	});
+
+	it('maps oracle-unavailable quotes to temporary price-data guidance', () => {
+		const error = new HttpError({
+			status: 503,
+			code: 'SWAP_ORACLE_UNAVAILABLE',
+			requestId: 'request-oracle',
+			publicMessage: 'raw oracle dependency wording',
+			retryAfter: null
+		});
+
+		expect(toUserFacingTradeError(error, 'quote')).toEqual({
+			code: 'SWAP_ORACLE_UNAVAILABLE',
+			title: 'Price data unavailable',
+			message: 'Live price data is temporarily unavailable. Try again in a moment.',
+			requestId: 'request-oracle',
+			stage: 'quote',
+			retryable: true,
+			action: 'try_later',
+			errorClass: 'stale_oracle'
+		});
+	});
+
+	it('does not immediately retry explicit backoff responses', () => {
+		const httpError = (status: number) =>
+			new HttpError({
+				status,
+				code: `HTTP_${status}`,
+				requestId: null,
+				publicMessage: 'request failed',
+				retryAfter: null
+			});
+
+		expect(shouldRetryTradeQuery(0, httpError(429))).toBe(false);
+		expect(shouldRetryTradeQuery(0, httpError(503))).toBe(false);
+		expect(shouldRetryTradeQuery(0, httpError(502))).toBe(true);
+		expect(shouldRetryTradeQuery(1, new Error('network failed'))).toBe(false);
 	});
 
 	it('normalizes wallet rejection and balance failures to stable local codes', () => {


### PR DESCRIPTION
## Related PR

This UI change consumes the `SWAP_ORACLE_UNAVAILABLE` error contract introduced by [ST0x REST API #168](https://github.com/ST0x-Technology/st0x.rest.api/pull/168).

It is safe to merge before the REST change; the new presentation becomes active when API #168 is deployed.

## Motivation

The REST API now distinguishes temporary oracle-context failures from genuine no-liquidity responses. Without a matching UI catalog entry, quote and calldata failures with the new code would fall back to a generic trade error and be classified as `unknown`.

Quote queries also configured an unconditional TanStack retry, which would immediately retry the explicit HTTP 503 backoff response even though the lower-level HTTP client deliberately does not retry 503s.

## Solution

- Present `SWAP_ORACLE_UNAVAILABLE` as temporary live-price unavailability with a try-later action.
- Classify the failure as `stale_oracle` in the existing trade analytics taxonomy and expose that class on the market-order UI.
- Skip immediate quote-query retries for HTTP 429 and 503 while retaining one retry for other failures.
- Cover both quote presentation and calldata execution, including request ID preservation.

## Validation

- `npm run svelte-lint-format-check`
- `npm test -- --run` — 84 files passed, 891 tests passed, 1 skipped
- Browser: injected a one-shot 503 `SWAP_ORACLE_UNAVAILABLE` response for `/v2/swap/quote`; Quick Trade rendered the price-data message, error code, quote stage, and request reference, with exactly one quote request and no immediate retry