### PR TITLE
fix(ui): prevent sidebar from overlapping advanced chart

### DIFF
--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -143,7 +143,8 @@
 		class:lg:ml-64={!useCleanLayout && !sidebarCollapsed}
 		class:lg:ml-0={useCleanLayout || sidebarCollapsed}
 		class:lg:mr-[22rem]={isTradePage && $tradePanelOpen}
-		style={$navCollapsed ? 'padding-bottom: calc(60px + env(safe-area-inset-bottom));' : ''}
+		style:--desktop-sidebar-offset={!useCleanLayout && !sidebarCollapsed ? '16rem' : '0rem'}
+		style:padding-bottom={$navCollapsed ? 'calc(60px + env(safe-area-inset-bottom))' : undefined}
 	>
 		<!-- Header for all screen sizes -->
 		<Header

--- a/src/routes/(main)/trade/[id]/+page.svelte
+++ b/src/routes/(main)/trade/[id]/+page.svelte
@@ -2196,7 +2196,10 @@
 	</footer>
 {/if}
 {#if showChartModal}
-	<div class="fixed inset-0 z-[2000]">
+	<div
+		class="fixed inset-0 z-[2000] transition-[left] duration-300 lg:left-[var(--desktop-sidebar-offset)]"
+		data-testid="advanced-chart-modal"
+	>
 		<button
 			type="button"
 			class="absolute inset-0 h-full w-full bg-black/60"


### PR DESCRIPTION
## Motivation

Opening the Advanced Chart on desktop covered the left side of the chart with the persistent asset sidebar, hiding chart content and controls.

## Solution

- Derive a desktop sidebar offset from the same expanded/collapsed state used by the main trade layout.
- Apply that offset to the Advanced Chart modal while preserving its full-width mobile layout.
- Transition the chart edge with the sidebar so collapsing or expanding navigation keeps the chart aligned.

## Validation

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run lint-check`
- [x] `npm test -- --run` — 92 files passed; 945 tests passed, 1 skipped
- [x] Production build with Node 22 and required local validation environment values
- [x] In-app browser: expanded desktop sidebar ends at x=256px and chart begins at x=256px
- [x] In-app browser: collapsed desktop sidebar and 390px mobile viewport both render the chart from x=0

Closes RAI-1966

Linear: https://linear.app/makeitrain/issue/RAI-1966/prevent-sidebar-from-overlapping-advanced-chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout alignment for the main content area and advanced chart modal when the desktop sidebar is visible.
  * Improved mobile navigation spacing for a more consistent layout.
* **Tests**
  * Added an identifier to the advanced chart modal to support reliable automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->