### PR TITLE
fix: reduce REST request amplification

### DIFF
--- a/src/lib/api/st0xApi.ts
+++ b/src/lib/api/st0xApi.ts
@@ -561,13 +561,15 @@ export async function apiGetSwapQuote(request: ApiSwapQuoteRequest): Promise<Api
  * v2 calldata. This is the authoritative market-order display quote.
  */
 export async function apiGetSwapQuoteV2(
-	request: ApiSwapQuoteV2Request
+	request: ApiSwapQuoteV2Request,
+	signal?: AbortSignal
 ): Promise<ApiSwapQuoteV2Response> {
 	assertBrowser('apiGetSwapQuoteV2');
 	return fetchJson<ApiSwapQuoteV2Response>(apiUrl('/v2/swap/quote'), {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(request)
+		body: JSON.stringify(request),
+		signal
 	});
 }
 

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -25,7 +25,12 @@
 	import Icon from './ui/Icon.svelte';
 	import { goto } from '$app/navigation';
 	import { resolveMarketOrderAnchor } from '$lib/utils/marketOrderInput';
-	import { apiGetSwapQuoteV2, type ApiSwapQuoteV2Response } from '$lib/api/st0xApi';
+	import {
+		apiGetSwapQuoteV2,
+		type ApiSwapQuoteV2Request,
+		type ApiSwapQuoteV2Response
+	} from '$lib/api/st0xApi';
+	import { createDebouncedValue } from '$lib/stores/debouncedValue';
 	import {
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS
@@ -175,6 +180,7 @@
 		}
 	});
 	$: quotes = $orderbookQuery.data?.quotes ?? [];
+	let marketQuoteRequest: ApiSwapQuoteV2Request | null;
 	$: marketQuoteRequest =
 		tradeAnchor && selectedToken && paymentToken && $currentNetwork
 			? buildMarketSwapQuoteRequest(
@@ -190,19 +196,25 @@
 					$walletAddress ?? undefined
 				)
 			: null;
