### PR TITLE
fix: quantize vault Floats so withdraw calldata can encode

### DIFF
--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -54,7 +54,7 @@ import { invalidateDashboardBalances } from '$lib/queries/balances';
 import { walletAddress } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { rainlangConfirmationModal, reviewStrategyOnDeploy } from '$lib/stores';
-import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken } from '$lib/utils/tokenMath';
+import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken, toTokenDecimalFloat } from '$lib/utils/tokenMath';
 import { ZERO_FLOAT_HEX } from '$lib/config/constants';
 import { getMakerOutputTokenAddress, getMakerInputTokenAddress } from '$lib/types/orderPerspective';
 import { TransactionErrorMessage } from '$lib/types/errors';
@@ -623,17 +623,27 @@ export const handleLimitDeploy = async (
 	await showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
 };
 
+/** Floor a vault Float to token decimals so Raindex can encode withdraw calldata. */
+function withdrawCalldataAmount(vault: RaindexVault) {
+	return toTokenDecimalFloat(
+		vault.balance,
+		Number(vault.token.decimals)
+	) as Parameters<RaindexVault['getCalldatas']>[0];
+}
+
 export const handleWithdraw = async (vault: RaindexVault) => {
 	const config = get(wagmiConfig);
 	if (!config) throw new Error('Wagmi config not found');
 
-	// vault.balance is already a Float instance, use it directly
-	const vaultCalldatas = await vault.getCalldatas(vault.balance);
-	if (vaultCalldatas.error || !vaultCalldatas.value) {
-		throw new Error(vaultCalldatas.error?.readableMsg ?? 'Failed to prepare withdrawal');
-	}
 	let hash: Hash;
 	try {
+		// Raindex encodes this amount as Decimal exactly; quantize to token
+		// decimals so leftover fill dust does not throw LossyConversionFromFloat.
+		const vaultCalldatas = await vault.getCalldatas(withdrawCalldataAmount(vault));
+		if (vaultCalldatas.error || !vaultCalldatas.value) {
+			throw new Error(vaultCalldatas.error?.readableMsg ?? 'Failed to prepare withdrawal');
+		}
+
 		// Security: Validate orderbook address is trusted before sending transaction
 		const network = get(currentNetwork);
 		validateOrderbookAddress(vault.raindex, network);
@@ -882,7 +892,7 @@ export const handleRemoveOrder = async (quote: {
 				// Security: Validate orderbook address is trusted
 				validateOrderbookAddress(vault.raindex, network);
 
-				const vaultCalldatas = await vault.getCalldatas(vault.balance);
+				const vaultCalldatas = await vault.getCalldatas(withdrawCalldataAmount(vault));
 				if (vaultCalldatas.error || !vaultCalldatas.value) {
 					throw new Error(vaultCalldatas.error?.readableMsg ?? 'Failed to prepare withdrawal');
 				}
@@ -1145,7 +1155,7 @@ export const handleWithdrawFromOrder = async (quote: {
 			// Security: Validate orderbook address is trusted
 			validateOrderbookAddress(vault.raindex, network);
 
-			const vaultCalldatas = await vault.getCalldatas(vault.balance);
+			const vaultCalldatas = await vault.getCalldatas(withdrawCalldataAmount(vault));
 			if (vaultCalldatas.error || !vaultCalldatas.value) {
 				throw new Error(vaultCalldatas.error?.readableMsg ?? 'Failed to prepare withdrawal');
 			}

--- a/src/lib/stores/deployTransactionStore.ts
+++ b/src/lib/stores/deployTransactionStore.ts
@@ -19,7 +19,7 @@ import { get } from 'svelte/store';
 import { decodeFunctionData, erc20Abi, type Hash, type Hex } from 'viem';
 import { readContract as wagmiReadContract } from '@wagmi/core';
 import { wagmiConfig } from 'svelte-wagmi';
-import { type DeploymentTransactionArgs, type RaindexVault } from '@rainlanguage/raindex';
+import { Float, type DeploymentTransactionArgs, type RaindexVault } from '@rainlanguage/raindex';
 import {
 	sendTransaction as walletServiceSendTransaction,
 	waitForTransaction as walletServiceWaitForTransaction
@@ -54,7 +54,7 @@ import { invalidateDashboardBalances } from '$lib/queries/balances';
 import { walletAddress } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { rainlangConfirmationModal, reviewStrategyOnDeploy } from '$lib/stores';
-import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken, toTokenDecimalFloat } from '$lib/utils/tokenMath';
+import { getRaindexOrderUrl, getRaindexVaultUrl, isPaymentToken } from '$lib/utils/tokenMath';
 import { ZERO_FLOAT_HEX } from '$lib/config/constants';
 import { getMakerOutputTokenAddress, getMakerInputTokenAddress } from '$lib/types/orderPerspective';
 import { TransactionErrorMessage } from '$lib/types/errors';
@@ -623,12 +623,22 @@ export const handleLimitDeploy = async (
 	await showRainlangConfirmation(composedRainlang, deploymentArgs, assetTokenInfo, eventContext);
 };
 
-/** Floor a vault Float to token decimals so Raindex can encode withdraw calldata. */
+/**
+ * Floor a vault Float to token decimals, then rebuild a Raindex `_Float`.
+ * `@rainlanguage/float` is a separate WASM class — passing it to getCalldatas
+ * throws "expected instance of _Float".
+ */
 function withdrawCalldataAmount(vault: RaindexVault) {
-	return toTokenDecimalFloat(
-		vault.balance,
-		Number(vault.token.decimals)
-	) as Parameters<RaindexVault['getCalldatas']>[0];
+	const decimals = Number(vault.token.decimals);
+	const fixed = vault.balance.toFixedDecimalLossy(decimals);
+	if (fixed.error || !fixed.value) {
+		throw new Error(fixed.error?.readableMsg ?? 'Failed to convert vault balance');
+	}
+	const rebuilt = Float.fromFixedDecimalLossy(BigInt(fixed.value.value), decimals);
+	if (!rebuilt.float) {
+		throw new Error('Failed to encode vault balance');
+	}
+	return rebuilt.float;
 }
 
 export const handleWithdraw = async (vault: RaindexVault) => {

--- a/src/lib/utils/tokenMath.ts
+++ b/src/lib/utils/tokenMath.ts
@@ -46,6 +46,23 @@ export function parseFloatHex(hexAmount: string, decimals: number, useAbsolute =
 	}
 }
 
+/**
+ * Quantize a Rain Float to an exact token-decimal amount.
+ *
+ * Vault balances from on-chain fills are often repeating Floats. Raindex
+ * `getCalldatas` converts the amount to Decimal exactly and throws
+ * `LossyConversionFromFloat` for those values. Flooring to `decimals` then
+ * rebuilding the Float produces an amount the SDK can encode, without
+ * requesting more than the vault holds.
+ */
+export function toTokenDecimalFloat(balance: Float, decimals: number): Float {
+	const fixed = balance.toFixedDecimalLossy(decimals);
+	if (fixed.error || !fixed.value) {
+		throw new Error(fixed.error?.readableMsg ?? 'Failed to convert vault balance');
+	}
+	return Float.fromFixedDecimalLossy(BigInt(fixed.value.value), decimals).float;
+}
+
 export function normalizeAddress(value: string | null | undefined): string | null {
 	if (!value) return null;
 	const trimmed = value.trim();

--- a/src/lib/utils/tokenMath.ts
+++ b/src/lib/utils/tokenMath.ts
@@ -54,6 +54,10 @@ export function parseFloatHex(hexAmount: string, decimals: number, useAbsolute =
  * `LossyConversionFromFloat` for those values. Flooring to `decimals` then
  * rebuilding the Float produces an amount the SDK can encode, without
  * requesting more than the vault holds.
+ *
+ * Returns `@rainlanguage/float`'s Float, which is a different WASM class than
+ * raindex's `_Float`. Do not pass this into `vault.getCalldatas` — rebuild with
+ * `@rainlanguage/raindex`'s `Float.fromFixedDecimalLossy` instead.
  */
 export function toTokenDecimalFloat(balance: Float, decimals: number): Float {
 	const fixed = balance.toFixedDecimalLossy(decimals);

--- a/tests/lib/utils/raindexFloat.test.ts
+++ b/tests/lib/utils/raindexFloat.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { Float as PackageFloat } from '@rainlanguage/float';
+import { Float as RaindexFloat } from '@rainlanguage/raindex';
+
+describe('Raindex vs package Float', () => {
+	it('package Float is not a raindex _Float', () => {
+		const pkg = PackageFloat.parse('0.9191').value;
+		if (!pkg) throw new Error('Failed to parse package Float');
+		expect(pkg instanceof RaindexFloat).toBe(false);
+	});
+
+	it('rebuilds a repeating amount as a raindex Float that encodes exactly', () => {
+		const one = RaindexFloat.parse('1').value;
+		const three = RaindexFloat.parse('3').value;
+		if (!one || !three) throw new Error('Failed to parse raindex Floats');
+		const third = one.div(three).value;
+		if (!third) throw new Error('Failed to divide raindex Floats');
+
+		expect(third.toFixedDecimal(6).error).toBeTruthy();
+
+		const decimals = 6;
+		const fixed = third.toFixedDecimalLossy(decimals);
+		if (fixed.error || !fixed.value) {
+			throw new Error(fixed.error?.readableMsg ?? 'Failed to convert vault balance');
+		}
+		const rebuilt = RaindexFloat.fromFixedDecimalLossy(BigInt(fixed.value.value), decimals).float;
+		if (!rebuilt) throw new Error('Failed to encode vault balance');
+
+		expect(rebuilt instanceof RaindexFloat).toBe(true);
+		expect(rebuilt.toFixedDecimal(6).error).toBeUndefined();
+		expect(rebuilt.toFixedDecimal(6).value).toBe(333333n);
+	});
+});

--- a/tests/lib/utils/tokenMath.test.ts
+++ b/tests/lib/utils/tokenMath.test.ts
@@ -6,6 +6,7 @@ import {
 	toBigInt,
 	absBigInt,
 	toDecimal,
+	toTokenDecimalFloat,
 	computePrice,
 	classifyFlow,
 	parseTradeAmounts,
@@ -426,6 +427,30 @@ describe('tokenMath', () => {
 			};
 
 			expect(analyzeTrade(trade, quoteToken)).toBeNull();
+		});
+	});
+
+	describe('toTokenDecimalFloat', () => {
+		it('quantizes a repeating Float so exact token-decimal conversion succeeds', () => {
+			const one = Float.parse('1').value;
+			const three = Float.parse('3').value;
+			if (!one || !three) throw new Error('Failed to parse test floats');
+			const third = one.div(three).value;
+			if (!third) throw new Error('Failed to divide test floats');
+
+			expect(third.toFixedDecimal(6).error).toBeTruthy();
+
+			const quantized = toTokenDecimalFloat(third, 6);
+			expect(quantized.toFixedDecimal(6).error).toBeUndefined();
+			expect(quantized.toFixedDecimal(6).value).toBe(333333n);
+			expect(quantized.format().value).toBe('0.333333');
+		});
+
+		it('preserves an already exact USDC amount', () => {
+			const amount = Float.parse('0.9191').value;
+			if (!amount) throw new Error('Failed to parse USDC amount');
+			const quantized = toTokenDecimalFloat(amount, 6);
+			expect(quantized.toFixedDecimal(6).value).toBe(919100n);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Dashboard vault Withdraw crashed with `LossyConversionFromFloat` before the wallet popup, because Raindex encodes the amount as an exact Decimal and leftover fill dust is a repeating Rain Float.
- Floor the vault balance to token decimals, rebuild the Float, and use that for withdraw calldata (including remove-order and withdraw-from-order).

## Test plan
- [x] On `/dashboard` Vaults, withdraw a USDC vault with a leftover fill amount (e.g. 0.9191) — wallet confirmation should appear instead of a console error
- [x] Withdraw a default vault with a clean balance (e.g. wtIAU 0.0400) still works
- [x] `npx vitest run tests/lib/utils/tokenMath.test.ts`


Made with [Cursor](https://cursor.com)