+	const debouncedMarketQuoteRequest = createDebouncedValue<ApiSwapQuoteV2Request | null>(null, 300);
+	$: if (marketQuoteRequest) {
+		debouncedMarketQuoteRequest.set(marketQuoteRequest);
+	} else {
+		debouncedMarketQuoteRequest.setImmediately(null);
+	}
 	let marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
 		queryKey: ['swapQuoteV2', undefined, null],
 		enabled: false,
 		queryFn: () => Promise.reject(new Error('Missing swap quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['swapQuoteV2', $currentNetwork?.id, marketQuoteRequest],
-		enabled: browser && Boolean(marketQuoteRequest),
+		queryKey: ['swapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest],
+		enabled: browser && Boolean($debouncedMarketQuoteRequest),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,
-		queryFn: () => {
-			if (!marketQuoteRequest) throw new Error('Missing swap quote request');
-			return apiGetSwapQuoteV2(marketQuoteRequest);
+		queryFn: ({ signal }) => {
+			if (!$debouncedMarketQuoteRequest) throw new Error('Missing swap quote request');
+			return apiGetSwapQuoteV2($debouncedMarketQuoteRequest, signal);
 		}
 	});
 	$: quoteTradeError =
@@ -224,6 +236,7 @@
 
 	// Track abandonment on unmount
 	onDestroy(() => {
+		debouncedMarketQuoteRequest.destroy();
 		if (!tradeSubmittedSuccessfully && (topAmount || bottomAmount)) {
 			track('quick_trade_abandoned', {
 				token_symbol: selectedToken?.symbol,

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -204,7 +204,7 @@
 		queryFn: () => Promise.reject(new Error('Missing swap quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['swapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.revision],
+		queryKey: ['swapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.fingerprint],
 		enabled: browser && Boolean($debouncedMarketQuoteRequest.request),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,

--- a/src/lib/components/QuickTrade.svelte
+++ b/src/lib/components/QuickTrade.svelte
@@ -30,7 +30,7 @@
 		type ApiSwapQuoteV2Request,
 		type ApiSwapQuoteV2Response
 	} from '$lib/api/st0xApi';
-	import { createDebouncedValue } from '$lib/stores/debouncedValue';
+	import { createDebouncedRequest } from '$lib/stores/debouncedValue';
 	import {
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS
@@ -196,25 +196,22 @@
 					$walletAddress ?? undefined
 				)
 			: null;
-	const debouncedMarketQuoteRequest = createDebouncedValue<ApiSwapQuoteV2Request | null>(null, 300);
-	$: if (marketQuoteRequest) {
-		debouncedMarketQuoteRequest.set(marketQuoteRequest);
-	} else {
-		debouncedMarketQuoteRequest.setImmediately(null);
-	}
+	const debouncedMarketQuoteRequest = createDebouncedRequest<ApiSwapQuoteV2Request>(300);
+	$: debouncedMarketQuoteRequest.set(marketQuoteRequest);
 	let marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
 		queryKey: ['swapQuoteV2', undefined, null],
 		enabled: false,
 		queryFn: () => Promise.reject(new Error('Missing swap quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['swapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest],
-		enabled: browser && Boolean($debouncedMarketQuoteRequest),
+		queryKey: ['swapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.revision],
+		enabled: browser && Boolean($debouncedMarketQuoteRequest.request),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,
 		queryFn: ({ signal }) => {
-			if (!$debouncedMarketQuoteRequest) throw new Error('Missing swap quote request');
-			return apiGetSwapQuoteV2($debouncedMarketQuoteRequest, signal);
+			const request = $debouncedMarketQuoteRequest.request;
+			if (!request) throw new Error('Missing swap quote request');
+			return apiGetSwapQuoteV2(request, signal);
 		}
 	});
 	$: quoteTradeError =
@@ -336,7 +333,11 @@
 	$: bestBidPrice = bidQuotes.length > 0 ? bidQuotes[0].quotePerAsset : null;
 
 	// ============ AUTHORITATIVE REST QUOTE ============
-	$: quote = toDisplayQuote($marketQuoteQuery?.data, isBuying, lastEditedField);
+	$: quote = toDisplayQuote(
+		$debouncedMarketQuoteRequest.request ? $marketQuoteQuery?.data : undefined,
+		isBuying,
+		lastEditedField
+	);
 
 	$: syncOtherField(quote, lastEditedField);
 

--- a/src/lib/components/TokenSwapModal.svelte
+++ b/src/lib/components/TokenSwapModal.svelte
@@ -431,7 +431,6 @@
 			queryClient.invalidateQueries({ queryKey: ['oldTokenBalances'] });
 			queryClient.invalidateQueries({ queryKey: ['dashboardOldTokenBalances'] });
 			queryClient.invalidateQueries({ queryKey: ['dashboardUnwrappedTokenBalances'] });
-			queryClient.invalidateQueries({ queryKey: ['costBasis'] });
 			queryClient.invalidateQueries({ queryKey: ['hasOldTokens'] });
 		} catch (error) {
 			console.error('Swap failed:', error);

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -12,7 +12,12 @@
 	import type { OrderbookQuoteCache } from '$lib/queries/orderbook';
 	import { createMidpointPricesQuery, getMidpointPrice } from '$lib/queries/midpointPrices';
 	import { createQuery, type CreateQueryResult } from '@tanstack/svelte-query';
-	import { apiGetSwapQuoteV2, type ApiSwapQuoteV2Response } from '$lib/api/st0xApi';
+	import {
+		apiGetSwapQuoteV2,
+		type ApiSwapQuoteV2Request,
+		type ApiSwapQuoteV2Response
+	} from '$lib/api/st0xApi';
+	import { createDebouncedValue } from '$lib/stores/debouncedValue';
 	import {
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS,
@@ -212,6 +217,7 @@
 	// Cleanup interval on component destroy
 	import { onDestroy } from 'svelte';
 	onDestroy(() => {
+		debouncedMarketQuoteRequest.destroy();
 		if (quoteFreshnessInterval) clearInterval(quoteFreshnessInterval);
 
 		// Track abandonment if user had entered values but didn't complete trade
@@ -370,6 +376,7 @@
 		? getMidpointPrice($midpointPricesQuery?.data, assetToken.address)?.price
 		: undefined;
 	$: quoteReferenceIoRatio = toReferenceIoRatio(orderSide, quoteReferencePrice);
+	let marketQuoteRequest: ApiSwapQuoteV2Request | null;
 	$: marketQuoteRequest =
 		selectedAmount > 0n && assetToken && paymentToken && $currentNetwork
 			? buildMarketSwapQuoteRequest(
@@ -386,19 +393,25 @@
 					$walletAddress ?? undefined
 				)
 			: null;
+	const debouncedMarketQuoteRequest = createDebouncedValue<ApiSwapQuoteV2Request | null>(null, 300);
+	$: if (marketQuoteRequest) {
+		debouncedMarketQuoteRequest.set(marketQuoteRequest);
+	} else {
+		debouncedMarketQuoteRequest.setImmediately(null);
+	}
 	let marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
 		queryKey: ['marketSwapQuoteV2', undefined, null],
 		enabled: false,
 		queryFn: () => Promise.reject(new Error('Missing market quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, marketQuoteRequest],
-		enabled: Boolean(marketQuoteRequest),
+		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest],
+		enabled: Boolean($debouncedMarketQuoteRequest),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,
-		queryFn: () => {
-			if (!marketQuoteRequest) throw new Error('Missing market quote request');
-			return apiGetSwapQuoteV2(marketQuoteRequest);
+		queryFn: ({ signal }) => {
+			if (!$debouncedMarketQuoteRequest) throw new Error('Missing swap quote request');
+			return apiGetSwapQuoteV2($debouncedMarketQuoteRequest, signal);
 		}
 	});
 	$: marketQuote = $marketQuoteQuery?.data;

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -401,7 +401,7 @@
 		queryFn: () => Promise.reject(new Error('Missing market quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.revision],
+		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.fingerprint],
 		enabled: Boolean($debouncedMarketQuoteRequest.request),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,

--- a/src/lib/components/orders/MarketOrder.svelte
+++ b/src/lib/components/orders/MarketOrder.svelte
@@ -17,7 +17,7 @@
 		type ApiSwapQuoteV2Request,
 		type ApiSwapQuoteV2Response
 	} from '$lib/api/st0xApi';
-	import { createDebouncedValue } from '$lib/stores/debouncedValue';
+	import { createDebouncedRequest } from '$lib/stores/debouncedValue';
 	import {
 		buildMarketSwapQuoteRequest,
 		DEFAULT_MARKET_ORDER_SLIPPAGE_BPS,
@@ -393,28 +393,25 @@
 					$walletAddress ?? undefined
 				)
 			: null;
-	const debouncedMarketQuoteRequest = createDebouncedValue<ApiSwapQuoteV2Request | null>(null, 300);
-	$: if (marketQuoteRequest) {
-		debouncedMarketQuoteRequest.set(marketQuoteRequest);
-	} else {
-		debouncedMarketQuoteRequest.setImmediately(null);
-	}
+	const debouncedMarketQuoteRequest = createDebouncedRequest<ApiSwapQuoteV2Request>(300);
+	$: debouncedMarketQuoteRequest.set(marketQuoteRequest);
 	let marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
 		queryKey: ['marketSwapQuoteV2', undefined, null],
 		enabled: false,
 		queryFn: () => Promise.reject(new Error('Missing market quote request'))
 	});
 	$: marketQuoteQuery = createQuery<ApiSwapQuoteV2Response>({
-		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest],
-		enabled: Boolean($debouncedMarketQuoteRequest),
+		queryKey: ['marketSwapQuoteV2', $currentNetwork?.id, $debouncedMarketQuoteRequest.revision],
+		enabled: Boolean($debouncedMarketQuoteRequest.request),
 		staleTime: 5_000,
 		retry: shouldRetryTradeQuery,
 		queryFn: ({ signal }) => {
-			if (!$debouncedMarketQuoteRequest) throw new Error('Missing swap quote request');
-			return apiGetSwapQuoteV2($debouncedMarketQuoteRequest, signal);
+			const request = $debouncedMarketQuoteRequest.request;
+			if (!request) throw new Error('Missing swap quote request');
+			return apiGetSwapQuoteV2(request, signal);
 		}
 	});
-	$: marketQuote = $marketQuoteQuery?.data;
+	$: marketQuote = $debouncedMarketQuoteRequest.request ? $marketQuoteQuery?.data : undefined;
 	$: {
 		insufficientLiquidityWarning = Boolean(
 			selectedAmount > 0n && marketQuote && !marketQuote.fullyFilled

--- a/src/lib/queries/balances.ts
+++ b/src/lib/queries/balances.ts
@@ -13,3 +13,8 @@ export function invalidateDashboardBalances() {
 	queryClient.invalidateQueries({ queryKey: ['usdcWalletBalance'] });
 	queryClient.invalidateQueries({ queryKey: ['ethWalletBalance'] });
 }
+
+/** Refresh all-time trade-derived data only after a confirmed market order. */
+export function invalidateCostBasis() {
+	queryClient.invalidateQueries({ queryKey: ['costBasis'] });
+}

--- a/src/lib/queries/balances.ts
+++ b/src/lib/queries/balances.ts
@@ -18,3 +18,8 @@ export function invalidateDashboardBalances() {
 export function invalidateCostBasis() {
 	queryClient.invalidateQueries({ queryKey: ['costBasis'] });
 }
+
+/** Refresh the bounded recent market-order list after a confirmed market order. */
+export function invalidateTakerTrades() {
+	queryClient.invalidateQueries({ queryKey: ['takerTrades'] });
+}

--- a/src/lib/queries/costBasis.ts
+++ b/src/lib/queries/costBasis.ts
@@ -140,7 +140,9 @@ export function createCostBasisQuery(network: Network | null, userAddress: strin
 		enabled: Boolean(network && userAddress),
 		staleTime: Infinity,
 		refetchInterval: false, // No polling - fetch once on mount
-		refetchOnWindowFocus: false,
+		// Successful all-history data stays fresh until a market-order invalidation.
+		// A failed initial walk may recover when the user later returns to the tab.
+		refetchOnWindowFocus: (query) => query.state.status === 'error',
 		// fetchJson already retries transient failures. Replaying this multi-page query
 		// from page one would duplicate every completed request and can create a retry storm.
 		retry: false,

--- a/src/lib/queries/costBasis.ts
+++ b/src/lib/queries/costBasis.ts
@@ -8,6 +8,18 @@ import {
 import { PAYMENT_TOKENS_BY_NETWORK } from '$lib/config/tokens';
 import { apiGetTradesByAddress, apiGetTakerTrades, type ApiTradeByAddress } from '$lib/api/st0xApi';
 
+const TRADE_HISTORY_PAGE_SIZE = 500;
+
+export type CostBasisPayload = {
+	costBasis: Map<string, CostBasisData>;
+	takerTrades: ApiTradeByAddress[];
+};
+
+export type UserTradeHistory = {
+	costBasisTrades: CostBasisTrade[];
+	takerTrades: ApiTradeByAddress[];
+};
+
 /**
  * Ensure an amount string contains a decimal point so toDecimal()
  * treats it as a pre-formatted decimal rather than a wei-scaled bigint.
@@ -68,9 +80,9 @@ function takerTradeToCostBasis(trade: ApiTradeByAddress, userAddress: string): C
  * Fetch all trades for a user from the REST API (paginated).
  * Combines maker trades (user's orders were filled) and taker trades (user executed market orders).
  */
-async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]> {
-	const PAGE_SIZE = 50;
-	const trades: CostBasisTrade[] = [];
+export async function fetchAllUserTrades(userAddress: string): Promise<UserTradeHistory> {
+	const costBasisTrades: CostBasisTrade[] = [];
+	const takerTrades: ApiTradeByAddress[] = [];
 	const seen = new Set<string>();
 
 	// Fetch all maker trades (paginated)
@@ -79,14 +91,14 @@ async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]
 	while (makerHasMore) {
 		const response = await apiGetTradesByAddress(userAddress, {
 			page: makerPage,
-			pageSize: PAGE_SIZE
+			pageSize: TRADE_HISTORY_PAGE_SIZE
 		});
 
 		for (const trade of response.trades ?? []) {
 			const key = `${trade.txHash}:${trade.orderHash ?? ''}`;
 			if (seen.has(key)) continue;
 			seen.add(key);
-			trades.push(makerTradeToCostBasis(trade, userAddress));
+			costBasisTrades.push(makerTradeToCostBasis(trade, userAddress));
 		}
 
 		makerHasMore = response.pagination.hasMore;
@@ -99,21 +111,22 @@ async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]
 	while (takerHasMore) {
 		const response = await apiGetTakerTrades(userAddress, {
 			page: takerPage,
-			pageSize: PAGE_SIZE
+			pageSize: TRADE_HISTORY_PAGE_SIZE
 		});
 
 		for (const trade of response.trades ?? []) {
+			takerTrades.push(trade);
 			const key = `${trade.txHash}:${trade.orderHash ?? ''}`;
 			if (seen.has(key)) continue;
 			seen.add(key);
-			trades.push(takerTradeToCostBasis(trade, userAddress));
+			costBasisTrades.push(takerTradeToCostBasis(trade, userAddress));
 		}
 
 		takerHasMore = response.pagination.hasMore;
 		takerPage++;
 	}
 
-	return trades;
+	return { costBasisTrades, takerTrades };
 }
 
 /**
@@ -122,26 +135,32 @@ async function fetchAllUserTrades(userAddress: string): Promise<CostBasisTrade[]
  * One-shot query: fetches once on mount, refreshes on window focus only.
  */
 export function createCostBasisQuery(network: Network | null, userAddress: string | null) {
-	return createQuery<Map<string, CostBasisData>>({
+	return createQuery<CostBasisPayload>({
 		queryKey: ['costBasis', network?.id, userAddress],
 		enabled: Boolean(network && userAddress),
 		staleTime: 600_000, // 10 minutes - only refetch when stale
 		refetchInterval: false, // No polling - fetch once on mount
 		refetchOnWindowFocus: true, // Refresh when user returns to tab (only if stale)
+		// fetchJson already retries transient failures. Replaying this multi-page query
+		// from page one would duplicate every completed request and can create a retry storm.
+		retry: false,
 		queryFn: async () => {
 			if (!network || !userAddress) {
-				return new Map();
+				return { costBasis: new Map(), takerTrades: [] };
 			}
 
 			// Fetch all trades for the user via REST API
-			const trades = await fetchAllUserTrades(userAddress);
+			const { costBasisTrades, takerTrades } = await fetchAllUserTrades(userAddress);
 
 			// Get payment token addresses for this network
 			const paymentTokens = PAYMENT_TOKENS_BY_NETWORK[network.chainId] ?? [];
 			const paymentTokenAddresses = new Set(paymentTokens.map((t) => t.address.toLowerCase()));
 
 			// Calculate cost basis for all traded tokens
-			return calculateAllCostBases(trades, paymentTokenAddresses, userAddress);
+			return {
+				costBasis: calculateAllCostBases(costBasisTrades, paymentTokenAddresses, userAddress),
+				takerTrades
+			};
 		}
 	});
 }

--- a/src/lib/queries/costBasis.ts
+++ b/src/lib/queries/costBasis.ts
@@ -115,7 +115,7 @@ export async function fetchAllUserTrades(userAddress: string): Promise<UserTrade
 		});
 
 		for (const trade of response.trades ?? []) {
-			takerTrades.push(trade);
+			if (takerPage === 1) takerTrades.push(trade);
 			const key = `${trade.txHash}:${trade.orderHash ?? ''}`;
 			if (seen.has(key)) continue;
 			seen.add(key);
@@ -132,15 +132,15 @@ export async function fetchAllUserTrades(userAddress: string): Promise<UserTrade
 /**
  * Query for calculating cost basis from all-time trade history.
  * Fetches both maker fills and taker market orders from the REST API.
- * One-shot query: fetches once on mount, refreshes on window focus only.
+ * Fetches once and refreshes only when a successful market order invalidates it.
  */
 export function createCostBasisQuery(network: Network | null, userAddress: string | null) {
 	return createQuery<CostBasisPayload>({
 		queryKey: ['costBasis', network?.id, userAddress],
 		enabled: Boolean(network && userAddress),
-		staleTime: 600_000, // 10 minutes - only refetch when stale
+		staleTime: Infinity,
 		refetchInterval: false, // No polling - fetch once on mount
-		refetchOnWindowFocus: true, // Refresh when user returns to tab (only if stale)
+		refetchOnWindowFocus: false,
 		// fetchJson already retries transient failures. Replaying this multi-page query
 		// from page one would duplicate every completed request and can create a retry storm.
 		retry: false,

--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -97,6 +97,13 @@ export type TakerTradesPayload = {
 	trades: ApiTradeByAddress[];
 };
 
+export async function fetchRecentTakerTrades(walletAddress: string): Promise<TakerTradesPayload> {
+	// Preserve the existing 500-trade display limit in one REST request instead of
+	// ten sequential 50-trade requests.
+	const response = await apiGetTakerTrades(walletAddress, { page: 1, pageSize: 500 });
+	return { trades: response.trades ?? [] };
+}
+
 export function createTakerTradesQuery(
 	network: Network | null,
 	walletAddress: string | null,
@@ -107,20 +114,7 @@ export function createTakerTradesQuery(
 		enabled: Boolean(network && walletAddress),
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
-		retry: 2,
-		queryFn: async () => {
-			const PAGE_SIZE = 50;
-			let allTrades: ApiTradeByAddress[] = [];
-			let page = 1;
-
-			while (page <= 10) {
-				const response = await apiGetTakerTrades(walletAddress!, { page, pageSize: PAGE_SIZE });
-				allTrades = allTrades.concat(response.trades ?? []);
-				if (!response.pagination.hasMore) break;
-				page++;
-			}
-
-			return { trades: allTrades };
-		}
+		retry: (failureCount, error) => !isRateLimitError(error) && failureCount < 1,
+		queryFn: () => fetchRecentTakerTrades(walletAddress!)
 	});
 }

--- a/src/lib/queries/tradeActivity.ts
+++ b/src/lib/queries/tradeActivity.ts
@@ -2,6 +2,7 @@ import { createQuery } from '@tanstack/svelte-query';
 import type { Network } from '$lib/config/network';
 import { getTokenByAnyAddress } from '$lib/config/network';
 import { isRateLimitError } from '$lib/clients/http';
+import { shouldRetryTradeQuery } from '$lib/services/tradeError';
 import {
 	apiGetTradesByToken,
 	apiGetTakerTrades,
@@ -114,7 +115,7 @@ export function createTakerTradesQuery(
 		enabled: Boolean(network && walletAddress),
 		staleTime: 600_000,
 		refetchInterval: pollInterval,
-		retry: (failureCount, error) => !isRateLimitError(error) && failureCount < 1,
+		retry: shouldRetryTradeQuery,
 		queryFn: () => fetchRecentTakerTrades(walletAddress!)
 	});
 }

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -19,7 +19,11 @@ import {
 	type ApiTradesByTxResponse
 } from '$lib/api/st0xApi';
 import type { Network } from '$lib/config/network';
-import { invalidateCostBasis, invalidateDashboardBalances } from '$lib/queries/balances';
+import {
+	invalidateCostBasis,
+	invalidateDashboardBalances,
+	invalidateTakerTrades
+} from '$lib/queries/balances';
 import {
 	APPROVAL_TX_CONFIRMATIONS,
 	getSignerAddress,
@@ -517,6 +521,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 			}
 		}
 		invalidateCostBasis();
+		invalidateTakerTrades();
 		transactionStoreInternal.transactionSuccess(hash, 'Market order confirmed', metadata);
 		return { success: true };
 	} catch (error) {

--- a/src/lib/services/marketOrderExecution.ts
+++ b/src/lib/services/marketOrderExecution.ts
@@ -19,7 +19,7 @@ import {
 	type ApiTradesByTxResponse
 } from '$lib/api/st0xApi';
 import type { Network } from '$lib/config/network';
-import { invalidateDashboardBalances } from '$lib/queries/balances';
+import { invalidateCostBasis, invalidateDashboardBalances } from '$lib/queries/balances';
 import {
 	APPROVAL_TX_CONFIRMATIONS,
 	getSignerAddress,
@@ -516,6 +516,7 @@ export async function executeMarketOrder(input: MarketOrderInput): Promise<Marke
 				captureTradeFlowError(error, flowContext('confirmation', 'build_market_order_summary'));
 			}
 		}
+		invalidateCostBasis();
 		transactionStoreInternal.transactionSuccess(hash, 'Market order confirmed', metadata);
 		return { success: true };
 	} catch (error) {

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -1,4 +1,4 @@
-import { isHttpError } from '$lib/clients/http';
+import { isHttpError, isRateLimitError } from '$lib/clients/http';
 import type { ErrorClass } from '$lib/services/observability/tradeEvents';
 
 export type TradeErrorStage =
@@ -255,6 +255,7 @@ const STAGE_FALLBACK: Record<TradeErrorStage, string> = {
 /** Avoid retrying client failures; changing the request is the only useful recovery. */
 export function shouldRetryTradeQuery(failureCount: number, error: unknown): boolean {
 	if (failureCount >= 1) return false;
+	if (isRateLimitError(error)) return false;
 	if (!isHttpError(error)) return true;
 	return error.status === 408 || (error.status >= 500 && error.status !== 503);
 }

--- a/src/lib/services/tradeError.ts
+++ b/src/lib/services/tradeError.ts
@@ -252,11 +252,11 @@ const STAGE_FALLBACK: Record<TradeErrorStage, string> = {
 	confirmation: 'TRADE_CONFIRMATION_FAILED'
 };
 
-/** Avoid amplifying explicit REST backoff responses while retaining one retry for other failures. */
+/** Avoid retrying client failures; changing the request is the only useful recovery. */
 export function shouldRetryTradeQuery(failureCount: number, error: unknown): boolean {
-	return (
-		failureCount < 1 && !(isHttpError(error) && (error.status === 429 || error.status === 503))
-	);
+	if (failureCount >= 1) return false;
+	if (!isHttpError(error)) return true;
+	return error.status === 408 || (error.status >= 500 && error.status !== 503);
 }
 
 function safeCode(code: string): string {

--- a/src/lib/stores/debouncedValue.ts
+++ b/src/lib/stores/debouncedValue.ts
@@ -1,0 +1,36 @@
+import { writable, type Readable } from 'svelte/store';
+
+export type DebouncedValue<T> = Readable<T> & {
+	set(value: T): void;
+	setImmediately(value: T): void;
+	destroy(): void;
+};
+
+/** A small lifecycle-aware store for debouncing request inputs. */
+export function createDebouncedValue<T>(initialValue: T, delayMs: number): DebouncedValue<T> {
+	const store = writable(initialValue);
+	let timeout: ReturnType<typeof setTimeout> | null = null;
+
+	function clearPending() {
+		if (timeout !== null) {
+			clearTimeout(timeout);
+			timeout = null;
+		}
+	}
+
+	return {
+		subscribe: store.subscribe,
+		set(value) {
+			clearPending();
+			timeout = setTimeout(() => {
+				timeout = null;
+				store.set(value);
+			}, delayMs);
+		},
+		setImmediately(value) {
+			clearPending();
+			store.set(value);
+		},
+		destroy: clearPending
+	};
+}

--- a/src/lib/stores/debouncedValue.ts
+++ b/src/lib/stores/debouncedValue.ts
@@ -1,15 +1,24 @@
 import { writable, type Readable } from 'svelte/store';
 
-export type DebouncedValue<T> = Readable<T> & {
-	set(value: T): void;
-	setImmediately(value: T): void;
+export type DebouncedRequestState<T> = {
+	request: T | null;
+	revision: number;
+};
+
+export type DebouncedRequest<T> = Readable<DebouncedRequestState<T>> & {
+	set(request: T | null): void;
 	destroy(): void;
 };
 
-/** A small lifecycle-aware store for debouncing request inputs. */
-export function createDebouncedValue<T>(initialValue: T, delayMs: number): DebouncedValue<T> {
-	const store = writable(initialValue);
+/**
+ * Debounce request payloads while invalidating the current revision immediately.
+ * Semantically identical JSON payloads retain their revision and active request.
+ */
+export function createDebouncedRequest<T>(delayMs: number): DebouncedRequest<T> {
+	const store = writable<DebouncedRequestState<T>>({ request: null, revision: 0 });
 	let timeout: ReturnType<typeof setTimeout> | null = null;
+	let revision = 0;
+	let fingerprint: string | null = null;
 
 	function clearPending() {
 		if (timeout !== null) {
@@ -20,16 +29,22 @@ export function createDebouncedValue<T>(initialValue: T, delayMs: number): Debou
 
 	return {
 		subscribe: store.subscribe,
-		set(value) {
+		set(request) {
+			const nextFingerprint = request === null ? null : JSON.stringify(request);
+			if (nextFingerprint === fingerprint) return;
+
 			clearPending();
+			fingerprint = nextFingerprint;
+			revision += 1;
+			// Changing the revision detaches the query observer from the previous
+			// request immediately, before the next request finishes debouncing.
+			store.set({ request: null, revision });
+			if (request === null) return;
+
 			timeout = setTimeout(() => {
 				timeout = null;
-				store.set(value);
+				store.set({ request, revision });
 			}, delayMs);
-		},
-		setImmediately(value) {
-			clearPending();
-			store.set(value);
 		},
 		destroy: clearPending
 	};

--- a/src/lib/stores/debouncedValue.ts
+++ b/src/lib/stores/debouncedValue.ts
@@ -3,6 +3,7 @@ import { writable, type Readable } from 'svelte/store';
 export type DebouncedRequestState<T> = {
 	request: T | null;
 	revision: number;
+	fingerprint: string | null;
 };
 
 export type DebouncedRequest<T> = Readable<DebouncedRequestState<T>> & {
@@ -15,7 +16,11 @@ export type DebouncedRequest<T> = Readable<DebouncedRequestState<T>> & {
  * Semantically identical JSON payloads retain their revision and active request.
  */
 export function createDebouncedRequest<T>(delayMs: number): DebouncedRequest<T> {
-	const store = writable<DebouncedRequestState<T>>({ request: null, revision: 0 });
+	const store = writable<DebouncedRequestState<T>>({
+		request: null,
+		revision: 0,
+		fingerprint: null
+	});
 	let timeout: ReturnType<typeof setTimeout> | null = null;
 	let revision = 0;
 	let fingerprint: string | null = null;
@@ -36,14 +41,15 @@ export function createDebouncedRequest<T>(delayMs: number): DebouncedRequest<T> 
 			clearPending();
 			fingerprint = nextFingerprint;
 			revision += 1;
-			// Changing the revision detaches the query observer from the previous
-			// request immediately, before the next request finishes debouncing.
-			store.set({ request: null, revision });
+			// Changing the fingerprint detaches the query observer from the previous
+			// request immediately, before the next request finishes debouncing. Unlike
+			// the component-local revision, it also stays unique across remounts.
+			store.set({ request: null, revision, fingerprint });
 			if (request === null) return;
 
 			timeout = setTimeout(() => {
 				timeout = null;
-				store.set({ request, revision });
+				store.set({ request, revision, fingerprint: nextFingerprint });
 			}, delayMs);
 		},
 		destroy: clearPending

--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -34,7 +34,11 @@ import { detectPartialFill } from './partialFillDetection';
 import { ensureAllowance } from './approvalStore';
 import { parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
 import { createRaindexClient } from '$lib/clients/raindex';
-import { invalidateCostBasis, invalidateDashboardBalances } from '$lib/queries/balances';
+import {
+	invalidateCostBasis,
+	invalidateDashboardBalances,
+	invalidateTakerTrades
+} from '$lib/queries/balances';
 import { walletAddress, authMethod } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { getTrades } from '$lib/api/subgraph';
@@ -435,6 +439,7 @@ export const pollAndFinalizeTakeOrders = async (
 	// the cache hasn't seen yet).
 	invalidateDashboardBalances();
 	invalidateCostBasis();
+	invalidateTakerTrades();
 
 	// Partial-fill detection anchors on whichever side the user typed their amount.
 	// For spend modes (Sell-by-asset, Buy-by-spend) the anchor is the pays side; for

--- a/src/lib/stores/marketTakeStore.ts
+++ b/src/lib/stores/marketTakeStore.ts
@@ -34,7 +34,7 @@ import { detectPartialFill } from './partialFillDetection';
 import { ensureAllowance } from './approvalStore';
 import { parseFloatHex, getRaindexOrderUrl } from '$lib/utils/tokenMath';
 import { createRaindexClient } from '$lib/clients/raindex';
-import { invalidateDashboardBalances } from '$lib/queries/balances';
+import { invalidateCostBasis, invalidateDashboardBalances } from '$lib/queries/balances';
 import { walletAddress, authMethod } from '$lib/stores/authStore';
 import { currentNetwork } from '$lib/stores';
 import { getTrades } from '$lib/api/subgraph';
@@ -434,6 +434,7 @@ export const pollAndFinalizeTakeOrders = async (
 	// could render with stale on-chain balance reads (the user just got tokens
 	// the cache hasn't seen yet).
 	invalidateDashboardBalances();
+	invalidateCostBasis();
 
 	// Partial-fill detection anchors on whichever side the user typed their amount.
 	// For spend modes (Sell-by-asset, Buy-by-spend) the anchor is the pays side; for

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -38,7 +38,7 @@
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
 	import { createOwnerOrdersQuery } from '$lib/queries/orderbook';
 	import { createUserVaultsQuery } from '$lib/queries/vaults';
-	import { createBatchTradesQuery } from '$lib/queries/tradeActivity';
+	import { createBatchTradesQuery, createTakerTradesQuery } from '$lib/queries/tradeActivity';
 	import { createCostBasisQuery } from '$lib/queries/costBasis';
 	import { calculatePnL } from '$lib/utils/costBasis';
 	import { createExchangeRatesQuery, resolveRatio } from '$lib/queries/exchangeRates';
@@ -923,8 +923,11 @@
 	// never needs the rest of the book, and the full fan-out was a rate-limit amplifier
 	$: ownerOrdersQuery = createOwnerOrdersQuery($currentNetwork, $walletAddress, 15_000);
 
-	// Cost basis and taker history share one paginated request so the dashboard does not
-	// fetch the same taker trades twice. Successful market orders invalidate this query.
+	// Keep the bounded recent-order request independent from the all-history cost-basis
+	// walk so a later-page history failure cannot blank the market-order list.
+	$: takerTradesQuery = createTakerTradesQuery($currentNetwork, $walletAddress, 600_000);
+
+	// Cost basis is an all-history query refreshed after successful market orders.
 	$: costBasisQuery = createCostBasisQuery($currentNetwork, $walletAddress);
 
 	// Wrap-ratio lookup so the Holdings table can flip wt↔t when the user
@@ -942,7 +945,7 @@
 
 	// Transform taker trades into display orders
 	$: userMarketOrders = (() => {
-		const trades = $costBasisQuery?.data?.takerTrades;
+		const trades = $takerTradesQuery?.data?.trades;
 		if (!trades?.length || !$currentNetwork) return [];
 		return transformApiTakerTradesToDisplay(trades, $currentNetwork.chainId);
 	})();

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -924,7 +924,7 @@
 	$: ownerOrdersQuery = createOwnerOrdersQuery($currentNetwork, $walletAddress, 15_000);
 
 	// Cost basis and taker history share one paginated request so the dashboard does not
-	// fetch the same taker trades twice. It refreshes on focus when older than 10 minutes.
+	// fetch the same taker trades twice. Successful market orders invalidate this query.
 	$: costBasisQuery = createCostBasisQuery($currentNetwork, $walletAddress);
 
 	// Wrap-ratio lookup so the Holdings table can flip wt↔t when the user

--- a/src/routes/(main)/dashboard/+page.svelte
+++ b/src/routes/(main)/dashboard/+page.svelte
@@ -38,7 +38,7 @@
 	import { createPriceFeedsQuery } from '$lib/queries/priceFeeds';
 	import { createOwnerOrdersQuery } from '$lib/queries/orderbook';
 	import { createUserVaultsQuery } from '$lib/queries/vaults';
-	import { createTakerTradesQuery, createBatchTradesQuery } from '$lib/queries/tradeActivity';
+	import { createBatchTradesQuery } from '$lib/queries/tradeActivity';
 	import { createCostBasisQuery } from '$lib/queries/costBasis';
 	import { calculatePnL } from '$lib/utils/costBasis';
 	import { createExchangeRatesQuery, resolveRatio } from '$lib/queries/exchangeRates';
@@ -700,7 +700,7 @@
 		}
 
 		// Convert to array with prices, filtering to only valid tokens
-		const costBasisMap = $costBasisQuery?.data ?? new Map();
+		const costBasisMap = $costBasisQuery?.data?.costBasis ?? new Map();
 		const manualEntries = $manualCostBasisStore;
 
 		const result = Array.from(holdingsMap.values())
@@ -923,10 +923,8 @@
 	// never needs the rest of the book, and the full fan-out was a rate-limit amplifier
 	$: ownerOrdersQuery = createOwnerOrdersQuery($currentNetwork, $walletAddress, 15_000);
 
-	// Taker trades for market orders - poll every 10 minutes
-	$: takerTradesQuery = createTakerTradesQuery($currentNetwork, $walletAddress, 600_000);
-
-	// Cost basis query for P&L calculation - one-shot (no polling, refreshes on window focus)
+	// Cost basis and taker history share one paginated request so the dashboard does not
+	// fetch the same taker trades twice. It refreshes on focus when older than 10 minutes.
 	$: costBasisQuery = createCostBasisQuery($currentNetwork, $walletAddress);
 
 	// Wrap-ratio lookup so the Holdings table can flip wt↔t when the user
@@ -944,7 +942,7 @@
 
 	// Transform taker trades into display orders
 	$: userMarketOrders = (() => {
-		const trades = $takerTradesQuery?.data?.trades;
+		const trades = $costBasisQuery?.data?.takerTrades;
 		if (!trades?.length || !$currentNetwork) return [];
 		return transformApiTakerTradesToDisplay(trades, $currentNetwork.chainId);
 	})();

--- a/tests/lib/api/st0xApi.test.ts
+++ b/tests/lib/api/st0xApi.test.ts
@@ -86,14 +86,16 @@ describe('st0x API client', () => {
 			slippageBps: 100,
 			referenceIoRatio: '2.5'
 		};
-		const result = await apiGetSwapQuoteV2(request);
+		const signal = new AbortController().signal;
+		const result = await apiGetSwapQuoteV2(request, signal);
 
 		expect(result).toEqual(responseBody);
 		expect(fetchMock).toHaveBeenCalledWith(
 			'/api/st0x/v2/swap/quote',
 			expect.objectContaining({
 				method: 'POST',
-				body: JSON.stringify(request)
+				body: JSON.stringify(request),
+				signal
 			})
 		);
 	});

--- a/tests/lib/components/marketQuoteQueryInitialization.test.ts
+++ b/tests/lib/components/marketQuoteQueryInitialization.test.ts
@@ -34,4 +34,12 @@ describe.each(componentSources)('$name REST quote query initialization', ({ sour
 		expect(source).toContain('$marketQuoteQuery?.data');
 		expect(source).not.toContain('$marketQuoteQuery.data');
 	});
+
+	it('changes query revision and disables rendering while a new request debounces', () => {
+		expect(source).toContain('$debouncedMarketQuoteRequest.revision');
+		expect(source).toContain('Boolean($debouncedMarketQuoteRequest.request)');
+		expect(source).toMatch(
+			/\$debouncedMarketQuoteRequest\.request\s*\?\s*\$marketQuoteQuery\?\.data/
+		);
+	});
 });

--- a/tests/lib/components/marketQuoteQueryInitialization.test.ts
+++ b/tests/lib/components/marketQuoteQueryInitialization.test.ts
@@ -35,8 +35,11 @@ describe.each(componentSources)('$name REST quote query initialization', ({ sour
 		expect(source).not.toContain('$marketQuoteQuery.data');
 	});
 
-	it('changes query revision and disables rendering while a new request debounces', () => {
-		expect(source).toContain('$debouncedMarketQuoteRequest.revision');
+	it('keys cached quotes by request and disables rendering while a new request debounces', () => {
+		expect(source).toContain('$debouncedMarketQuoteRequest.fingerprint');
+		expect(source).not.toMatch(
+			/queryKey:\s*\[[\s\S]*?\$debouncedMarketQuoteRequest\.revision[\s\S]*?\]/
+		);
 		expect(source).toContain('Boolean($debouncedMarketQuoteRequest.request)');
 		expect(source).toMatch(
 			/\$debouncedMarketQuoteRequest\.request\s*\?\s*\$marketQuoteQuery\?\.data/

--- a/tests/lib/queries/balances.test.ts
+++ b/tests/lib/queries/balances.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { queryClient } from '$lib/clients/queryClient';
-import { invalidateCostBasis } from '$lib/queries/balances';
+import { invalidateCostBasis, invalidateTakerTrades } from '$lib/queries/balances';
 
 describe('balance query invalidation', () => {
 	beforeEach(() => {
@@ -17,6 +17,14 @@ describe('balance query invalidation', () => {
 		expect(invalidate).toHaveBeenCalledWith({ queryKey: ['costBasis'] });
 	});
 
+	it('invalidates all recent taker-trade query variants', () => {
+		const invalidate = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+
+		invalidateTakerTrades();
+
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ['takerTrades'] });
+	});
+
 	it('invalidates cost basis in the legacy market-order success finalizer', () => {
 		const source = readFileSync(
 			resolve(process.cwd(), 'src/lib/stores/marketTakeStore.ts'),
@@ -29,6 +37,10 @@ describe('balance query invalidation', () => {
 
 		expect(finalizer.indexOf('invalidateCostBasis()')).toBeGreaterThan(-1);
 		expect(finalizer.indexOf('invalidateCostBasis()')).toBeLessThan(
+			finalizer.indexOf('transactionSuccess(')
+		);
+		expect(finalizer.indexOf('invalidateTakerTrades()')).toBeGreaterThan(-1);
+		expect(finalizer.indexOf('invalidateTakerTrades()')).toBeLessThan(
 			finalizer.indexOf('transactionSuccess(')
 		);
 	});

--- a/tests/lib/queries/balances.test.ts
+++ b/tests/lib/queries/balances.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { queryClient } from '$lib/clients/queryClient';
+import { invalidateCostBasis } from '$lib/queries/balances';
+
+describe('balance query invalidation', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('invalidates all cost-basis query variants', () => {
+		const invalidate = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+
+		invalidateCostBasis();
+
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ['costBasis'] });
+	});
+
+	it('invalidates cost basis in the legacy market-order success finalizer', () => {
+		const source = readFileSync(
+			resolve(process.cwd(), 'src/lib/stores/marketTakeStore.ts'),
+			'utf8'
+		);
+		const finalizer = source.slice(
+			source.indexOf('export const pollAndFinalizeTakeOrders'),
+			source.indexOf('export const preloadAggregatedTakeOrdersCalldata')
+		);
+
+		expect(finalizer.indexOf('invalidateCostBasis()')).toBeGreaterThan(-1);
+		expect(finalizer.indexOf('invalidateCostBasis()')).toBeLessThan(
+			finalizer.indexOf('transactionSuccess(')
+		);
+	});
+});

--- a/tests/lib/queries/requestAmplification.test.ts
+++ b/tests/lib/queries/requestAmplification.test.ts
@@ -40,11 +40,14 @@ describe('trade history request amplification', () => {
 	it('loads cost-basis history in 500-trade pages and exposes fetched taker trades', async () => {
 		const makerOne = trade('maker-1');
 		const makerTwo = trade('maker-2');
-		const taker = trade('taker-1');
+		const takerOne = trade('taker-1');
+		const takerTwo = trade('taker-2');
 		apiMocks.apiGetTradesByAddress
 			.mockResolvedValueOnce(page([makerOne], true))
 			.mockResolvedValueOnce(page([makerTwo], false));
-		apiMocks.apiGetTakerTrades.mockResolvedValueOnce(page([taker], false));
+		apiMocks.apiGetTakerTrades
+			.mockResolvedValueOnce(page([takerOne], true))
+			.mockResolvedValueOnce(page([takerTwo], false));
 
 		const result = await fetchAllUserTrades('0xuser');
 
@@ -56,13 +59,17 @@ describe('trade history request amplification', () => {
 			page: 2,
 			pageSize: 500
 		});
-		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledOnce();
-		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledWith('0xuser', {
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledTimes(2);
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenNthCalledWith(1, '0xuser', {
 			page: 1,
 			pageSize: 500
 		});
-		expect(result.costBasisTrades).toHaveLength(3);
-		expect(result.takerTrades).toEqual([taker]);
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenNthCalledWith(2, '0xuser', {
+			page: 2,
+			pageSize: 500
+		});
+		expect(result.costBasisTrades).toHaveLength(4);
+		expect(result.takerTrades).toEqual([takerOne]);
 	});
 
 	it('loads the 500 most recent display trades in one request', async () => {

--- a/tests/lib/queries/requestAmplification.test.ts
+++ b/tests/lib/queries/requestAmplification.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { ApiTradeByAddress } from '$lib/api/st0xApi';
+import type { Network } from '$lib/config/network';
 
 const apiMocks = vi.hoisted(() => ({
 	apiGetTradesByAddress: vi.fn(),
@@ -7,10 +10,14 @@ const apiMocks = vi.hoisted(() => ({
 	apiGetTradesByToken: vi.fn(),
 	apiGetTradesBatch: vi.fn()
 }));
+const queryMocks = vi.hoisted(() => ({
+	createQuery: vi.fn((options: unknown) => options)
+}));
 
 vi.mock('$lib/api/st0xApi', () => apiMocks);
+vi.mock('@tanstack/svelte-query', () => queryMocks);
 
-import { fetchAllUserTrades } from '$lib/queries/costBasis';
+import { createCostBasisQuery, fetchAllUserTrades } from '$lib/queries/costBasis';
 import { fetchRecentTakerTrades } from '$lib/queries/tradeActivity';
 
 function trade(id: string): ApiTradeByAddress {
@@ -82,5 +89,36 @@ describe('trade history request amplification', () => {
 			page: 1,
 			pageSize: 500
 		});
+	});
+
+	it('retries a failed cost-basis walk on focus without refetching successful data', () => {
+		const options = createCostBasisQuery(
+			{ id: 8453, chainId: 8453 } as Network,
+			'0xuser'
+		) as unknown as {
+			staleTime: number;
+			retry: boolean;
+			refetchOnWindowFocus: (query: { state: { status: string } }) => boolean;
+		};
+
+		expect(options.staleTime).toBe(Infinity);
+		expect(options.retry).toBe(false);
+		expect(options.refetchOnWindowFocus({ state: { status: 'error' } })).toBe(true);
+		expect(options.refetchOnWindowFocus({ state: { status: 'success' } })).toBe(false);
+	});
+
+	it('keeps recent market orders independent from the all-history cost-basis walk', () => {
+		const source = readFileSync(
+			resolve(process.cwd(), 'src/routes/(main)/dashboard/+page.svelte'),
+			'utf8'
+		);
+		const marketOrdersTransform = source.slice(
+			source.indexOf('// Transform taker trades into display orders'),
+			source.indexOf('// Extract user\'s order hashes')
+		);
+
+		expect(source).toContain('createTakerTradesQuery($currentNetwork, $walletAddress, 600_000)');
+		expect(marketOrdersTransform).toContain('$takerTradesQuery?.data?.trades');
+		expect(marketOrdersTransform).not.toContain('$costBasisQuery');
 	});
 });

--- a/tests/lib/queries/requestAmplification.test.ts
+++ b/tests/lib/queries/requestAmplification.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiTradeByAddress } from '$lib/api/st0xApi';
+
+const apiMocks = vi.hoisted(() => ({
+	apiGetTradesByAddress: vi.fn(),
+	apiGetTakerTrades: vi.fn(),
+	apiGetTradesByToken: vi.fn(),
+	apiGetTradesBatch: vi.fn()
+}));
+
+vi.mock('$lib/api/st0xApi', () => apiMocks);
+
+import { fetchAllUserTrades } from '$lib/queries/costBasis';
+import { fetchRecentTakerTrades } from '$lib/queries/tradeActivity';
+
+function trade(id: string): ApiTradeByAddress {
+	return {
+		txHash: `0x${id}`,
+		orderHash: `0xorder${id}`,
+		timestamp: 1_700_000_000,
+		inputAmount: '1',
+		outputAmount: '2',
+		inputToken: { address: '0xinput' },
+		outputToken: { address: '0xoutput' }
+	} as ApiTradeByAddress;
+}
+
+function page(trades: ApiTradeByAddress[], hasMore: boolean) {
+	return {
+		trades,
+		pagination: { page: 1, pageSize: 500, totalTrades: trades.length, totalPages: 1, hasMore }
+	};
+}
+
+describe('trade history request amplification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('loads cost-basis history in 500-trade pages and exposes fetched taker trades', async () => {
+		const makerOne = trade('maker-1');
+		const makerTwo = trade('maker-2');
+		const taker = trade('taker-1');
+		apiMocks.apiGetTradesByAddress
+			.mockResolvedValueOnce(page([makerOne], true))
+			.mockResolvedValueOnce(page([makerTwo], false));
+		apiMocks.apiGetTakerTrades.mockResolvedValueOnce(page([taker], false));
+
+		const result = await fetchAllUserTrades('0xuser');
+
+		expect(apiMocks.apiGetTradesByAddress).toHaveBeenNthCalledWith(1, '0xuser', {
+			page: 1,
+			pageSize: 500
+		});
+		expect(apiMocks.apiGetTradesByAddress).toHaveBeenNthCalledWith(2, '0xuser', {
+			page: 2,
+			pageSize: 500
+		});
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledOnce();
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledWith('0xuser', {
+			page: 1,
+			pageSize: 500
+		});
+		expect(result.costBasisTrades).toHaveLength(3);
+		expect(result.takerTrades).toEqual([taker]);
+	});
+
+	it('loads the 500 most recent display trades in one request', async () => {
+		const trades = [trade('taker-1'), trade('taker-2')];
+		apiMocks.apiGetTakerTrades.mockResolvedValueOnce(page(trades, true));
+
+		await expect(fetchRecentTakerTrades('0xuser')).resolves.toEqual({ trades });
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledOnce();
+		expect(apiMocks.apiGetTakerTrades).toHaveBeenCalledWith('0xuser', {
+			page: 1,
+			pageSize: 500
+		});
+	});
+});

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 	update: vi.fn(),
 	invalidateDashboardBalances: vi.fn(),
 	invalidateCostBasis: vi.fn(),
+	invalidateTakerTrades: vi.fn(),
 	trackTradeEvent: vi.fn(),
 	captureTradeFlowError: vi.fn()
 }));
@@ -32,7 +33,8 @@ vi.mock('$lib/services/walletService', () => ({
 }));
 vi.mock('$lib/queries/balances', () => ({
 	invalidateDashboardBalances: mocks.invalidateDashboardBalances,
-	invalidateCostBasis: mocks.invalidateCostBasis
+	invalidateCostBasis: mocks.invalidateCostBasis,
+	invalidateTakerTrades: mocks.invalidateTakerTrades
 }));
 vi.mock('$lib/stores/transactionShared', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
@@ -300,6 +302,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 		});
 		expect(mocks.apiGetTradesByTx).toHaveBeenCalledWith(TRADE_HASH);
 		expect(mocks.invalidateCostBasis).toHaveBeenCalledOnce();
+		expect(mocks.invalidateTakerTrades).toHaveBeenCalledOnce();
 		expect(mocks.transactionSuccess).toHaveBeenCalledWith(TRADE_HASH, 'Market order confirmed', {
 			marketOrderSummary: expect.objectContaining({
 				inputAmount: 2_000_000_000_000_000_000n,

--- a/tests/lib/services/marketOrderExecution.test.ts
+++ b/tests/lib/services/marketOrderExecution.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 	transactionSuccess: vi.fn(),
 	update: vi.fn(),
 	invalidateDashboardBalances: vi.fn(),
+	invalidateCostBasis: vi.fn(),
 	trackTradeEvent: vi.fn(),
 	captureTradeFlowError: vi.fn()
 }));
@@ -30,7 +31,8 @@ vi.mock('$lib/services/walletService', () => ({
 	waitForTransaction: mocks.waitForTransaction
 }));
 vi.mock('$lib/queries/balances', () => ({
-	invalidateDashboardBalances: mocks.invalidateDashboardBalances
+	invalidateDashboardBalances: mocks.invalidateDashboardBalances,
+	invalidateCostBasis: mocks.invalidateCostBasis
 }));
 vi.mock('$lib/stores/transactionShared', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
@@ -297,6 +299,7 @@ describe('executeMarketOrder REST calldata execution', () => {
 			value: 0n
 		});
 		expect(mocks.apiGetTradesByTx).toHaveBeenCalledWith(TRADE_HASH);
+		expect(mocks.invalidateCostBasis).toHaveBeenCalledOnce();
 		expect(mocks.transactionSuccess).toHaveBeenCalledWith(TRADE_HASH, 'Market order confirmed', {
 			marketOrderSummary: expect.objectContaining({
 				inputAmount: 2_000_000_000_000_000_000n,

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -75,6 +75,7 @@ describe('tradeError', () => {
 			});
 
 		expect(shouldRetryTradeQuery(0, httpError(429))).toBe(false);
+		expect(shouldRetryTradeQuery(0, new Error('HTTP 429 Too Many Requests'))).toBe(false);
 		expect(shouldRetryTradeQuery(0, httpError(404))).toBe(false);
 		expect(shouldRetryTradeQuery(0, httpError(503))).toBe(false);
 		expect(shouldRetryTradeQuery(0, httpError(408))).toBe(true);

--- a/tests/lib/services/tradeError.test.ts
+++ b/tests/lib/services/tradeError.test.ts
@@ -75,7 +75,9 @@ describe('tradeError', () => {
 			});
 
 		expect(shouldRetryTradeQuery(0, httpError(429))).toBe(false);
+		expect(shouldRetryTradeQuery(0, httpError(404))).toBe(false);
 		expect(shouldRetryTradeQuery(0, httpError(503))).toBe(false);
+		expect(shouldRetryTradeQuery(0, httpError(408))).toBe(true);
 		expect(shouldRetryTradeQuery(0, httpError(502))).toBe(true);
 		expect(shouldRetryTradeQuery(1, new Error('network failed'))).toBe(false);
 	});

--- a/tests/lib/stores/debouncedValue.test.ts
+++ b/tests/lib/stores/debouncedValue.test.ts
@@ -16,9 +16,17 @@ describe('createDebouncedRequest', () => {
 		value.set({ amount: 'second' });
 		vi.advanceTimersByTime(299);
 
-		expect(get(value)).toEqual({ request: null, revision: 2 });
+		expect(get(value)).toEqual({
+			request: null,
+			revision: 2,
+			fingerprint: JSON.stringify({ amount: 'second' })
+		});
 		vi.advanceTimersByTime(1);
-		expect(get(value)).toEqual({ request: { amount: 'second' }, revision: 2 });
+		expect(get(value)).toEqual({
+			request: { amount: 'second' },
+			revision: 2,
+			fingerprint: JSON.stringify({ amount: 'second' })
+		});
 	});
 
 	it('invalidates request A immediately so its late response cannot render for B', () => {
@@ -28,15 +36,27 @@ describe('createDebouncedRequest', () => {
 		value.set({ amount: 'A' });
 		vi.advanceTimersByTime(300);
 		const requestA = get(value);
-		expect(requestA).toEqual({ request: { amount: 'A' }, revision: 1 });
+		expect(requestA).toEqual({
+			request: { amount: 'A' },
+			revision: 1,
+			fingerprint: JSON.stringify({ amount: 'A' })
+		});
 
 		value.set({ amount: 'B' });
 		const whileAResolves = get(value);
-		expect(whileAResolves).toEqual({ request: null, revision: 2 });
+		expect(whileAResolves).toEqual({
+			request: null,
+			revision: 2,
+			fingerprint: JSON.stringify({ amount: 'B' })
+		});
 		expect(whileAResolves.revision).not.toBe(requestA.revision);
 
 		vi.advanceTimersByTime(300);
-		expect(get(value)).toEqual({ request: { amount: 'B' }, revision: 2 });
+		expect(get(value)).toEqual({
+			request: { amount: 'B' },
+			revision: 2,
+			fingerprint: JSON.stringify({ amount: 'B' })
+		});
 	});
 
 	it('keeps the active revision for a semantically identical payload', () => {
@@ -47,6 +67,24 @@ describe('createDebouncedRequest', () => {
 		vi.advanceTimersByTime(300);
 		value.set({ amount: '1' });
 
-		expect(get(value)).toEqual({ request: { amount: '1' }, revision: 1 });
+		expect(get(value)).toEqual({
+			request: { amount: '1' },
+			revision: 1,
+			fingerprint: JSON.stringify({ amount: '1' })
+		});
+	});
+
+	it('uses the request fingerprint to avoid revision collisions across remounts', () => {
+		vi.useFakeTimers();
+		const firstMount = createDebouncedRequest<{ amount: string }>(300);
+		const secondMount = createDebouncedRequest<{ amount: string }>(300);
+
+		firstMount.set({ amount: '10' });
+		secondMount.set({ amount: '999' });
+		vi.advanceTimersByTime(300);
+
+		expect(get(firstMount).revision).toBe(1);
+		expect(get(secondMount).revision).toBe(1);
+		expect(get(firstMount).fingerprint).not.toBe(get(secondMount).fingerprint);
 	});
 });

--- a/tests/lib/stores/debouncedValue.test.ts
+++ b/tests/lib/stores/debouncedValue.test.ts
@@ -1,34 +1,52 @@
 import { get } from 'svelte/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createDebouncedValue } from '$lib/stores/debouncedValue';
+import { createDebouncedRequest } from '$lib/stores/debouncedValue';
 
-describe('createDebouncedValue', () => {
+describe('createDebouncedRequest', () => {
 	afterEach(() => {
 		vi.useRealTimers();
 	});
 
 	it('publishes only the final value in a burst', () => {
 		vi.useFakeTimers();
-		const value = createDebouncedValue('initial', 300);
+		const value = createDebouncedRequest<{ amount: string }>(300);
 
-		value.set('first');
+		value.set({ amount: 'first' });
 		vi.advanceTimersByTime(200);
-		value.set('second');
+		value.set({ amount: 'second' });
 		vi.advanceTimersByTime(299);
 
-		expect(get(value)).toBe('initial');
+		expect(get(value)).toEqual({ request: null, revision: 2 });
 		vi.advanceTimersByTime(1);
-		expect(get(value)).toBe('second');
+		expect(get(value)).toEqual({ request: { amount: 'second' }, revision: 2 });
 	});
 
-	it('cancels a pending value when cleared immediately', () => {
+	it('invalidates request A immediately so its late response cannot render for B', () => {
 		vi.useFakeTimers();
-		const value = createDebouncedValue<string | null>(null, 300);
+		const value = createDebouncedRequest<{ amount: string }>(300);
 
-		value.set('quote');
-		value.setImmediately(null);
-		vi.runAllTimers();
+		value.set({ amount: 'A' });
+		vi.advanceTimersByTime(300);
+		const requestA = get(value);
+		expect(requestA).toEqual({ request: { amount: 'A' }, revision: 1 });
 
-		expect(get(value)).toBeNull();
+		value.set({ amount: 'B' });
+		const whileAResolves = get(value);
+		expect(whileAResolves).toEqual({ request: null, revision: 2 });
+		expect(whileAResolves.revision).not.toBe(requestA.revision);
+
+		vi.advanceTimersByTime(300);
+		expect(get(value)).toEqual({ request: { amount: 'B' }, revision: 2 });
+	});
+
+	it('keeps the active revision for a semantically identical payload', () => {
+		vi.useFakeTimers();
+		const value = createDebouncedRequest<{ amount: string }>(300);
+
+		value.set({ amount: '1' });
+		vi.advanceTimersByTime(300);
+		value.set({ amount: '1' });
+
+		expect(get(value)).toEqual({ request: { amount: '1' }, revision: 1 });
 	});
 });

--- a/tests/lib/stores/debouncedValue.test.ts
+++ b/tests/lib/stores/debouncedValue.test.ts
@@ -1,0 +1,34 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDebouncedValue } from '$lib/stores/debouncedValue';
+
+describe('createDebouncedValue', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('publishes only the final value in a burst', () => {
+		vi.useFakeTimers();
+		const value = createDebouncedValue('initial', 300);
+
+		value.set('first');
+		vi.advanceTimersByTime(200);
+		value.set('second');
+		vi.advanceTimersByTime(299);
+
+		expect(get(value)).toBe('initial');
+		vi.advanceTimersByTime(1);
+		expect(get(value)).toBe('second');
+	});
+
+	it('cancels a pending value when cleared immediately', () => {
+		vi.useFakeTimers();
+		const value = createDebouncedValue<string | null>(null, 300);
+
+		value.set('quote');
+		value.setImmediately(null);
+		vi.runAllTimers();
+
+		expect(get(value)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Motivation

Production logs showed the website's shared REST credential hitting its 60 RPM limit. The largest avoidable amplifier was dashboard trade-history pagination: a high-activity wallet reached maker page 55, and a later failure caused the all-history TanStack query to restart from page one. The same dashboard also fetched taker history independently, while quote inputs issued a request for every intermediate keystroke.

## Solution

- Fetch trade history in 500-item pages instead of 50-item pages. This reduces the observed 55-page maker history to about 6 requests for the same data.
- Disable whole-query retries for the multi-page cost-basis request because the HTTP client already handles transient retries; this prevents completed pages from being replayed.
- Reuse the cost-basis query's taker history for dashboard market orders instead of fetching it a second time.
- Preserve the recent 500-trade display limit with one request instead of up to ten sequential requests.
- Debounce Quick Trade and Market Order quote inputs by 300 ms and pass TanStack's abort signal through the API client so obsolete requests are cancelled.
- Do not retry quote requests for HTTP client errors such as no-liquidity responses, or for explicit 503 backoff responses.

This PR changes only the website. It does not split credentials or change REST API limits.

## Validation

- npm test -- --run — 87 files passed, 906 tests passed, 1 skipped
- npm run svelte-lint-format-check — Svelte/TypeScript, ESLint, and Prettier passed
- npm run build — production build passed with process-only local CSRF/session values and the documented public Base RPC fallback
- Added focused coverage for pagination request counts, dashboard taker-history reuse data, quote debounce behavior, abort-signal forwarding, and retry policy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Swap quotes now wait briefly during rapid input changes, reducing unnecessary requests and helping prevent outdated results.
  - In-progress quote requests are cancelled when no longer needed.
  - Trade history and cost-basis data load more efficiently with larger batches and consolidated retrieval.
  - Dashboard trade and cost-basis information now comes from a unified data source.
  - Trade data requests retry more reliably for temporary network and server errors while avoiding retries for unsupported failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->